### PR TITLE
fix: auto-retry when SDK session resume fails

### DIFF
--- a/src/main/handlers/agentSdk.ts
+++ b/src/main/handlers/agentSdk.ts
@@ -188,6 +188,9 @@ async function runTurn(
     const errorMessage = err instanceof Error ? err.message : String(err)
     if (errorMessage.includes('aborted')) {
       // User cancelled — not an error
+    } else if (isStaleSessionError(errorMessage)) {
+      // Stale SDK session ID — re-throw so startTurn can retry without resume
+      throw err
     } else {
       console.error('[agentSdk] Stream error:', errorMessage)
       if (err instanceof Error && err.stack) console.error(err.stack)
@@ -282,6 +285,16 @@ function buildQueryOptions(
 }
 
 /**
+ * Detect errors caused by a stale/expired SDK session ID used for resume.
+ * These are retriable — the turn can be restarted without resume.
+ */
+function isStaleSessionError(message: string): boolean {
+  const lower = message.toLowerCase()
+  return lower.includes('no conversation found') ||
+    (lower.includes('session') && lower.includes('not found'))
+}
+
+/**
  * Start a turn: create a V1 query() and iterate its messages.
  * In fake-SDK mode (E2E_FAKE_SDK=true), uses createFakeQuery to validate
  * options without spawning a real subprocess.
@@ -302,34 +315,48 @@ async function startTurn(
   const queryOptions = buildQueryOptions(cwd, options, sessionId, win)
   console.log('[agentSdk] startTurn', sessionId, 'cwd:', cwd, 'resume:', options.sdkSessionId ?? 'none')
 
-  let q: SdkQuery
-  if (process.env.E2E_FAKE_SDK === 'true') {
-    q = createFakeQuery({ prompt, options: queryOptions })
-  } else {
-    const { query: sdkQuery } = await import('@anthropic-ai/claude-agent-sdk')
-    q = sdkQuery({ prompt, options: queryOptions }) as unknown as SdkQuery
-  }
-
-  // Reuse existing session entry (preserves sdkSessionId & initSent) or create new
-  let session = activeSessions.get(sessionId)
-  if (session) {
-    session.query = q
-    session.ownerWindow = win
-  } else {
-    session = {
-      query: q,
-      sdkSessionId: options.sdkSessionId,
-      ownerWindow: win,
-      pendingPermission: null,
-      initSent: false,
-    }
-    activeSessions.set(sessionId, session)
-  }
-
   try {
+    let q: SdkQuery
+    if (process.env.E2E_FAKE_SDK === 'true') {
+      q = createFakeQuery({ prompt, options: queryOptions })
+    } else {
+      const { query: sdkQuery } = await import('@anthropic-ai/claude-agent-sdk')
+      q = sdkQuery({ prompt, options: queryOptions }) as unknown as SdkQuery
+    }
+
+    // Reuse existing session entry (preserves sdkSessionId & initSent) or create new
+    let session = activeSessions.get(sessionId)
+    if (session) {
+      session.query = q
+      session.ownerWindow = win
+    } else {
+      session = {
+        query: q,
+        sdkSessionId: options.sdkSessionId,
+        ownerWindow: win,
+        pendingPermission: null,
+        initSent: false,
+      }
+      activeSessions.set(sessionId, session)
+    }
+
     await runTurn(sessionId, session, win)
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err)
+
+    // If we were resuming a stale SDK session, clear it and retry fresh
+    if (options.sdkSessionId && isStaleSessionError(errorMessage)) {
+      console.log('[agentSdk] Stale SDK session — retrying without resume for', sessionId)
+      sendMsg(win, sessionId, {
+        id: nextMessageId(),
+        type: 'system',
+        timestamp: Date.now(),
+        text: 'Previous session expired — starting a new conversation.',
+      })
+      activeSessions.delete(sessionId)
+      return startTurn(sessionId, prompt, cwd, win, { ...options, sdkSessionId: undefined })
+    }
+
     console.error('[agentSdk] startTurn error:', errorMessage)
     if (err instanceof Error && err.stack) console.error(err.stack)
     win.webContents.send(`agentSdk:error:${sessionId}`, errorMessage)


### PR DESCRIPTION
## Background and Motivation

When a session's stored `sdkSessionId` becomes invalid — e.g. after switching from a terminal-based agent to an API-based agent, or after the Claude CLI cleans up old session files on disk — the Agent SDK's `query()` call with `resume` fails with "No conversation found with session Id." The user sees an error and has to manually retry, which then works because the error handler clears the stale ID.

## Design Decisions

- **Auto-retry in the main process** rather than the renderer, so it's invisible to the user — no error flash, no manual retry needed.
- **Re-throw from `runTurn`** only for stale-session errors, keeping all other error handling unchanged.
- **System message on retry** ("Previous session expired — starting a new conversation.") so the user understands the old context wasn't carried over.
- **Single retry** (not a loop) since the second attempt has no `resume` and will always create a fresh session.

## Proposed Changes

**Stale session detection and auto-retry** (`src/main/handlers/agentSdk.ts`):
- Added `isStaleSessionError()` helper that matches "No conversation found" and "session not found" error patterns
- `runTurn` now re-throws stale session errors instead of swallowing them, so `startTurn` can handle the retry
- `startTurn` wraps the entire query creation + iteration in a single try/catch; on stale session error with a resume ID present, it sends a system message, cleans up, and retries without resume
- Moved query creation inside the try/catch so errors from `query()` itself (not just iteration) are also caught and retriable

## Testing

- All 3236 unit tests pass
- All 72 E2E tests pass
- Lint, typecheck, and check:all clean
- Line coverage at 90.13%

🤖 Generated with [Claude Code](https://claude.com/claude-code)