### PR TITLE
Add Windows platform support: WSL agent detection, UX guidance, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm typecheck
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm test:unit
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpm dist:mac
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-macos
+          path: dist/*.dmg
+          retention-days: 7
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm build
+      - run: npx electron-builder --win --x64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-windows
+          path: |
+            dist/*.exe
+          retention-days: 7
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm build
+      - run: npx electron-builder --linux --x64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-linux
+          path: |
+            dist/*.AppImage
+            dist/*.deb
+          retention-days: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@
 
 - Node.js 18+
 - [pnpm](https://pnpm.io/) (enforced -- npm and yarn will not work)
-- macOS (for native PTY support; Linux support is possible but untested)
+- macOS, Windows, or Linux
+- **Windows:** C++ build tools for node-pty (`npm install -g windows-build-tools` or Visual Studio Build Tools)
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,19 @@ Built with Electron, React, and xterm.js.
 - **Customizable panels** -- Toggle and reorder panels (Explorer, File Viewer, Agent Terminal, User Terminal, Settings)
 - **Keyboard shortcuts** -- `Cmd+1-6` to toggle panels, `Cmd+Shift+C` to copy terminal content
 
+## Platform Support
+
+- **macOS** -- Full support (signed + notarized releases)
+- **Windows** -- Supported (NSIS installer + portable exe)
+- **Linux** -- Supported (AppImage + .deb)
+
 ## Quick Start
 
 ### Prerequisites
 
 - Node.js 18+
 - [pnpm](https://pnpm.io/) (required -- npm/yarn will not work)
+- **Windows:** C++ build tools for node-pty native module (`npm install -g windows-build-tools` or install Visual Studio Build Tools)
 
 ### Installation
 
@@ -37,7 +44,10 @@ The app opens automatically in development mode with hot reload. Dev mode uses a
 ### Building for Distribution
 
 ```bash
-pnpm dist          # Build and package for macOS
+pnpm dist          # Build and package for current platform
+pnpm dist:mac      # Build for macOS
+pnpm dist:win      # Build for Windows (x64)
+pnpm dist:linux    # Build for Linux (x64 + arm64)
 pnpm start         # Run the packaged app
 ```
 
@@ -74,8 +84,8 @@ Each session has independently togglable panels:
 
 ### Keyboard Shortcuts
 
-- `Cmd+1` through `Cmd+6` -- Toggle panels (based on toolbar order)
-- `Cmd+Shift+C` -- Copy terminal content + session summary to clipboard
+- `Cmd+1` through `Cmd+6` (macOS) / `Ctrl+1` through `Ctrl+6` (Windows/Linux) -- Toggle panels (based on toolbar order)
+- `Cmd+Shift+C` (macOS) / `Ctrl+Shift+C` (Windows/Linux) -- Copy terminal content + session summary to clipboard
 
 ## Architecture
 
@@ -202,6 +212,10 @@ Config files are stored at `~/.broomy/`:
 **Blank screen on launch** -- Check the DevTools console for preload script errors. Ensure the preload script is built as CommonJS (`.js`, not `.mjs`).
 
 **pnpm is required** -- This project enforces pnpm via a `preinstall` script. Using npm or yarn will fail.
+
+**Windows: node-pty build fails** -- Install C++ build tools: `npm install -g windows-build-tools` or install [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the "Desktop development with C++" workload.
+
+**Windows: SmartScreen warning** -- Windows builds are unsigned. Click "More info" > "Run anyway" on first launch. The warning diminishes as download reputation builds.
 
 ## License
 

--- a/scripts/dist-win.ps1
+++ b/scripts/dist-win.ps1
@@ -1,0 +1,68 @@
+# Build and package Broomy for Windows.
+# Run from the project root: .\scripts\dist-win.ps1
+
+$ErrorActionPreference = "Stop"
+
+$projectRoot = "$PSScriptRoot\.."
+Set-Location $projectRoot
+
+Write-Host "Checking prerequisites..." -ForegroundColor Cyan
+
+# Check Node.js
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    Write-Host "ERROR: Node.js is not installed. Install from https://nodejs.org/" -ForegroundColor Red
+    exit 1
+}
+$nodeVersion = (node --version)
+Write-Host "  Node.js: $nodeVersion" -ForegroundColor Green
+
+# Check pnpm
+if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
+    Write-Host "  pnpm not found, installing..." -ForegroundColor Yellow
+    npm install -g pnpm
+}
+$pnpmVersion = (pnpm --version)
+Write-Host "  pnpm: $pnpmVersion" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "Installing dependencies..." -ForegroundColor Cyan
+pnpm install
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host ""
+Write-Host "Building application..." -ForegroundColor Cyan
+pnpm build
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+# Fix symlinks that break electron-builder on Windows.
+# AGENTS.md -> CLAUDE.md is a Unix symlink; replace with a copy for packaging.
+$symlinkFixed = $false
+if (Test-Path "AGENTS.md") {
+    $item = Get-Item "AGENTS.md" -Force
+    if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+        Write-Host "  Replacing AGENTS.md symlink with file copy for packaging..." -ForegroundColor Yellow
+        Remove-Item "AGENTS.md" -Force
+        Copy-Item "CLAUDE.md" "AGENTS.md"
+        $symlinkFixed = $true
+    }
+}
+
+Write-Host ""
+Write-Host "Packaging for Windows (NSIS installer + portable)..." -ForegroundColor Cyan
+try {
+    npx electron-builder --win --x64
+    if ($LASTEXITCODE -ne 0) { throw "electron-builder failed" }
+} finally {
+    # Restore the original symlink if we replaced it
+    if ($symlinkFixed) {
+        Remove-Item "AGENTS.md" -Force -ErrorAction SilentlyContinue
+        git checkout -- AGENTS.md 2>$null
+    }
+}
+
+Write-Host ""
+Write-Host "Build complete! Artifacts in dist/:" -ForegroundColor Green
+Get-ChildItem dist\*.exe | ForEach-Object { Write-Host "  $($_.Name) ($([math]::Round($_.Length / 1MB, 1)) MB)" -ForegroundColor Green }
+
+# Return to scripts directory
+Set-Location "$projectRoot\scripts"

--- a/src/main/handlers/fsCore.ts
+++ b/src/main/handlers/fsCore.ts
@@ -98,7 +98,7 @@ async function handleAppendFile(ctx: HandlerContext, filePath: string, content: 
 async function handleExists(ctx: HandlerContext, filePath: string) {
   if (ctx.isE2ETest) {
     // Check if scenario has marketing review files in tmp dir
-    if (getScenarioData(ctx.e2eScenario).hasMarketingReviewFiles && /\/tmp\/broomy-review-[^/]+\/(review|comments)\.json$/.exec(filePath)) {
+    if (getScenarioData(ctx.e2eScenario).hasMarketingReviewFiles && /broomy-review-[^/\\]+[/\\](review|comments)\.json$/.exec(filePath)) {
       return true
     }
     // Review/comments files always exist for mock data in any scenario

--- a/src/main/handlers/ghCore.ts
+++ b/src/main/handlers/ghCore.ts
@@ -89,7 +89,19 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
       return true
     } catch {
       // Fall back to well-known install locations on all platforms
-      return resolveCommand(baseCommand) !== null
+      if (resolveCommand(baseCommand) !== null) return true
+
+      // On Windows, also check inside WSL — many agents (e.g. Claude Code)
+      // are only installed there
+      if (isWindows && /^[a-zA-Z0-9_.-]+$/.test(baseCommand)) {
+        try {
+          await execFileAsync('wsl', ['which', baseCommand], { encoding: 'utf-8', timeout: 5000 })
+          return true
+        } catch {
+          // not in WSL either
+        }
+      }
+      return false
     }
   })
 

--- a/src/main/handlers/scenarios.ts
+++ b/src/main/handlers/scenarios.ts
@@ -379,7 +379,7 @@ const MARKETING: ScenarioData = {
   readFile(filePath: string): string | null {
     if (filePath.includes('auth.ts')) return buildMarketingAuthTs()
     if (/broomy-review-[^/\\]+[/\\]review\.json$/.exec(filePath)) return buildMarketingReviewJson()
-    if (/\/tmp\/broomy-review-[^/]+\/comments\.json$/.exec(filePath)) return '[]'
+    if (/broomy-review-[^/\\]+[/\\]comments\.json$/.exec(filePath)) return '[]'
     return null
   },
   hasMarketingReviewFiles: true,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -106,11 +106,19 @@ function GitMissingBanner() {
 
 function GhMissingBanner() {
   const { ghAvailable } = useRepoStore()
+  const [isWindows, setIsWindows] = useState(false)
+  useEffect(() => {
+    void window.app.platform().then((p) => setIsWindows(p === 'win32'))
+  }, [])
   if (ghAvailable !== false) return null
   return (
     <div className="bg-yellow-900/30 border-b border-yellow-500/30 px-4 py-2 text-xs text-yellow-300 flex items-center gap-2">
       <span className="font-medium">GitHub CLI (gh) is not installed.</span>
-      <span className="text-yellow-400">Install it for authentication, issues, and PR features.</span>
+      <span className="text-yellow-400">
+        {isWindows
+          ? 'Install it on Windows (not WSL) for authentication, issues, and PR features.'
+          : 'Install it for authentication, issues, and PR features.'}
+      </span>
       <button onClick={() => window.shell.openExternal('https://cli.github.com')} className="text-accent hover:underline ml-1">Install gh</button>
     </div>
   )

--- a/src/renderer/components/SettingsRootScreen.tsx
+++ b/src/renderer/components/SettingsRootScreen.tsx
@@ -2,6 +2,7 @@
  * Root screen of the settings panel showing General settings and navigation rows
  * for Agents and individual repositories.
  */
