### PR TITLE
Fix search history saving prefixes on every keystroke

### DIFF
--- a/src/renderer/components/explorer/SearchPanel.tsx
+++ b/src/renderer/components/explorer/SearchPanel.tsx
@@ -171,7 +171,6 @@ export function SearchPanel({ directory, onFileSelect, sessionId }: SearchPanelP
         try {
           const results = await window.fs.search(directory, searchQuery)
           setSearchResults(results)
-          if (sessionId) addSearchHistory(sessionId, searchQuery)
         } catch {
           setSearchResults([])
           setSearchError('Search failed')
@@ -211,6 +210,7 @@ export function SearchPanel({ directory, onFileSelect, sessionId }: SearchPanelP
             data-explorer-search
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
+            onBlur={() => { if (sessionId && searchQuery.length >= 2) addSearchHistory(sessionId, searchQuery) }}
             placeholder="Search files..."
             className="w-full bg-bg-tertiary border border-border rounded px-2 py-1 pr-6 text-xs text-text-primary outline-none focus:border-accent"
           />


### PR DESCRIPTION
## Summary

- Search history was recording every intermediate prefix typed into the search box (e.g. "fo", "foo", "foob", "fooba", "foobar") because `addSearchHistory` was called inside the debounced search effect that fires on each keystroke.
- Moved the `addSearchHistory` call to the search input's `onBlur` handler so a search is only saved when the user moves focus away from the search box, capturing only completed searches.

## Test plan

- [ ] Type a search query in the explorer search tab
- [ ] Verify no history entries appear until focus leaves the input
- [ ] Click on a search result (moves focus away) and confirm the search is saved to history
- [ ] Clear the search and verify only the final query appears in history, not intermediate prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)