### PR TITLE
Focus terminal input after clicking resume

### DIFF
--- a/src/renderer/components/Terminal.test.tsx
+++ b/src/renderer/components/Terminal.test.tsx
@@ -232,6 +232,34 @@ describe('Terminal', () => {
       expect(screen.getByText(/Resume your previous conversation/)).toBeTruthy()
     })
 
+    it('focuses the terminal after clicking resume', async () => {
+      const { useTerminalSetup } = await import('../hooks/useTerminalSetup')
+      const mockFocus = vi.fn()
+      vi.mocked(useTerminalSetup).mockReturnValue({
+        terminalRef: { current: { focus: mockFocus } as unknown as import('@xterm/xterm').Terminal },
+        ptyIdRef: { current: 'pty-123' },
+        isActiveRef: { current: true },
+        showScrollButton: false,
+        handleScrollToBottom: vi.fn(),
+        exitInfo: null,
+      })
+
+      const rAFs: FrameRequestCallback[] = []
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => { rAFs.push(cb); return rAFs.length })
+
+      render(<Terminal sessionId="session-1" cwd="/tmp/test" isAgentTerminal isRestored />)
+      fireEvent.click(screen.getByText(/Run \/resume/))
+
+      // Banner should be dismissed
+      expect(screen.queryByText(/Resume your previous conversation/)).toBeNull()
+
+      // Trigger the double-rAF chain to flush focus
+      while (rAFs.length) rAFs.shift()!(0)
+
+      expect(mockFocus).toHaveBeenCalled()
+      vi.restoreAllMocks()
+    })
+
     it('dismisses resume banner when close button is clicked', async () => {
       const { useTerminalSetup } = await import('../hooks/useTerminalSetup')
       vi.mocked(useTerminalSetup).mockReturnValue({

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -93,6 +93,13 @@ export default function Terminal({ sessionId, cwd, command, env, isAgentTerminal
       void sendAgentPrompt(ptyIdRef.current, '/resume')
     }
     setResumeDismissed(true)
+    // Focus the xterm instance after React removes the banner so keyboard
+    // input reaches the terminal immediately (e.g. to pick a chat to resume).
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        terminalRef.current?.focus()
+      })
+    })
   }, [])
 
   const config: TerminalConfig = {


### PR DESCRIPTION
## Background and Motivation

When clicking "Run /resume" on the resume banner above an agent terminal, the `/resume` command is sent but keyboard focus is lost. The banner button that held focus is immediately removed from the DOM by `setResumeDismissed(true)`, leaving focus on `document.body`. The delayed focus attempt inside `sendAgentPrompt` → `focusAgentTerminal()` uses a DOM querySelector that doesn't reliably restore focus after the banner removal re-render.

This makes it hard to interact with the `/resume` conversation picker without an extra click on the terminal.

## Design Decisions

- **Direct xterm API focus** rather than DOM querySelector: `terminalRef.current?.focus()` is more reliable than querying for `.xterm-helper-textarea` since it uses xterm's own focus management.
- **Double requestAnimationFrame**: Ensures React has committed the banner removal before attempting focus, matching the existing pattern used elsewhere in focusHelpers.
- **Kept existing `sendAgentPrompt` focus**: The new focus call is additive — belt-and-suspenders. The earlier call via `sendAgentPrompt` still runs ~250ms later as a fallback.

## Proposed Changes

- **Terminal resume handler** (`Terminal.tsx`): Added a double-rAF `terminalRef.current?.focus()` call in `handleResume` so the terminal receives keyboard focus immediately after the banner is dismissed.
- **Test coverage** (`Terminal.test.tsx`): Added a test verifying that clicking the resume button triggers `terminal.focus()` after the rAF chain flushes.

## Testing

- All 3001 unit tests pass
- All 72 E2E tests pass
- Lint, typecheck, and check:all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)