### PR TITLE
Fix devcontainer cwd using host path instead of container path

### DIFF
--- a/src/main/handlers/pty.test.ts
+++ b/src/main/handlers/pty.test.ts
@@ -498,6 +498,28 @@ describe('pty handlers', () => {
       expect(ctx.ptyProcesses.has('no-sender')).toBe(true)
       expect(ctx.ptyOwnerWindows.has('no-sender')).toBe(false)
     })
+    it('kills existing PTY with the same ID before creating a new one', async () => {
+      const { register } = await import('./pty')
+      const ctx = createCtx()
+      register(mockIpcMain as never, ctx)
+
+      // Pre-populate an existing PTY in the context
+      const existingProcess = createMockPtyProcess()
+      ctx.ptyProcesses.set('dup-id', existingProcess as never)
+      ctx.ptyOwnerWindows.set('dup-id', mockSenderWindow as never)
+
+      const newProcess = createMockPtyProcess()
+      mockPtySpawn.mockReturnValue(newProcess)
+      mockBrowserWindowFromWebContents.mockReturnValue(mockSenderWindow)
+
+      await handlers['pty:create'](mockEvent, {
+        id: 'dup-id',
+        cwd: '/tmp',
+      })
+
+      expect(existingProcess.kill).toHaveBeenCalled()
+      expect(ctx.ptyProcesses.get('dup-id')).toBe(newProcess)
+    })
   })
 
   describe('pty:create with devcontainer isolation', () => {
@@ -646,7 +668,7 @@ describe('pty handlers', () => {
       mockIsDockerAvailable.mockResolvedValue({ available: true })
       mockDevcontainerUp.mockResolvedValue({
         success: true,
-        result: { containerId: 'dc-123', remoteUser: 'node' },
+        result: { containerId: 'dc-123', remoteUser: 'node', remoteWorkspaceFolder: '/workspaces/repo' },
       })
       mockBuildDevcontainerExecArgs.mockReturnValue(['exec', '-it', '-u', 'node', 'dc-123', 'bash', '-l'])
       mockEnsureAgentInstalled.mockResolvedValue({ success: true })
@@ -663,6 +685,9 @@ describe('pty handlers', () => {
       })
 
       await vi.waitFor(() => {
+        expect(mockBuildDevcontainerExecArgs).toHaveBeenCalledWith(
+          'dc-123', 'node', '/workspaces/repo', expect.any(Object), 'claude',
+        )
         expect(mockPtySpawn).toHaveBeenCalledWith(
           'docker',
           ['exec', '-it', '-u', 'node', 'dc-123', 'bash', '-l'],
@@ -682,7 +707,7 @@ describe('pty handlers', () => {
       mockIsDockerAvailable.mockResolvedValue({ available: true })
       mockDevcontainerUp.mockResolvedValue({
         success: true,
-        result: { containerId: 'dc-svc', remoteUser: 'node', postAttachCommand: 'npm start' },
+        result: { containerId: 'dc-svc', remoteUser: 'node', remoteWorkspaceFolder: '/workspaces/repo', postAttachCommand: 'npm start' },
       })
       mockBuildDevcontainerExecArgs.mockReturnValue(['exec', '-it', 'dc-svc', 'bash', '-l'])
 

--- a/src/main/handlers/pty.ts
+++ b/src/main/handlers/pty.ts
@@ -154,6 +154,7 @@ function createDevcontainerPty(
     const releaseLock = await acquireSetupLock(workspaceFolder)
     let containerId: string
     let remoteUser: string
+    let remoteWorkspaceFolder: string
     let postAttachCommand: string | undefined
     try {
       // Run devcontainer up
@@ -166,6 +167,7 @@ function createDevcontainerPty(
       }
       containerId = result.result.containerId
       remoteUser = result.result.remoteUser
+      remoteWorkspaceFolder = result.result.remoteWorkspaceFolder
       postAttachCommand = result.result.postAttachCommand
 
       // Store container info for DockerInfoPanel
@@ -219,7 +221,7 @@ function createDevcontainerPty(
         }
       }
     }
-    const dockerArgs = buildDevcontainerExecArgs(containerId, remoteUser, cwd, dockerEnv, command)
+    const dockerArgs = buildDevcontainerExecArgs(containerId, remoteUser, remoteWorkspaceFolder, dockerEnv, command)
 
     let ptyProcess: IPty
     try {


### PR DESCRIPTION
## Background and Motivation

Starting Broomy sessions in devcontainers fails with:

```
OCI runtime exec failed: exec failed: unable to start container process:
chdir to cwd ("/Users/rob/broomy-work/psi-product/test/devcontainer")
set in config.json failed: no such file or directory: unknown
```

The host machine's working directory path was being passed directly to `docker exec -w`, but that path doesn't exist inside the container.

## Design Decisions

The `devcontainer up` command already returns a `remoteWorkspaceFolder` (e.g. `/workspaces/repo`) that maps the host path to the correct container path. The value was being parsed and returned but never used — the fix simply wires it through to `buildDevcontainerExecArgs`.

## Proposed Changes

- **Use container workspace path for docker exec**: Replace the host `cwd` with `remoteWorkspaceFolder` from `devcontainerUp()` result when building `docker exec` arguments (`pty.ts`)
- **Test coverage**: Added assertion that `buildDevcontainerExecArgs` receives the container path, not the host path. Added test for duplicate PTY ID cleanup. Updated test mocks to include `remoteWorkspaceFolder`.

## Testing

- [x] All 2976 unit tests pass
- [x] Line coverage at 90.04% (above 90% threshold)
- [x] All 72 E2E tests pass
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)