### PR TITLE
Fix crash banner re-prompting on dismiss

### DIFF
--- a/src/main/crashLog.test.ts
+++ b/src/main/crashLog.test.ts
@@ -19,7 +19,7 @@ vi.mock('./handlers/types', () => ({
   CONFIG_DIR: '/mock/.broomy',
 }))
 
-import { writeCrashLog, readLatestCrashLog, deleteCrashLog, buildCrashReportUrl, appendErrorLog, getRecentErrors, type CrashReport } from './crashLog'
+import { writeCrashLog, readLatestCrashLog, deleteCrashLog, deleteAllCrashLogs, buildCrashReportUrl, appendErrorLog, getRecentErrors, type CrashReport } from './crashLog'
 
 const CRASH_DIR = '/mock/.broomy/crash-reports'
 
@@ -112,6 +112,38 @@ describe('crashLog', () => {
     it('silently ignores errors', () => {
       vi.mocked(unlinkSync).mockImplementation(() => { throw new Error('ENOENT') })
       expect(() => deleteCrashLog('/nonexistent')).not.toThrow()
+    })
+  })
+
+  describe('deleteAllCrashLogs', () => {
+    it('deletes all crash files in the directory', () => {
+      vi.mocked(readdirSync).mockReturnValue([
+        'crash-1700000000000.json',
+        'crash-1700000001000.json',
+      ] as unknown as ReturnType<typeof readdirSync>)
+
+      deleteAllCrashLogs()
+
+      expect(unlinkSync).toHaveBeenCalledTimes(2)
+      expect(unlinkSync).toHaveBeenCalledWith(join(CRASH_DIR, 'crash-1700000000000.json'))
+      expect(unlinkSync).toHaveBeenCalledWith(join(CRASH_DIR, 'crash-1700000001000.json'))
+    })
+
+    it('ignores non-crash files', () => {
+      vi.mocked(readdirSync).mockReturnValue([
+        'crash-1700000000000.json',
+        'other-file.txt',
+      ] as unknown as ReturnType<typeof readdirSync>)
+
+      deleteAllCrashLogs()
+
+      expect(unlinkSync).toHaveBeenCalledTimes(1)
+      expect(unlinkSync).toHaveBeenCalledWith(join(CRASH_DIR, 'crash-1700000000000.json'))
+    })
+
+    it('silently ignores errors', () => {
+      vi.mocked(readdirSync).mockImplementation(() => { throw new Error('ENOENT') })
+      expect(() => deleteAllCrashLogs()).not.toThrow()
     })
   })
 

--- a/src/main/crashLog.ts
+++ b/src/main/crashLog.ts
@@ -90,6 +90,23 @@ export function deleteCrashLog(filepath: string): void {
   }
 }
 
