### PR TITLE
Fix garbled terminal when switching sessions

### DIFF
--- a/src/renderer/hooks/useTerminalSetup.ts
+++ b/src/renderer/hooks/useTerminalSetup.ts
@@ -470,6 +470,13 @@ export function useTerminalSetup(
         // Without this, buffered TUI frames render at stale dimensions and
         // leave orphaned lines / blank gaps in the scrollback.
         try { s.fitAddonRef.current?.fit() } catch { /* ignore */ }
+        // Sync PTY dimensions — the ResizeObserver won't fire because the
+        // container size hasn't changed, but the terminal may have been
+        // created or last fitted at different dimensions.
+        const term = s.terminalRef.current
+        if (s.ptyIdRef.current && term && term.cols > 0 && term.rows > 0) {
+          void window.pty.resize(s.ptyIdRef.current, term.cols, term.rows)
+        }
         s.dataHandlerRef.current?.flush()
         requestAnimationFrame(() => {
           s.terminalRef.current?.focus()


### PR DESCRIPTION
## Background and Motivation

PR #25 fixed phantom spinner flashes by skipping ResizeObserver callbacks for background terminals. However, this introduced a regression: when switching back to a terminal, the display often appeared garbled. Dragging to resize would fix it, pointing to a missing resize sync.

## Design Decisions

Rather than re-enabling ResizeObserver for active terminals on focus/blur (which was the original cause of the spinner issue), we add an explicit PTY resize in the activation handler. This is simpler and more targeted — the terminal only gets resized when it actually becomes active, not on every window focus/blur event.

## Proposed Changes

- **PTY resize on activation** (`useTerminalSetup.ts`): After `fitAddon.fit()` syncs xterm's internal dimensions, send `window.pty.resize()` to the PTY process. The ResizeObserver won't fire because the container size hasn't changed between sessions, so this explicit call is needed to keep the PTY and xterm in sync.

## Testing

- All 3006 unit tests pass
- Coverage at 90.02% (above 90% threshold)
- Lint and typecheck clean
- Manual verification: switching sessions no longer produces garbled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)