### PR TITLE
fix: show PR link in source control when branchStatus lags

### DIFF
--- a/src/renderer/features/git/explorerHelpers.ts
+++ b/src/renderer/features/git/explorerHelpers.ts
@@ -106,3 +106,15 @@ export const branchStatusBadge: Record<string, { label: string; classes: string 
   merged: { label: 'MERGED', classes: 'bg-purple-500/20 text-purple-400' },
   closed: { label: 'CLOSED', classes: 'bg-red-500/20 text-red-400' },
 }
+
+/**
+ * Badge derived directly from the GitHub PR state (OPEN/MERGED/CLOSED).
+ * Used as a fallback when branchStatus hasn't caught up with the live PR data
+ * (e.g. branch is still 'pushed' or 'in-progress' while gh pr view already
+ * reports the PR).
+ */
+export const prStateBadge: Record<string, { label: string; classes: string }> = {
+  OPEN: { label: 'PR OPEN', classes: 'bg-green-500/20 text-green-400' },
+  MERGED: { label: 'MERGED', classes: 'bg-purple-500/20 text-purple-400' },
+  CLOSED: { label: 'CLOSED', classes: 'bg-red-500/20 text-red-400' },
+}

--- a/src/renderer/features/git/explorerHelpers.ts
+++ b/src/renderer/features/git/explorerHelpers.ts
@@ -113,7 +113,7 @@ export const branchStatusBadge: Record<string, { label: string; classes: string 
  * (e.g. branch is still 'pushed' or 'in-progress' while gh pr view already
  * reports the PR).
  */
-export const prStateBadge: Record<string, { label: string; classes: string }> = {
+export const prStateBadge: Record<'OPEN' | 'MERGED' | 'CLOSED', { label: string; classes: string }> = {
   OPEN: { label: 'PR OPEN', classes: 'bg-green-500/20 text-green-400' },
   MERGED: { label: 'MERGED', classes: 'bg-purple-500/20 text-purple-400' },
   CLOSED: { label: 'CLOSED', classes: 'bg-red-500/20 text-red-400' },

--- a/src/renderer/features/git/hooks/useGitPolling.test.ts
+++ b/src/renderer/features/git/hooks/useGitPolling.test.ts
@@ -470,6 +470,68 @@ describe('useGitPolling', () => {
     })
   })
 
+  describe('agent-finished PR fetch', () => {
+    it('fetches PR status when agent finishes work', async () => {
+      vi.mocked(window.git.status).mockResolvedValue(makeGitStatus())
+      vi.mocked(normalizeGitStatus).mockReturnValue(makeGitStatus())
+      vi.mocked(window.gh.prStatus).mockResolvedValue({
+        number: 42, title: 'Test PR', state: 'OPEN',
+        url: 'https://github.com/test/pr/42',
+        headRefName: 'feature/test', baseRefName: 'main',
+      })
+
+      renderHook(() => useGitPolling(defaultProps))
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent('broomy:agent-finished'))
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(window.gh.prStatus).toHaveBeenCalledWith('/test/project')
+      expect(updatePrState).toHaveBeenCalledWith('session-1', 'OPEN', 42, 'https://github.com/test/pr/42')
+    })
+
+    it('does not call updatePrState when no PR exists', async () => {
+      vi.mocked(window.git.status).mockResolvedValue(makeGitStatus())
+      vi.mocked(normalizeGitStatus).mockReturnValue(makeGitStatus())
+      vi.mocked(window.gh.prStatus).mockResolvedValue(null)
+
+      renderHook(() => useGitPolling(defaultProps))
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent('broomy:agent-finished'))
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(window.gh.prStatus).toHaveBeenCalledWith('/test/project')
+      // updatePrState may be called by branch status computation, but not from the PR fetch
+      const prStateCalls = vi.mocked(updatePrState).mock.calls.filter(
+        ([, state]) => state === 'OPEN' || state === 'MERGED' || state === 'CLOSED'
+      )
+      expect(prStateCalls).toHaveLength(0)
+    })
+
+    it('handles gh.prStatus errors gracefully', async () => {
+      vi.mocked(window.git.status).mockResolvedValue(makeGitStatus())
+      vi.mocked(normalizeGitStatus).mockReturnValue(makeGitStatus())
+      vi.mocked(window.gh.prStatus).mockRejectedValue(new Error('gh not found'))
+
+      renderHook(() => useGitPolling(defaultProps))
+
+      // Should not throw
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent('broomy:agent-finished'))
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      // updatePrState should not be called with PR data on error
+      const prStateCalls = vi.mocked(updatePrState).mock.calls.filter(
+        ([, state]) => state === 'OPEN' || state === 'MERGED' || state === 'CLOSED'
+      )
+      expect(prStateCalls).toHaveLength(0)
+    })
+  })
+
   describe('activeSessionGitStatus', () => {
     it('returns files from active session git status', async () => {
       const files = [{ path: 'file.ts', status: 'modified' as const, staged: false, indexStatus: ' ', workingDirStatus: 'M' }]

--- a/src/renderer/features/git/hooks/useGitPolling.ts
+++ b/src/renderer/features/git/hooks/useGitPolling.ts
@@ -124,6 +124,24 @@ export function useGitPolling({
     }
   }, [gitStatusBySession, isMergedBySession, sessions, updateBranchStatus])
 
+  // Fetch PR status when any agent finishes work.
+  // This runs at the app level (always mounted) so it catches the event even when
+  // the source control tab isn't open. Without this, lastKnownPrState wouldn't be
+  // updated until the user manually navigates to the source control tab.
+  useEffect(() => {
+    const handler = () => {
+      if (!activeSession?.directory) return
+      const sessionId = activeSession.id
+      void window.gh.prStatus(activeSession.directory).then(pr => {
+        if (pr) {
+          updatePrState(sessionId, pr.state, pr.number, pr.url)
+        }
+      }).catch(() => { /* gh not available or no PR */ })
+    }
+    document.addEventListener('broomy:agent-finished', handler)
+    return () => document.removeEventListener('broomy:agent-finished', handler)
+  }, [activeSession?.id, activeSession?.directory, updatePrState])
+
   // Get git status for the selected file
   const selectedFileStatus = useMemo(() => {
     if (!activeSession?.selectedFilePath || !activeSession.directory) return null

--- a/src/renderer/panels/explorer/tabs/source-control/SCPrBanner.test.tsx
+++ b/src/renderer/panels/explorer/tabs/source-control/SCPrBanner.test.tsx
@@ -59,6 +59,32 @@ describe('SCPrBanner', () => {
     expect(window.shell.openExternal).toHaveBeenCalledWith('https://github.com/test/pr/42')
   })
 
+  it('shows PR link when branchStatus is pushed (gh detected PR before polling caught up)', () => {
+    const prStatus = { number: 99, title: 'New feature', state: 'OPEN' as const, url: 'https://github.com/test/pr/99', headRefName: 'feature/new', baseRefName: 'main' }
+    render(<SCPrBanner {...defaultProps} prStatus={prStatus} branchStatus="pushed" />)
+    expect(screen.getByText(/#99: New feature/)).toBeTruthy()
+    expect(screen.getByText('PR OPEN')).toBeTruthy()
+  })
+
+  it('shows PR link when branchStatus is in-progress (branch has commits ahead with open PR)', () => {
+    const prStatus = { number: 99, title: 'New feature', state: 'OPEN' as const, url: 'https://github.com/test/pr/99', headRefName: 'feature/new', baseRefName: 'main' }
+    render(<SCPrBanner {...defaultProps} prStatus={prStatus} branchStatus="in-progress" />)
+    expect(screen.getByText(/#99: New feature/)).toBeTruthy()
+    expect(screen.getByText('PR OPEN')).toBeTruthy()
+  })
+
+  it('hides stale merged PR link when branch has moved on', () => {
+    const prStatus = { number: 99, title: 'Old PR', state: 'MERGED' as const, url: 'https://github.com/test/pr/99', headRefName: 'feature/old', baseRefName: 'main' }
+    render(<SCPrBanner {...defaultProps} prStatus={prStatus} branchStatus="in-progress" />)
+    expect(screen.queryByText(/#99/)).toBeNull()
+  })
+
+  it('hides stale closed PR link when branch has new work', () => {
+    const prStatus = { number: 99, title: 'Old PR', state: 'CLOSED' as const, url: 'https://github.com/test/pr/99', headRefName: 'feature/old', baseRefName: 'main' }
+    render(<SCPrBanner {...defaultProps} prStatus={prStatus} branchStatus="pushed" />)
+    expect(screen.queryByText(/#99/)).toBeNull()
+  })
+
   it('shows merged status banner', () => {
     render(<SCPrBanner {...defaultProps} branchStatus="merged" />)
     expect(screen.getByText('MERGED')).toBeTruthy()

--- a/src/renderer/panels/explorer/tabs/source-control/SCPrBanner.tsx
+++ b/src/renderer/panels/explorer/tabs/source-control/SCPrBanner.tsx
@@ -58,6 +58,38 @@ function RefreshButton({ onRefresh, isRefreshing }: { onRefresh: () => void; isR
   )
 }
 
+/**
+ * Compute the badge and visibility for the PR link.
+ *
+ * Shows the PR link whenever prStatus has metadata from gh, unless it's a stale
+ * MERGED/CLOSED PR on a branch that has moved on. Derives the badge from the live
+ * PR state when branchStatus hasn't caught up yet (e.g. still 'pushed' or
+ * 'in-progress' because useGitPolling hasn't recomputed).
+ */
+function computePrBadge(
+  prStatus: GitHubPrStatus,
+  branchStatus: BranchStatus | undefined,
+  statusChip: StatusChip | undefined,
+): { badge: { label: string; classes: string }; isStale: boolean } | null {
+  const hasPrMetadata = prStatus?.number && prStatus.url
+  if (!hasPrMetadata) return null
+
+  const isStaleTerminalPr =
+    (prStatus.state === 'MERGED' || prStatus.state === 'CLOSED') &&
+    (branchStatus === 'in-progress' || branchStatus === 'pushed')
+
+  // When branchStatus is PR-aware (open/merged/closed/feedback/failed), use its badge.
+  // Otherwise the branch status hasn't caught up with the live PR data, so derive
+  // the badge directly from the PR state.
+  const chipKey = statusChip ?? branchStatus
+  const branchBadge = chipKey ? branchStatusBadge[chipKey] : undefined
+  const isPrAwareBranch = branchStatus === 'open' || branchStatus === 'merged' || branchStatus === 'closed'
+    || statusChip === 'feedback' || statusChip === 'failed'
+  const badge = (isPrAwareBranch && branchBadge) ? branchBadge : prStateBadge[prStatus.state]
+
+  return { badge, isStale: isStaleTerminalPr }
+}
+
 function PrStatusContent({
   prStatus, branchStatus, statusChip, branchBaseName, issueNumber, issueTitle, issueUrl,
   onFileSelect, onRefresh, isRefreshing, reviewStatus, isReview,
@@ -68,36 +100,14 @@ function PrStatusContent({
   'reviewStatus' | 'isReview'
 >) {
   const refresh = onRefresh ? <RefreshButton onRefresh={onRefresh} isRefreshing={isRefreshing} /> : null
+  const prInfo = computePrBadge(prStatus, branchStatus, statusChip)
 
-  // Use statusChip (which accounts for feedback/failed) as the single source of truth
-  // for the badge, falling back to branchStatus for backwards compat.
-  const chipKey = statusChip ?? branchStatus
-  const badge = chipKey ? branchStatusBadge[chipKey] : undefined
-  const hasPrMetadata = prStatus?.number && prStatus.url
-
-  // Show PR link whenever we have metadata from gh, unless it's a stale MERGED/CLOSED
-  // PR on a branch that has moved on (new commits or uncommitted work).
-  // We derive the badge from the live PR state when branchStatus hasn't caught up yet
-  // (e.g. branchStatus is still 'pushed' or 'in-progress' because useGitPolling hasn't
-  // recomputed, or because the branch has commits ahead of remote).
-  const isStaleTerminalPr = hasPrMetadata &&
-    (prStatus.state === 'MERGED' || prStatus.state === 'CLOSED') &&
-    (branchStatus === 'in-progress' || branchStatus === 'pushed')
-  // When branchStatus is PR-aware (open/merged/closed/feedback/failed), use its badge.
-  // Otherwise the branch status hasn't caught up with the live PR data, so derive
-  // the badge directly from the PR state.
-  const isPrAwareBranch = branchStatus === 'open' || branchStatus === 'merged' || branchStatus === 'closed'
-    || statusChip === 'feedback' || statusChip === 'failed'
-  const prBadge = (isPrAwareBranch && badge) ? badge
-    : hasPrMetadata ? prStateBadge[prStatus.state]
-    : undefined
-
-  if (hasPrMetadata && !isStaleTerminalPr && prBadge) {
+  if (prInfo && !prInfo.isStale && prStatus) {
     return (
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-2">
-          <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${prBadge.classes}`}>
-            {prBadge.label}
+          <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${prInfo.badge.classes}`}>
+            {prInfo.badge.label}
           </span>
           <button
             onClick={() => onFileSelect

--- a/src/renderer/panels/explorer/tabs/source-control/SCPrBanner.tsx
+++ b/src/renderer/panels/explorer/tabs/source-control/SCPrBanner.tsx
@@ -4,7 +4,7 @@
 import type { GitHubPrStatus } from '../../../../../preload/index'
 import type { BranchStatus, StatusChip } from '../../../../store/sessions'
 import type { NavigationTarget } from '../../../../shared/utils/fileNavigation'
-import { branchStatusBadge } from '../../../../features/git/explorerHelpers'
+import { branchStatusBadge, prStateBadge } from '../../../../features/git/explorerHelpers'
 import { DialogErrorBanner } from '../../../../shared/components/ErrorBanner'
 import { useRepoStore } from '../../../../store/repos'
 import { AuthSetupSection, isAuthError } from '../../../../shared/components/AuthSetupSection'
@@ -74,15 +74,30 @@ function PrStatusContent({
   const chipKey = statusChip ?? branchStatus
   const badge = chipKey ? branchStatusBadge[chipKey] : undefined
   const hasPrMetadata = prStatus?.number && prStatus.url
-  const isPrRelated = branchStatus === 'open' || branchStatus === 'merged' || branchStatus === 'closed'
-    || statusChip === 'feedback' || statusChip === 'failed'
 
-  if (hasPrMetadata && isPrRelated && badge) {
+  // Show PR link whenever we have metadata from gh, unless it's a stale MERGED/CLOSED
+  // PR on a branch that has moved on (new commits or uncommitted work).
+  // We derive the badge from the live PR state when branchStatus hasn't caught up yet
+  // (e.g. branchStatus is still 'pushed' or 'in-progress' because useGitPolling hasn't
+  // recomputed, or because the branch has commits ahead of remote).
+  const isStaleTerminalPr = hasPrMetadata &&
+    (prStatus.state === 'MERGED' || prStatus.state === 'CLOSED') &&
+    (branchStatus === 'in-progress' || branchStatus === 'pushed')
+  // When branchStatus is PR-aware (open/merged/closed/feedback/failed), use its badge.
+  // Otherwise the branch status hasn't caught up with the live PR data, so derive
+  // the badge directly from the PR state.
+  const isPrAwareBranch = branchStatus === 'open' || branchStatus === 'merged' || branchStatus === 'closed'
+    || statusChip === 'feedback' || statusChip === 'failed'
+  const prBadge = (isPrAwareBranch && badge) ? badge
+    : hasPrMetadata ? prStateBadge[prStatus.state]
+    : undefined
+
+  if (hasPrMetadata && !isStaleTerminalPr && prBadge) {
     return (
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-2">
-          <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${badge.classes}`}>
-            {badge.label}
+          <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${prBadge.classes}`}>
+            {prBadge.label}
           </span>
           <button
             onClick={() => onFileSelect

--- a/src/renderer/panels/explorer/tabs/source-control/useSourceControlData.ts
+++ b/src/renderer/panels/explorer/tabs/source-control/useSourceControlData.ts
@@ -37,16 +37,8 @@ function usePrEffects(config: PrEffectsConfig) {
   const [hasPrLoadedOnce, setHasPrLoadedOnce] = useState(false)
   const [prRefreshKey, setPrRefreshKey] = useState(0)
 
-  // Listen for agent-finished events to re-check PR status
-  useEffect(() => {
-    const handler = () => {
-      if (directory) {
-        setPrRefreshKey(k => k + 1)
-      }
-    }
-    document.addEventListener('broomy:agent-finished', handler)
-    return () => document.removeEventListener('broomy:agent-finished', handler)
-  }, [directory])
+  // Agent-finished PR detection is handled by useGitPolling (always mounted)
+  // so it works even when the source control tab isn't open.
 
   // Fetch PR status, write access, checks, and feedback when source control is active
   useEffect(() => {

--- a/src/renderer/panels/explorer/tabs/source-control/useSourceControlData.ts
+++ b/src/renderer/panels/explorer/tabs/source-control/useSourceControlData.ts
@@ -101,9 +101,11 @@ function usePrEffects(config: PrEffectsConfig) {
   // Don't re-persist MERGED/CLOSED state if the branch has moved on (new work after merge).
   // The git polling hook clears stale PR state when it detects new commits, and we avoid
   // re-setting it here so the branch can transition to a fresh PR lifecycle.
+  // Wait until hasPrLoadedOnce so we don't clear persisted state on initial mount
+  // before the gh fetch has had a chance to run.
   useEffect(() => {
     if (!onUpdatePrState) return
-    if (isPrLoading) return
+    if (!hasPrLoadedOnce) return
     if (prStatus) {
       const isTerminalState = prStatus.state === 'MERGED' || prStatus.state === 'CLOSED'
       const branchMovedOn = branchStatus === 'in-progress' || branchStatus === 'pushed'
@@ -115,7 +117,7 @@ function usePrEffects(config: PrEffectsConfig) {
     } else {
       onUpdatePrState(null)
     }
-  }, [prStatus, isPrLoading, branchStatus])
+  }, [prStatus, hasPrLoadedOnce, branchStatus])
 
   // Reset on directory change
   const resetPr = () => {


### PR DESCRIPTION
## Background and Motivation

The PR link in the source control banner stopped appearing after commit 3d95c43 refactored `SCPrBanner` to add feedback/failed status chips. The refactoring changed the display condition to require `branchStatus` to be `'open'`/`'merged'`/`'closed'`, but `branchStatus` is computed by `useGitPolling` from `lastKnownPrState` in the session store — which lags behind the live `prStatus` returned by `gh pr view`. When the branch has commits ahead of remote, `computeBranchStatus` returns `'in-progress'` (rule 2 takes priority), so the link was permanently hidden for active branches with open PRs.

Additionally, the `broomy:agent-finished` event listener lived inside `usePrEffects` (only mounted with the source control tab), so PR status was never fetched on agent finish unless the user was already viewing source control.

## Design Decisions

- **Derive badge from live PR state as fallback**: When `branchStatus` hasn't caught up (still `'pushed'` or `'in-progress'`), we fall back to `prStateBadge` keyed by the GitHub PR state (`OPEN`/`MERGED`/`CLOSED`). This avoids coupling the banner display to the git polling cycle.
- **Restore original stale-PR guard**: The old logic only hid MERGED/CLOSED PRs when the branch had moved on — OPEN PRs were always shown regardless of `branchStatus`. The new code restores this behavior.
- **Gate update effect on `hasPrLoadedOnce`**: Previously the effect could clear `lastKnownPrState` on mount before the `gh` fetch had a chance to run, causing a brief flash of "No pull request".
- **Single agent-finished listener at app level**: Moved the `broomy:agent-finished` → `gh pr view` fetch into `useGitPolling` (always mounted) and removed the duplicate listener from `usePrEffects`, so the session store gets updated regardless of which explorer tab is active without firing redundant `gh` calls.

## Proposed Changes

**PR link display logic** (`SCPrBanner.tsx`):
- Extract `computePrBadge` helper (also fixes complexity lint error)
- Replace the restrictive `isPrRelated` gate with `isStaleTerminalPr` guard (only hides MERGED/CLOSED on moved-on branches)
- Add `prStateBadge` fallback when `branchStatus` doesn't map to a PR-aware badge

**Badge definitions** (`explorerHelpers.ts`):
- Add `prStateBadge` record typed as `Record<'OPEN' | 'MERGED' | 'CLOSED', ...>` for compile-time safety

**PR state persistence** (`useSourceControlData.ts`):
- Change guard from `isPrLoading` to `hasPrLoadedOnce` so persisted PR state isn't cleared before the initial fetch completes
- Remove duplicate `broomy:agent-finished` listener (now handled by `useGitPolling`)

**Agent-finished PR fetch** (`useGitPolling.ts`):
- Add `broomy:agent-finished` listener that calls `gh pr view` and updates `lastKnownPrState` in the session store, regardless of which explorer tab is open

## Testing

- 4 new SCPrBanner tests: PR link visible with `branchStatus='pushed'`, PR link visible with `branchStatus='in-progress'`, stale MERGED PR hidden, stale CLOSED PR hidden
- 3 new useGitPolling tests: agent-finished triggers PR fetch, no updatePrState on null PR, error handling
- All 3243 unit tests pass, all 72 E2E tests pass
- Lint, typecheck, and check:all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)