### PR TITLE
Show remote URL in repo settings panels

### DIFF
--- a/src/renderer/components/CrashRecoveryBanner.test.tsx
+++ b/src/renderer/components/CrashRecoveryBanner.test.tsx
@@ -11,6 +11,8 @@ const mockCrashReport: CrashReport = {
   stack: null,
   electronVersion: '1.0.0',
   appVersion: '0.9.0',
+  platform: 'darwin',
+  processType: 'main',
 }
 
 afterEach(() => {
@@ -33,7 +35,7 @@ describe('CrashRecoveryBanner', () => {
   })
 
   it('renders the banner when a crash log exists', async () => {
-    vi.mocked(window.app.getCrashLog).mockResolvedValue('crash data')
+    vi.mocked(window.app.getCrashLog).mockResolvedValue(mockCrashReport)
     render(<CrashRecoveryBanner />)
     await waitFor(() => {
       expect(screen.getByText('Broomy crashed unexpectedly during your last session.')).toBeTruthy()
@@ -43,7 +45,7 @@ describe('CrashRecoveryBanner', () => {
   })
 
   it('opens the crash report URL and dismisses on Report Issue click', async () => {
-    vi.mocked(window.app.getCrashLog).mockResolvedValue('crash data')
+    vi.mocked(window.app.getCrashLog).mockResolvedValue(mockCrashReport)
     vi.mocked(window.app.getCrashReportUrl).mockResolvedValue('https://github.com/issues/new')
     vi.mocked(window.app.dismissCrashLog).mockResolvedValue(undefined)
     vi.mocked(window.shell.openExternal).mockResolvedValue(undefined)
@@ -63,7 +65,7 @@ describe('CrashRecoveryBanner', () => {
   })
 
   it('dismisses without reporting on Dismiss click', async () => {
-    vi.mocked(window.app.getCrashLog).mockResolvedValue('crash data')
+    vi.mocked(window.app.getCrashLog).mockResolvedValue(mockCrashReport)
     vi.mocked(window.app.dismissCrashLog).mockResolvedValue(undefined)
 
     render(<CrashRecoveryBanner />)
@@ -80,7 +82,7 @@ describe('CrashRecoveryBanner', () => {
   })
 
   it('does not call openExternal when crash report URL is null', async () => {
-    vi.mocked(window.app.getCrashLog).mockResolvedValue('crash data')
+    vi.mocked(window.app.getCrashLog).mockResolvedValue(mockCrashReport)
     vi.mocked(window.app.getCrashReportUrl).mockResolvedValue(null)
     vi.mocked(window.app.dismissCrashLog).mockResolvedValue(undefined)
 

--- a/src/renderer/components/RepoSettingsEditor.tsx
+++ b/src/renderer/components/RepoSettingsEditor.tsx
@@ -129,6 +129,9 @@ export function RepoSettingsEditor({
 
       <div className="text-sm font-medium text-text-primary">{repo.name}</div>
       <div className="text-xs text-text-secondary font-mono">{repo.rootDir}</div>
+      {repo.remoteUrl && (
+        <div className="text-xs text-text-secondary font-mono truncate" title={repo.remoteUrl}>{repo.remoteUrl}</div>
+      )}
 
       <div className="space-y-2">
         <label className="text-xs text-text-secondary">Default Agent</label>

--- a/src/renderer/components/newSession/RepoSettingsView.tsx
+++ b/src/renderer/components/newSession/RepoSettingsView.tsx
@@ -113,6 +113,15 @@ export function RepoSettingsView({
               </div>
             </div>
 
+            {repo.remoteUrl && (
+              <div>
+                <label className="block text-xs font-medium text-text-secondary mb-1">Remote URL</label>
+                <div className="text-sm font-mono text-text-primary bg-bg-tertiary rounded px-3 py-2 truncate">
+                  {repo.remoteUrl}
+                </div>
+              </div>
+            )}
+
             <div>
               <label className="block text-xs font-medium text-text-secondary mb-1">Default Agent</label>
               <select


### PR DESCRIPTION
## Summary

- Display the git remote URL in both repo settings panels (RepoSettingsEditor and RepoSettingsView) when available
- Update CrashRecoveryBanner tests to use the structured `CrashReport` object instead of raw strings, matching the current API

## Changes

- **RepoSettingsEditor**: Show `repo.remoteUrl` below the directory path, with truncation and title tooltip
- **RepoSettingsView**: Add a labeled "Remote URL" field in the repo detail panel
- **CrashRecoveryBanner tests**: Fix mock return values to use `mockCrashReport` object (with new `platform` and `processType` fields) instead of plain strings

## Test plan

- [x] All 2999 unit tests pass
- [x] 72 E2E tests pass
- [x] Coverage at 90.66% (above 90% threshold)
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)