### PR TITLE
Fix postinstall to work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "release": "bash scripts/release.sh",
     "release:all": "bash scripts/release-all.sh",
     "stats": "node scripts/download-stats.cjs",
-    "postinstall": "electron-builder install-app-deps && node scripts/postinstall.cjs"
+    "postinstall": "node scripts/postinstall.cjs"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,7 +1,16 @@
-// Cross-platform postinstall: chmod spawn-helper on Unix only
+// Cross-platform postinstall: rebuild native deps and chmod spawn-helper on Unix only
 const { execSync } = require('child_process')
 
 if (process.platform !== 'win32') {
+  // On Windows, electron-builder install-app-deps fails when pnpm is installed via nvm
+  // because it tries to exec pnpm.cjs directly rather than the .cmd wrapper.
+  // node-pty ships prebuilt Windows binaries so no rebuild is needed there.
+  try {
+    execSync('electron-builder install-app-deps', { stdio: 'inherit' })
+  } catch (e) {
+    process.exit(1)
+  }
+
   try {
     execSync('chmod +x node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true', { stdio: 'ignore' })
     execSync('chmod +x node_modules/node-pty/prebuilds/linux-*/spawn-helper 2>/dev/null || true', { stdio: 'ignore' })


### PR DESCRIPTION
Move electron-builder install-app-deps into postinstall.cjs so it only runs on non-Windows platforms, avoiding failures caused by pnpm.cjs not being directly executable when pnpm is installed via nvm on Windows.