+export function deleteAllCrashLogs(): void {
+  try {
+    const files = readdirSync(CRASH_DIR).filter(
+      f => f.startsWith('crash-') && f.endsWith('.json'),
+    )
+    for (const file of files) {
+      try {
+        unlinkSync(join(CRASH_DIR, file))
+      } catch {
+        // ignore individual failures
+      }
+    }
+  } catch {
+    // directory doesn't exist or inaccessible — ignore
+  }
+}
+
 export function buildCrashReportUrl(report: CrashReport): string {
   const title = `Crash: ${report.message.slice(0, 80)}`
   const lines = [

--- a/src/main/handlers/app.test.ts
+++ b/src/main/handlers/app.test.ts
@@ -16,14 +16,14 @@ vi.mock('electron', () => ({
 
 vi.mock('../crashLog', () => ({
   readLatestCrashLog: vi.fn(() => null),
-  deleteCrashLog: vi.fn(),
+  deleteAllCrashLogs: vi.fn(),
   buildCrashReportUrl: vi.fn(() => 'https://github.com/Broomy-AI/broomy/issues/new?title=test'),
 }))
 
 import { register } from './app'
 import { E2EScenario, type HandlerContext } from './types'
 import type { IpcMain } from 'electron'
-import { readLatestCrashLog, deleteCrashLog } from '../crashLog'
+import { readLatestCrashLog, deleteAllCrashLogs } from '../crashLog'
 
 describe('app handler register', () => {
   let mockIpcMain: { handle: ReturnType<typeof vi.fn> }
@@ -167,16 +167,15 @@ describe('app handler register', () => {
     const call = mockIpcMain.handle.mock.calls.find((c: unknown[]) => c[0] === 'app:dismissCrashLog')
     const handler = call![1] as () => void
     handler()
-    expect(deleteCrashLog).not.toHaveBeenCalled()
+    expect(deleteAllCrashLogs).not.toHaveBeenCalled()
   })
 
-  it('app:dismissCrashLog deletes crash log when one exists', () => {
-    vi.mocked(readLatestCrashLog).mockReturnValue({ path: '/tmp/crash.log', report: { timestamp: '2024-01-01', message: 'test', stack: '', electronVersion: '28.0.0', appVersion: '0.6.1', platform: 'darwin', processType: 'main' } })
+  it('app:dismissCrashLog deletes all crash logs', () => {
     register(mockIpcMain as unknown as IpcMain, mockCtx)
     const call = mockIpcMain.handle.mock.calls.find((c: unknown[]) => c[0] === 'app:dismissCrashLog')
     const handler = call![1] as () => void
     handler()
-    expect(deleteCrashLog).toHaveBeenCalledWith('/tmp/crash.log')
+    expect(deleteAllCrashLogs).toHaveBeenCalled()
   })
 
   it('app:getCrashReportUrl returns URL when crash log exists', () => {

--- a/src/main/handlers/app.ts
+++ b/src/main/handlers/app.ts
@@ -6,7 +6,11 @@ import { app, IpcMain } from 'electron'
 import { homedir, tmpdir } from 'os'
 import { normalizePath } from '../platform'
 import { HandlerContext } from './types'
-import { readLatestCrashLog, deleteCrashLog, buildCrashReportUrl } from '../crashLog'
+import {
+  readLatestCrashLog,
+  deleteAllCrashLogs,
+  buildCrashReportUrl,
+} from '../crashLog'
 
 export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
   ipcMain.handle('app:isDev', () => ctx.isDev)
@@ -23,8 +27,7 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
 
   ipcMain.handle('app:dismissCrashLog', () => {
     if (ctx.isE2ETest) return
-    const result = readLatestCrashLog()
-    if (result) deleteCrashLog(result.path)
+    deleteAllCrashLogs()
   })
 
   ipcMain.handle('app:getCrashReportUrl', () => {

--- a/src/renderer/components/CrashRecoveryBanner.test.tsx
+++ b/src/renderer/components/CrashRecoveryBanner.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '../../test/react-setup'
+import CrashRecoveryBanner from './CrashRecoveryBanner'
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CrashRecoveryBanner', () => {
+  it('renders nothing when there is no crash log', async () => {
+    vi.mocked(window.app.getCrashLog).mockResolvedValue(null)
+    const { container } = render(<CrashRecoveryBanner />)
+    // Wait for the useEffect to resolve
+    await waitFor(() => {
+      expect(window.app.getCrashLog).toHaveBeenCalled()
+    })
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the banner when a crash log exists', async () => {
+    vi.mocked(window.app.getCrashLog).mockResolvedValue('crash data')
+    render(<CrashRecoveryBanner />)
+    await waitFor(() => {
+      expect(screen.getByText('Broomy crashed unexpectedly during your last session.')).toBeTruthy()
+    })
+    expect(screen.getByText('Report Issue')).toBeTruthy()
+    expect(screen.getByText('Dismiss')).toBeTruthy()
+  })
+
+  it('opens the crash report URL and dismisses on Report Issue click', async () => {
+    vi.mocked(window.app.getCrashLog).mockResolvedValue('crash data')
+    vi.mocked(window.app.getCrashReportUrl).mockResolvedValue('https://github.com/issues/new')
+    vi.mocked(window.app.dismissCrashLog).mockResolvedValue(undefined)
+    vi.mocked(window.shell.openExternal).mockResolvedValue(undefined)
+
+    render(<CrashRecoveryBanner />)
+    await waitFor(() => {
+      expect(screen.getByText('Report Issue')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByText('Report Issue'))
+
+    await waitFor(() => {
+      expect(window.app.getCrashReportUrl).toHaveBeenCalled()
+      expect(window.shell.openExternal).toHaveBeenCalledWith('https://github.com/issues/new')
+      expect(window.app.dismissCrashLog).toHaveBeenCalled()
+    })
+  })
+
+  it('dismisses without reporting on Dismiss click', async () => {
+    vi.mocked(window.app.getCrashLog).mockResolvedValue('crash data')
+    vi.mocked(window.app.dismissCrashLog).mockResolvedValue(undefined)
+
+    render(<CrashRecoveryBanner />)
+    await waitFor(() => {
+      expect(screen.getByText('Dismiss')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByText('Dismiss'))
+
+    await waitFor(() => {
+      expect(window.app.dismissCrashLog).toHaveBeenCalled()
+      expect(window.shell.openExternal).not.toHaveBeenCalled()
+    })
+  })
+
+  it('does not call openExternal when crash report URL is null', async () => {
+    vi.mocked(window.app.getCrashLog).mockResolvedValue('crash data')
+    vi.mocked(window.app.getCrashReportUrl).mockResolvedValue(null)
+    vi.mocked(window.app.dismissCrashLog).mockResolvedValue(undefined)
+
+    render(<CrashRecoveryBanner />)
+    await waitFor(() => {
+      expect(screen.getByText('Report Issue')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByText('Report Issue'))
+
+    await waitFor(() => {
+      expect(window.app.getCrashReportUrl).toHaveBeenCalled()
+      expect(window.shell.openExternal).not.toHaveBeenCalled()
+      expect(window.app.dismissCrashLog).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/renderer/components/ExperimentalPlatformModal.test.tsx
+++ b/src/renderer/components/ExperimentalPlatformModal.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '../../test/react-setup'
+import ExperimentalPlatformModal from './ExperimentalPlatformModal'
+
+afterEach(() => {
+  cleanup()
+  sessionStorage.clear()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sessionStorage.clear()
+})
+
+describe('ExperimentalPlatformModal', () => {
+  it('renders nothing on macOS', async () => {
+    vi.mocked(window.app.platform).mockResolvedValue('darwin')
+    const { container } = render(<ExperimentalPlatformModal />)
+    // Wait for the useEffect to resolve
+    await waitFor(() => {
+      expect(window.app.platform).toHaveBeenCalled()
+    })
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the modal on Windows', async () => {
+    vi.mocked(window.app.platform).mockResolvedValue('win32')
+    render(<ExperimentalPlatformModal />)
+    await waitFor(() => {
+      expect(screen.getByText('Windows Support')).toBeTruthy()
+    })
+    expect(screen.getByText(/Broomy on Windows is still experimental/)).toBeTruthy()
+    expect(screen.getByText('Got it')).toBeTruthy()
+    expect(screen.getByText('Report an issue')).toBeTruthy()
+  })
+
+  it('renders the modal on Linux', async () => {
+    vi.mocked(window.app.platform).mockResolvedValue('linux')
+    render(<ExperimentalPlatformModal />)
+    await waitFor(() => {
+      expect(screen.getByText('Linux Support')).toBeTruthy()
+    })
+    expect(screen.getByText(/Broomy on Linux is still experimental/)).toBeTruthy()
+  })
+
+  it('dismisses the modal and sets sessionStorage on Got it click', async () => {
+    vi.mocked(window.app.platform).mockResolvedValue('win32')
+    render(<ExperimentalPlatformModal />)
+    await waitFor(() => {
+      expect(screen.getByText('Got it')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByText('Got it'))
+
+    expect(sessionStorage.getItem('broomy:experimental-platform-dismissed')).toBe('1')
+    // Modal should be gone
+    expect(screen.queryByText('Windows Support')).toBeNull()
+  })
+
+  it('does not show modal when already dismissed in sessionStorage', async () => {
+    sessionStorage.setItem('broomy:experimental-platform-dismissed', '1')
+    vi.mocked(window.app.platform).mockResolvedValue('win32')
+    const { container } = render(<ExperimentalPlatformModal />)
+    // Give it time to potentially render
+    await waitFor(() => {
+      expect(container.innerHTML).toBe('')
+    })
+  })
+
+  it('opens GitHub issues on Report an issue click', async () => {
+    vi.mocked(window.app.platform).mockResolvedValue('linux')
+    vi.mocked(window.shell.openExternal).mockResolvedValue(undefined)
+    render(<ExperimentalPlatformModal />)
+    await waitFor(() => {
+      expect(screen.getByText('Report an issue')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByText('Report an issue'))
+
+    expect(window.shell.openExternal).toHaveBeenCalledWith('https://github.com/Broomy-AI/broomy/issues')
+  })
+})

--- a/src/renderer/store/sessionBranchActions.test.ts
+++ b/src/renderer/store/sessionBranchActions.test.ts
@@ -142,4 +142,34 @@ describe('sessionBranchActions', () => {
       expect(useSessionStore.getState().sessions[0].isArchived).toBe(false)
     })
   })
+
+  describe('updateReviewStatus', () => {
+    it('updates review status for a session', () => {
+      addTestSession()
+      useSessionStore.getState().updateReviewStatus('test-session', 'reviewed')
+      expect(useSessionStore.getState().sessions[0].reviewStatus).toBe('reviewed')
+    })
+
+    it('is a no-op when status is already the same', () => {
+      addTestSession()
+      useSessionStore.getState().updateReviewStatus('test-session', 'reviewed')
+      vi.clearAllMocks()
+      useSessionStore.getState().updateReviewStatus('test-session', 'reviewed')
+      // Should not trigger another save since status did not change
+      expect(useSessionStore.getState().sessions[0].reviewStatus).toBe('reviewed')
+    })
+
+    it('is a no-op for non-existent session', () => {
+      addTestSession()
+      useSessionStore.getState().updateReviewStatus('nonexistent', 'reviewed')
+      expect(useSessionStore.getState().sessions[0].reviewStatus).toBeUndefined()
+    })
+
+    it('changes from reviewed back to pending', () => {
+      addTestSession()
+      useSessionStore.getState().updateReviewStatus('test-session', 'reviewed')
+      useSessionStore.getState().updateReviewStatus('test-session', 'pending')
+      expect(useSessionStore.getState().sessions[0].reviewStatus).toBe('pending')
+    })
+  })
 })

--- a/src/renderer/store/sessionPanelActions.test.ts
+++ b/src/renderer/store/sessionPanelActions.test.ts
@@ -153,5 +153,52 @@ describe('sessionPanelActions', () => {
       useSessionStore.getState().toggleFileViewer('test-session')
       expect(useSessionStore.getState().sessions[0].panelVisibility[PANEL_IDS.FILE_VIEWER]).toBe(true)
     })
+
+    it('toggleSidebar delegates to toggleGlobalPanel', () => {
+      addTestSession()
+      expect(useSessionStore.getState().showSidebar).toBe(true)
+      useSessionStore.getState().toggleSidebar()
+      expect(useSessionStore.getState().showSidebar).toBe(false)
+      expect(useSessionStore.getState().globalPanelVisibility[PANEL_IDS.SIDEBAR]).toBe(false)
+    })
+  })
+
+  describe('openCommandsEditor', () => {
+    it('opens the commands editor for a session', () => {
+      addTestSession()
+      useSessionStore.getState().openCommandsEditor('test-session', '/repo/dir')
+      const session = useSessionStore.getState().sessions[0]
+      expect(session.commandsEditorDirectory).toBe('/repo/dir')
+      expect(session.panelVisibility[PANEL_IDS.FILE_VIEWER]).toBe(true)
+      expect(session.showFileViewer).toBe(true)
+    })
+
+    it('does not affect other sessions', () => {
+      addTestSession('s1')
+      const s2 = { ...useSessionStore.getState().sessions[0], id: 's2' }
+      useSessionStore.setState({ sessions: [...useSessionStore.getState().sessions, s2] })
+
+      useSessionStore.getState().openCommandsEditor('s1', '/repo')
+      expect(useSessionStore.getState().sessions[1].commandsEditorDirectory).toBeUndefined()
+    })
+  })
+
+  describe('closeCommandsEditor', () => {
+    it('closes the commands editor for a session', () => {
+      addTestSession()
+      useSessionStore.getState().openCommandsEditor('test-session', '/repo/dir')
+      useSessionStore.getState().closeCommandsEditor('test-session')
+      const session = useSessionStore.getState().sessions[0]
+      expect(session.commandsEditorDirectory).toBeNull()
+    })
+
+    it('does not affect other sessions', () => {
+      addTestSession('s1')
+      const s2 = { ...useSessionStore.getState().sessions[0], id: 's2', commandsEditorDirectory: '/other' }
+      useSessionStore.setState({ sessions: [...useSessionStore.getState().sessions, s2] })
+
+      useSessionStore.getState().closeCommandsEditor('s1')
+      expect(useSessionStore.getState().sessions[1].commandsEditorDirectory).toBe('/other')
+    })
   })
 })


### PR DESCRIPTION
## Background and Motivation

When a user clicks "Dismiss" on the crash recovery banner, the app only deletes the most recent crash log file. If multiple crash reports have accumulated (e.g. from repeated crashes), the banner reappears on the next launch because `getCrashLog` finds the next oldest file. Users expect dismiss to mean "stop showing me this."

## Design Decisions

- **Delete all crash files on dismiss** rather than deleting one at a time. Once a user dismisses, they've made a conscious choice not to report — there's no value in re-prompting for older crashes.
- Added a dedicated `deleteAllCrashLogs()` function to `crashLog.ts` to keep the single-file `deleteCrashLog()` available for other callers that may need it.

## Proposed Changes

**Core fix:**
- Added `deleteAllCrashLogs()` in `src/main/crashLog.ts` that iterates all `crash-*.json` files and removes them
- Updated the `app:dismissCrashLog` IPC handler to call `deleteAllCrashLogs()` instead of reading the latest and deleting just that one

**Test coverage:**
- Added unit tests for `deleteAllCrashLogs()` (deletes all, ignores non-crash files, handles errors)
- Updated `app.test.ts` to reflect the new dismiss behavior
- Added new test files for `CrashRecoveryBanner` and `ExperimentalPlatformModal` components
- Extended `sessionPanelActions` and `sessionBranchActions` store tests

## Testing

- All 2978+ unit tests pass
- All 72 E2E tests pass
- Line coverage improved from 89.99% to 90.63%

🤖 Generated with [Claude Code](https://claude.com/claude-code)