+import { useState, useEffect } from 'react'
 import type { AgentConfig } from '../store/agents'
 import type { ManagedRepo } from '../../preload/index'
 import type { ShellOption } from '../../preload/apis/types'
@@ -29,6 +30,13 @@ export function SettingsRootScreen({
   onNavigateToAgents,
   onNavigateToRepo,
 }: SettingsRootScreenProps) {
+  const [isWindows, setIsWindows] = useState(false)
+  useEffect(() => {
+    void window.app.platform().then((p) => setIsWindows(p === 'win32'))
+  }, [])
+
+  const isWslSelected = isWindows && (defaultShell || '').toLowerCase().includes('wsl')
+
   return (
     <div className="space-y-4">
       {/* General section */}
@@ -73,6 +81,13 @@ export function SettingsRootScreen({
         <p className="text-xs text-text-tertiary">
           Applied to new terminal sessions. Existing sessions are not affected.
         </p>
+        {isWslSelected && (
+          <p className="text-xs text-yellow-400/80 mt-1">
+            Ensure your default WSL distro has your agents installed.
+            Run <span className="font-mono">wsl --set-default &lt;distro&gt;</span> in
+            PowerShell to change it (check with <span className="font-mono">wsl -l -v</span>).
+          </p>
+        )}
       </div>
 
       {/* Agents nav row */}

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -85,6 +85,11 @@ export default function Terminal({ sessionId, cwd, command, env, isAgentTerminal
   const containerRef = useRef<HTMLDivElement>(null)
   const [restartKey, setRestartKey] = useState(0)
   const [resumeDismissed, setResumeDismissed] = useState(false)
+  const [isWindows, setIsWindows] = useState(false)
+
+  useEffect(() => {
+    void window.app.platform().then((p) => setIsWindows(p === 'win32'))
+  }, [])
 
   const showResumeBanner = isAgentTerminal && isRestored && !resumeDismissed && !agentNotInstalled
 
@@ -205,6 +210,13 @@ export default function Terminal({ sessionId, cwd, command, env, isAgentTerminal
               <span> Install it to use this agent.</span>
             )
           })()}
+          {isWindows && (
+            <div className="mt-1.5 text-yellow-400/80">
+              <span className="font-medium">Windows tip:</span> Many agents (e.g. Claude Code) run in WSL.
+              Select <span className="font-medium">WSL</span> as your shell in Settings,
+              or set the agent command to <span className="font-mono">wsl {command}</span>.
+            </div>
+          )}
         </div>
       )}
       {showResumeBanner && (

--- a/src/renderer/components/newSession/AgentPickerView.tsx
+++ b/src/renderer/components/newSession/AgentPickerView.tsx
@@ -22,6 +22,11 @@ export function AgentPickerView({
   const folderName = repoName || directory.split('/').pop() || directory
   const [installedStatus, setInstalledStatus] = useState<Record<string, boolean>>({})
   const [warningAgentId, setWarningAgentId] = useState<string | null>(null)
+  const [isWindows, setIsWindows] = useState(false)
+
+  useEffect(() => {
+    void window.app.platform().then((p) => setIsWindows(p === 'win32'))
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -114,6 +119,13 @@ export function AgentPickerView({
                       <> Install it first, or click again to proceed anyway.</>
                     )
                   })()}
+                  {isWindows && (
+                    <div className="mt-1.5 text-yellow-400/80">
+                      <span className="font-medium">Windows tip:</span> Many agents (e.g. Claude Code) run in WSL.
+                      Select <span className="font-medium">WSL</span> as your shell in Settings,
+                      or set the agent command to <span className="font-mono">wsl {agent.command}</span>.
+                    </div>
+                  )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary

- **WSL agent detection**: When `where` fails to find an agent on Windows PATH, falls back to `wsl which` so agents installed in WSL (e.g. Claude Code) are detected correctly. Input is sanitized with `/^[a-zA-Z0-9_.-]+$/` before passing to WSL.
- **Windows UX guidance**: Contextual tips throughout the app — WSL shell selection in Settings shows distro configuration advice, agent "not installed" banners suggest WSL usage, and the GitHub CLI banner clarifies it must be installed natively on Windows (not in WSL).
- **Cross-platform regex fixes**: E2E mock data path matching in `fsCore.ts` and `scenarios.ts` now accepts both `/` and `\` separators.
- **Native Windows build script**: `scripts/dist-win.ps1` handles the `AGENTS.md` symlink (replaces with file copy for electron-builder, restores via `git checkout` afterward).
- **GitHub Actions CI**: Lint, typecheck, unit tests, and platform builds (macOS, Windows, Linux) with artifact upload.
- **Documentation**: README and CONTRIBUTING updated with Windows prerequisites, all platform build commands, Windows keyboard shortcuts, and troubleshooting section.

## Testing

- All 3006 unit tests pass (179 test files)
- Lint and typecheck clean
- Built and tested the Windows portable exe — agent detection via WSL works, terminal sessions launch correctly
- Verified `wsl which` fallback only triggers on Windows and only with safe command names

## Test plan

- [ ] CI passes on all three platform builds
- [ ] Windows build produces working NSIS installer and portable exe
- [ ] Agent detection finds WSL-installed agents (e.g. `claude`, `codex`)
- [ ] WSL tips appear only on Windows when relevant
- [ ] GitHub CLI banner shows Windows-specific message on Windows
- [ ] Settings WSL distro hint appears when WSL shell is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)