### PR TITLE
fix: prevent SDK agent sessions from losing message history

### DIFF
--- a/src/main/handlers/agentSdk.ts
+++ b/src/main/handlers/agentSdk.ts
@@ -8,7 +8,7 @@ import type { AgentSdkPermissionRequest } from '../../shared/agentSdkTypes'
 import {
   expandHome, nextMessageId, sendMsg, resolveAgentSdkCliPath,
   handleLoadHistory, handleStatus, handleFetchCommands, handleFetchModels, handleLogin,
-  createFakeQuery, sendMockAgentResponse,
+  createFakeQuery, sendMockAgentResponse, isSessionNotFoundError,
   type SdkModelInfo, type SdkQuery,
 } from './agentSdkHelpers'
 
@@ -26,12 +26,6 @@ class ResumeFailedError extends Error {
     super(message)
     this.name = 'ResumeFailedError'
   }
-}
-
-/** Check if an error message indicates the SDK session no longer exists. */
-function isSessionNotFoundError(message: string): boolean {
-  const lower = message.toLowerCase()
-  return lower.includes('no conversation found') || lower.includes('session not found')
 }
 
 interface ActiveSession {

--- a/src/main/handlers/agentSdk.ts
+++ b/src/main/handlers/agentSdk.ts
@@ -16,6 +16,24 @@ interface PendingPermission {
   resolve: (result: { behavior: 'allow' } | { behavior: 'deny'; message: string }) => void
 }
 
+/**
+ * Thrown when a resume attempt fails because the SDK session no longer exists.
+ * Caught by startTurn to retry without resume, rather than surfacing the error
+ * to the renderer — which would leave the user stuck in a loop.
+ */
+class ResumeFailedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ResumeFailedError'
+  }
+}
+
+/** Check if an error message indicates the SDK session no longer exists. */
+function isSessionNotFoundError(message: string): boolean {
+  const lower = message.toLowerCase()
+  return lower.includes('no conversation found') || lower.includes('session not found')
+}
+
 interface ActiveSession {
   query: SdkQuery | null
   sdkSessionId?: string
@@ -188,6 +206,12 @@ async function runTurn(
     const errorMessage = err instanceof Error ? err.message : String(err)
     if (errorMessage.includes('aborted')) {
       // User cancelled — not an error
+    } else if (session.sdkSessionId && isSessionNotFoundError(errorMessage)) {
+      // Resume failed because the SDK session no longer exists — let startTurn
+      // retry without resume rather than sending an error to the renderer.
+      console.warn('[agentSdk] Session not found for resume:', session.sdkSessionId)
+      activeSessions.delete(sessionId)
+      throw new ResumeFailedError(errorMessage)
     } else {
       console.error('[agentSdk] Stream error:', errorMessage)
       if (err instanceof Error && err.stack) console.error(err.stack)
@@ -306,8 +330,18 @@ async function startTurn(
   if (process.env.E2E_FAKE_SDK === 'true') {
     q = createFakeQuery({ prompt, options: queryOptions })
   } else {
-    const { query: sdkQuery } = await import('@anthropic-ai/claude-agent-sdk')
-    q = sdkQuery({ prompt, options: queryOptions }) as unknown as SdkQuery
+    try {
+      const { query: sdkQuery } = await import('@anthropic-ai/claude-agent-sdk')
+      q = sdkQuery({ prompt, options: queryOptions }) as unknown as SdkQuery
+    } catch (err: unknown) {
+      // If query construction fails due to invalid session, retry without resume
+      const msg = err instanceof Error ? err.message : String(err)
+      if (options.sdkSessionId && isSessionNotFoundError(msg)) {
+        console.warn('[agentSdk] Session not found at construction, retrying without resume')
+        return startTurn(sessionId, prompt, cwd, win, { ...options, sdkSessionId: undefined })
+      }
+      throw err
+    }
   }
 
   // Reuse existing session entry (preserves sdkSessionId & initSent) or create new
@@ -329,6 +363,11 @@ async function startTurn(
   try {
     await runTurn(sessionId, session, win)
   } catch (err: unknown) {
+    // If resume failed during iteration, retry the whole turn without resume
+    if (err instanceof ResumeFailedError && options.sdkSessionId) {
+      console.log('[agentSdk] Retrying without resume after session-not-found')
+      return startTurn(sessionId, prompt, cwd, win, { ...options, sdkSessionId: undefined })
+    }
     const errorMessage = err instanceof Error ? err.message : String(err)
     console.error('[agentSdk] startTurn error:', errorMessage)
     if (err instanceof Error && err.stack) console.error(err.stack)
@@ -469,11 +508,8 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
     if (ctx.isE2ETest || !sdkSessionId || sdkSessionId.length === 0) return
     const senderWindow = BrowserWindow.fromWebContents(_event.sender)
     if (!senderWindow) return
-    try {
-      await handleLoadHistory(senderWindow, sdkSessionId, sessionId, agentEnv, limit)
-    } catch (err) {
-      console.warn('[agentSdk] Failed to load history:', err instanceof Error ? err.message : err)
-    }
+    // Let errors propagate to the renderer so it can preserve existing messages
+    await handleLoadHistory(senderWindow, sdkSessionId, sessionId, agentEnv, limit)
   })
 
   ipcMain.handle('agentSdk:login', (_event, sessionId: string) => {

--- a/src/main/handlers/agentSdkHelpers.test.ts
+++ b/src/main/handlers/agentSdkHelpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { isSessionNotFoundError } from './agentSdkHelpers'
+
+describe('isSessionNotFoundError', () => {
+  it('matches "No conversation found with session: <id>"', () => {
+    expect(isSessionNotFoundError('No conversation found with session: abc-123')).toBe(true)
+  })
+
+  it('matches "Session not found"', () => {
+    expect(isSessionNotFoundError('Session not found')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isSessionNotFoundError('NO CONVERSATION FOUND with session: xyz')).toBe(true)
+    expect(isSessionNotFoundError('SESSION NOT FOUND')).toBe(true)
+  })
+
+  it('matches when embedded in a longer message', () => {
+    expect(isSessionNotFoundError('Error: no conversation found for the given ID')).toBe(true)
+    expect(isSessionNotFoundError('API error: session not found (expired)')).toBe(true)
+  })
+
+  it('does not match unrelated errors', () => {
+    expect(isSessionNotFoundError('Rate limit exceeded')).toBe(false)
+    expect(isSessionNotFoundError('Network timeout')).toBe(false)
+    expect(isSessionNotFoundError('Authentication failed')).toBe(false)
+    expect(isSessionNotFoundError('Internal server error')).toBe(false)
+  })
+
+  it('does not match partial keywords', () => {
+    expect(isSessionNotFoundError('conversation was reset')).toBe(false)
+    expect(isSessionNotFoundError('session expired')).toBe(false)
+    expect(isSessionNotFoundError('not found')).toBe(false)
+  })
+})

--- a/src/main/handlers/agentSdkHelpers.ts
+++ b/src/main/handlers/agentSdkHelpers.ts
@@ -249,6 +249,12 @@ export async function handleFetchCommands(cwd?: string, agentEnv?: Record<string
   })
 }
 
+/** Check if an error message indicates the SDK session no longer exists. */
+export function isSessionNotFoundError(message: string): boolean {
+  const lower = message.toLowerCase()
+  return lower.includes('no conversation found') || lower.includes('session not found')
+}
+
 /** Minimal shape of the V1 Query object (dynamically imported). */
 export interface SdkQuery {
   close(): void

--- a/src/renderer/panels/agent/hooks/useAgentSdk.test.ts
+++ b/src/renderer/panels/agent/hooks/useAgentSdk.test.ts
@@ -130,7 +130,7 @@ describe('useAgentSdk', () => {
       expect(chatSession.error).toBe('Something broke')
     })
 
-    it('preserves hasStarted — sendPrompt uses send() not start() after error', () => {
+    it('error transitions to idle — sendPrompt uses send() not start() after error', () => {
       vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
       const { result } = renderHook(() => useAgentSdk(defaultHookOptions))
 

--- a/src/renderer/panels/agent/hooks/useAgentSdk.test.ts
+++ b/src/renderer/panels/agent/hooks/useAgentSdk.test.ts
@@ -1,0 +1,392 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useAgentSdk } from './useAgentSdk'
+import { useAgentChatStore } from '../../../store/agentChat'
+import { useSessionStore, type StatusChip } from '../../../store/sessions'
+import { PANEL_IDS, DEFAULT_TOOLBAR_PANELS } from '../../../panels/system/types'
+import type { AgentSdkMessage } from '../../../../shared/agentSdkTypes'
+
+// --- Helpers ---
+
+function makeMsg(overrides: Partial<AgentSdkMessage> & { id: string }): AgentSdkMessage {
+  return { type: 'text', timestamp: Date.now(), text: 'hello', ...overrides }
+}
+
+function makeSession(id: string, sdkSessionId?: string) {
+  return {
+    id, name: 'test', directory: '/test', branch: 'main',
+    status: 'idle' as const, agentId: null, panelVisibility: {},
+    showExplorer: false, showFileViewer: false, showDiff: false,
+    selectedFilePath: null, planFilePath: null,
+    fileViewerPosition: 'top' as const,
+    layoutSizes: { explorerWidth: 256, fileViewerSize: 300, userTerminalHeight: 192, diffPanelWidth: 320, tutorialPanelWidth: 320 },
+    explorerFilter: 'files' as const,
+    lastMessage: null, lastMessageTime: null, isUnread: false,
+    workingStartTime: null, recentFiles: [], searchHistory: [],
+    terminalTabs: { tabs: [], activeTabId: '__agent__' },
+    branchStatus: 'in-progress' as const, hasFeedback: false,
+    checksStatus: 'none' as const, statusChip: 'in-progress' as StatusChip,
+    isArchived: false, isRestored: false,
+    sdkSessionId,
+  }
+}
+
+const defaultStoreState = {
+  activeSessionId: 'session-1',
+  isLoading: false,
+  showSidebar: true,
+  showSettings: false,
+  sidebarWidth: 224,
+  toolbarPanels: [...DEFAULT_TOOLBAR_PANELS],
+  globalPanelVisibility: {
+    [PANEL_IDS.SIDEBAR]: true,
+    [PANEL_IDS.SETTINGS]: false,
+  },
+}
+
+// --- Captured IPC callbacks ---
+
+type MessageCb = (msg: AgentSdkMessage) => void
+type DoneCb = (sdkSessionId: string) => void
+type ErrorCb = (error: string) => void
+
+let messageCb: MessageCb
+let doneCb: DoneCb
+let errorCb: ErrorCb
+
+function setupIpcMocks() {
+  vi.mocked(window.agentSdk.onMessage).mockImplementation((_id, cb) => {
+    messageCb = cb
+    return () => undefined
+  })
+  vi.mocked(window.agentSdk.onDone).mockImplementation((_id, cb) => {
+    doneCb = cb
+    return () => undefined
+  })
+  vi.mocked(window.agentSdk.onError).mockImplementation((_id, cb) => {
+    errorCb = cb
+    return () => undefined
+  })
+  vi.mocked(window.agentSdk.onPermissionRequest).mockReturnValue(() => undefined)
+  vi.mocked(window.agentSdk.onHistoryMeta).mockReturnValue(() => undefined)
+  vi.mocked(window.agentSdk.commands).mockResolvedValue([])
+}
+
+const defaultHookOptions = {
+  sessionId: 'session-1',
+  cwd: '/test',
+}
+
+// --- Tests ---
+
+describe('useAgentSdk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAgentChatStore.setState({ sessions: {} })
+    useSessionStore.setState({
+      ...defaultStoreState,
+      sessions: [makeSession('session-1', 'sdk-abc')],
+    })
+    setupIpcMocks()
+  })
+
+  describe('error handling (Bug 1: sdkSessionId preservation)', () => {
+    it('does not clear sdkSessionId on error', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      act(() => {
+        errorCb('Rate limit exceeded')
+      })
+
+      const session = useSessionStore.getState().sessions.find(s => s.id === 'session-1')
+      expect(session?.sdkSessionId).toBe('sdk-abc')
+    })
+
+    it('adds error message to chat on error', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      act(() => {
+        errorCb('Network timeout')
+      })
+
+      const chatSession = useAgentChatStore.getState().getSession('session-1')
+      const errorMsg = chatSession.messages.find(m => m.type === 'error')
+      expect(errorMsg).toBeDefined()
+      expect(errorMsg!.text).toBe('Network timeout')
+    })
+
+    it('sets error state on chat session', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      act(() => {
+        errorCb('Something broke')
+      })
+
+      const chatSession = useAgentChatStore.getState().getSession('session-1')
+      expect(chatSession.error).toBe('Something broke')
+    })
+
+    it('preserves hasStarted — sendPrompt uses send() not start() after error', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      const { result } = renderHook(() => useAgentSdk(defaultHookOptions))
+
+      // First message — starts the session
+      act(() => { result.current.sendPrompt('hello') })
+      expect(vi.mocked(window.agentSdk.start)).toHaveBeenCalledTimes(1)
+
+      // Done callback so isRunning resets
+      act(() => { doneCb('sdk-abc') })
+
+      // Error on some later operation
+      act(() => { errorCb('transient failure') })
+
+      // Next message should use send() (not start()) because session still exists
+      act(() => { result.current.sendPrompt('retry') })
+      expect(vi.mocked(window.agentSdk.send)).toHaveBeenCalledTimes(1)
+      // start should still only have been called once (for the first message)
+      expect(vi.mocked(window.agentSdk.start)).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('history loading (Bug 2: atomic replacement)', () => {
+    it('buffers history messages during load and replaces atomically on success', async () => {
+      // Pre-populate with existing messages
+      useAgentChatStore.getState().addMessage('session-1', makeMsg({ id: 'existing-1', text: 'old' }))
+
+      let resolveLoad!: () => void
+      vi.mocked(window.agentSdk.loadHistory).mockReturnValue(
+        new Promise<void>((resolve) => { resolveLoad = resolve })
+      )
+
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      // Simulate history messages arriving during load
+      const historyMsg1 = makeMsg({ id: 'history-user-1', text: 'user said hi' })
+      const historyMsg2 = makeMsg({ id: 'history-asst-1', text: 'assistant replied' })
+      act(() => {
+        messageCb(historyMsg1)
+        messageCb(historyMsg2)
+      })
+
+      // While loading, history messages should NOT be in the store yet
+      // (they're buffered), and old messages should still be present
+      const duringLoad = useAgentChatStore.getState().getSession('session-1')
+      expect(duringLoad.messages.find(m => m.id === 'existing-1')).toBeDefined()
+      expect(duringLoad.messages.find(m => m.id === 'history-user-1')).toBeUndefined()
+
+      // Complete the load
+      act(() => { resolveLoad() })
+
+      // After load, messages are atomically replaced with history
+      await waitFor(() => {
+        const afterLoad = useAgentChatStore.getState().getSession('session-1')
+        expect(afterLoad.messages).toHaveLength(2)
+        expect(afterLoad.messages[0].id).toBe('history-user-1')
+        expect(afterLoad.messages[1].id).toBe('history-asst-1')
+      })
+    })
+
+    it('preserves existing messages when history load fails', async () => {
+      useAgentChatStore.getState().addMessage('session-1', makeMsg({ id: 'existing-1', text: 'keep me' }))
+
+      vi.mocked(window.agentSdk.loadHistory).mockRejectedValue(new Error('SDK error'))
+
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      // Wait for the rejected promise to settle
+      await waitFor(() => {
+        const session = useAgentChatStore.getState().getSession('session-1')
+        // Existing messages must be preserved
+        expect(session.messages).toHaveLength(1)
+        expect(session.messages[0].id).toBe('existing-1')
+      })
+    })
+
+    it('allows retry after history load failure', async () => {
+      // First call fails
+      vi.mocked(window.agentSdk.loadHistory).mockRejectedValueOnce(new Error('fail'))
+      const { unmount } = renderHook(() => useAgentSdk(defaultHookOptions))
+      await waitFor(() => {
+        expect(vi.mocked(window.agentSdk.loadHistory)).toHaveBeenCalledTimes(1)
+      })
+      unmount()
+
+      // Second mount should retry (historyLoadedRef was reset on failure)
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      await waitFor(() => {
+        expect(vi.mocked(window.agentSdk.loadHistory)).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    it('skips history loading when no sdkSessionId exists', () => {
+      useSessionStore.setState({
+        ...defaultStoreState,
+        sessions: [makeSession('session-1', undefined)],
+      })
+
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      expect(vi.mocked(window.agentSdk.loadHistory)).not.toHaveBeenCalled()
+    })
+
+    it('supersedes an in-flight load when a new load starts (generation counter)', async () => {
+      // Load A starts (mount-time)
+      let resolveLoadA!: () => void
+      vi.mocked(window.agentSdk.loadHistory).mockReturnValueOnce(
+        new Promise<void>((resolve) => { resolveLoadA = resolve })
+      )
+
+      const { result } = renderHook(() => useAgentSdk(defaultHookOptions))
+
+      // Load A messages arrive
+      act(() => {
+        messageCb(makeMsg({ id: 'history-a-1', text: 'from load A' }))
+      })
+
+      // Load B starts (user clicks "load full history") before A finishes
+      let resolveLoadB!: () => void
+      vi.mocked(window.agentSdk.loadHistory).mockReturnValueOnce(
+        new Promise<void>((resolve) => { resolveLoadB = resolve })
+      )
+      act(() => { result.current.loadFullHistory() })
+
+      // Load B messages arrive
+      act(() => {
+        messageCb(makeMsg({ id: 'history-b-1', text: 'from load B' }))
+        messageCb(makeMsg({ id: 'history-b-2', text: 'from load B too' }))
+      })
+
+      // Load A finishes — should be a no-op since Load B superseded it
+      act(() => { resolveLoadA() })
+      await waitFor(() => {
+        // Load A's replaceMessages should NOT have fired
+        const session = useAgentChatStore.getState().getSession('session-1')
+        // Messages should not have been replaced with load A's stale buffer
+        expect(session.messages.find(m => m.id === 'history-a-1')).toBeUndefined()
+      })
+
+      // Load B finishes — should apply its buffer
+      act(() => { resolveLoadB() })
+      await waitFor(() => {
+        const session = useAgentChatStore.getState().getSession('session-1')
+        expect(session.messages).toHaveLength(2)
+        expect(session.messages[0].id).toBe('history-b-1')
+        expect(session.messages[1].id).toBe('history-b-2')
+      })
+    })
+
+    it('routes non-history messages to store immediately during load', async () => {
+      let resolveLoad!: () => void
+      vi.mocked(window.agentSdk.loadHistory).mockReturnValue(
+        new Promise<void>((resolve) => { resolveLoad = resolve })
+      )
+
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      // Live message arrives while history is loading
+      const liveMsg = makeMsg({ id: 'sdk-msg-1', type: 'text', text: 'live update' })
+      act(() => { messageCb(liveMsg) })
+
+      // Live messages go straight to the store
+      const session = useAgentChatStore.getState().getSession('session-1')
+      expect(session.messages.find(m => m.id === 'sdk-msg-1')).toBeDefined()
+
+      act(() => { resolveLoad() })
+    })
+  })
+
+  describe('sendPrompt', () => {
+    it('uses start() for the first message', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      const { result } = renderHook(() => useAgentSdk(defaultHookOptions))
+
+      act(() => { result.current.sendPrompt('hello world') })
+
+      expect(vi.mocked(window.agentSdk.start)).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(window.agentSdk.start)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'session-1',
+          prompt: 'hello world',
+          sdkSessionId: 'sdk-abc',
+        })
+      )
+    })
+
+    it('uses send() for subsequent messages', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      const { result } = renderHook(() => useAgentSdk(defaultHookOptions))
+
+      // First message
+      act(() => { result.current.sendPrompt('first') })
+      // Mark as done
+      act(() => { doneCb('sdk-abc') })
+      // Second message
+      act(() => { result.current.sendPrompt('second') })
+
+      expect(vi.mocked(window.agentSdk.send)).toHaveBeenCalledTimes(1)
+    })
+
+    it('queues when agent is running', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      const { result } = renderHook(() => useAgentSdk(defaultHookOptions))
+
+      act(() => { result.current.sendPrompt('first') })
+      // Agent is now running — second message should be queued
+      act(() => { result.current.sendPrompt('queued msg') })
+
+      expect(vi.mocked(window.agentSdk.inject)).toHaveBeenCalledWith('session-1', 'queued msg')
+    })
+  })
+
+  describe('done handler', () => {
+    it('stores returned sdkSessionId', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      act(() => { doneCb('new-sdk-id-123') })
+
+      const session = useSessionStore.getState().sessions.find(s => s.id === 'session-1')
+      expect(session?.sdkSessionId).toBe('new-sdk-id-123')
+    })
+
+    it('does not overwrite sdkSessionId with empty string', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      renderHook(() => useAgentSdk(defaultHookOptions))
+
+      act(() => { doneCb('') })
+
+      const session = useSessionStore.getState().sessions.find(s => s.id === 'session-1')
+      expect(session?.sdkSessionId).toBe('sdk-abc')
+    })
+  })
+
+  describe('stopAgent', () => {
+    it('calls stop IPC and resets state', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      const { result } = renderHook(() => useAgentSdk(defaultHookOptions))
+
+      act(() => { result.current.stopAgent() })
+
+      expect(vi.mocked(window.agentSdk.stop)).toHaveBeenCalledWith('session-1')
+    })
+
+    it('allows start() to be used again after stop', () => {
+      vi.mocked(window.agentSdk.loadHistory).mockResolvedValue(undefined)
+      const { result } = renderHook(() => useAgentSdk(defaultHookOptions))
+
+      // Start, then stop, then send again
+      act(() => { result.current.sendPrompt('first') })
+      act(() => { result.current.stopAgent() })
+      act(() => { result.current.sendPrompt('after stop') })
+
+      // Should call start again (not send) because stop destroys the session
+      expect(vi.mocked(window.agentSdk.start)).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/src/renderer/panels/agent/hooks/useAgentSdk.ts
+++ b/src/renderer/panels/agent/hooks/useAgentSdk.ts
@@ -11,10 +11,34 @@ import { useAgentChatStore } from '../../../store/agentChat'
 import { useSessionStore } from '../../../store/sessions'
 import type { AgentSdkMessage } from '../../../../shared/agentSdkTypes'
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 let userMsgCounter = 0
 function nextUserMsgId(): string {
   return `user-${String(++userMsgCounter)}-${String(Date.now())}`
 }
+
+/** Look up the persisted SDK session ID for a given Broomy session. */
+function getStoredSdkSessionId(sessionId: string): string | undefined {
+  return useSessionStore.getState().sessions.find(s => s.id === sessionId)?.sdkSessionId
+}
+
+/** Add a user-authored message to the chat store. */
+function addUserMessage(sessionId: string, text: string, queued?: boolean): void {
+  useAgentChatStore.getState().addMessage(sessionId, {
+    id: nextUserMsgId(),
+    type: 'text',
+    timestamp: Date.now(),
+    text,
+    ...(queued ? { queued: true } : {}),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface UseAgentSdkOptions {
   sessionId: string
@@ -46,12 +70,57 @@ interface UseAgentSdkReturn {
   loadFullHistory: () => void
 }
 
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
   const { sessionId, cwd, sdkSessionId, permissionMode, env, model, effort } = options
+
+  // Lifecycle refs — track whether the agent turn is active and whether
+  // at least one query has been created in the main process.
   const isRunningRef = useRef(false)
   const hasStartedRef = useRef(false)
+
   const [availableCommands, setAvailableCommands] = useState<CommandInfo[]>([])
   const [historyMeta, setHistoryMeta] = useState<HistoryMeta | null>(null)
+
+  // --- History loading state ------------------------------------------------
+  // History messages from the SDK transcript are buffered into
+  // `historyBufferRef`, then atomically replace existing messages via
+  // `replaceMessages` once the load completes. If the load fails, existing
+  // messages are left untouched and the guard key is reset so the next
+  // mount/visit can retry.
+  const historyLoadedRef = useRef<string | null>(null)
+  const historyBufferRef = useRef<AgentSdkMessage[]>([])
+  const isLoadingHistoryRef = useRef(false)
+  const loadGenRef = useRef(0)
+
+  /** Shared logic for loading history from the SDK transcript. */
+  const startHistoryLoad = useCallback((sdkId: string, limit?: number) => {
+    // Bump the generation so any in-flight load's callbacks become no-ops.
+    const gen = ++loadGenRef.current
+    historyBufferRef.current = []
+    isLoadingHistoryRef.current = true
+
+    window.agentSdk.loadHistory(sdkId, sessionId, env, limit)
+      .then(() => {
+        if (loadGenRef.current !== gen) return // superseded by a newer load
+        useAgentChatStore.getState().replaceMessages(sessionId, historyBufferRef.current)
+      })
+      .catch(() => {
+        if (loadGenRef.current !== gen) return // superseded
+        // Load failed — keep existing messages, allow retry on next visit
+        historyLoadedRef.current = null
+      })
+      .finally(() => {
+        if (loadGenRef.current !== gen) return // superseded
+        isLoadingHistoryRef.current = false
+        historyBufferRef.current = []
+      })
+  }, [sessionId, env])
+
+  // --- Effects --------------------------------------------------------------
 
   // Fetch available slash commands on mount and when cwd changes
   useEffect(() => {
@@ -59,36 +128,38 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
   }, [cwd, env])
 
   // Load message history from the SDK transcript on mount.
-  const historyLoadedRef = useRef<string | null>(null)
   useEffect(() => {
-    const stored = useSessionStore.getState().sessions.find(s => s.id === sessionId)
-    const currentSdkId = stored?.sdkSessionId ?? sdkSessionId
+    const currentSdkId = getStoredSdkSessionId(sessionId) ?? sdkSessionId
     if (!currentSdkId || currentSdkId.length === 0) return
     const key = `${sessionId}:${currentSdkId}`
     if (historyLoadedRef.current === key) return
     historyLoadedRef.current = key
-    useAgentChatStore.getState().clearSession(sessionId)
-    void window.agentSdk.loadHistory(currentSdkId, sessionId, env)
-  }, [sessionId, sdkSessionId, env])
+    startHistoryLoad(currentSdkId)
+  }, [sessionId, sdkSessionId, env, startHistoryLoad])
 
-  // Subscribe to IPC events
+  // Subscribe to IPC events from the main process.
   useEffect(() => {
     const cleanups: (() => void)[] = []
 
-    const unsubMessage = window.agentSdk.onMessage(sessionId, (msg: AgentSdkMessage) => {
-      useAgentChatStore.getState().addMessage(sessionId, msg)
-
+    cleanups.push(window.agentSdk.onMessage(sessionId, (msg: AgentSdkMessage) => {
       const isHistory = msg.id.startsWith('history-')
+
+      if (isHistory && isLoadingHistoryRef.current) {
+        // Buffer history messages for atomic replacement when load completes
+        historyBufferRef.current.push(msg)
+      } else {
+        useAgentChatStore.getState().addMessage(sessionId, msg)
+      }
+
       if (!isHistory && (msg.type === 'text' || msg.type === 'tool_use')) {
         useSessionStore.getState().updateAgentMonitor(sessionId, {
           status: 'working',
           lastMessage: msg.text ?? msg.toolName ?? undefined,
         })
       }
-    })
-    cleanups.push(unsubMessage)
+    }))
 
-    const unsubDone = window.agentSdk.onDone(sessionId, (returnedSdkSessionId: string) => {
+    cleanups.push(window.agentSdk.onDone(sessionId, (returnedSdkSessionId: string) => {
       isRunningRef.current = false
       useAgentChatStore.getState().clearQueuedFlag(sessionId)
       useAgentChatStore.getState().setState(sessionId, 'idle')
@@ -96,13 +167,13 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
       if (returnedSdkSessionId && returnedSdkSessionId.length > 0) {
         useSessionStore.getState().setSdkSessionId(sessionId, returnedSdkSessionId)
       }
-    })
-    cleanups.push(unsubDone)
+    }))
 
-    const unsubError = window.agentSdk.onError(sessionId, (error: string) => {
+    cleanups.push(window.agentSdk.onError(sessionId, (error: string) => {
       isRunningRef.current = false
-      hasStartedRef.current = false
-      useSessionStore.getState().setSdkSessionId(sessionId, '')
+      // Do NOT clear sdkSessionId — errors are transient, the session is still
+      // resumable and clearing it permanently destroys the history link.
+      // Do NOT reset hasStartedRef — the session still exists in the main process.
       useAgentChatStore.getState().setError(sessionId, error)
       useAgentChatStore.getState().addMessage(sessionId, {
         id: `error-${String(Date.now())}`,
@@ -111,34 +182,25 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
         text: error,
       })
       useSessionStore.getState().updateAgentMonitor(sessionId, { status: 'idle' })
-    })
-    cleanups.push(unsubError)
+    }))
 
-    const unsubPermission = window.agentSdk.onPermissionRequest(sessionId, (req) => {
+    cleanups.push(window.agentSdk.onPermissionRequest(sessionId, (req) => {
       useAgentChatStore.getState().setPendingPermission(sessionId, req)
-    })
-    cleanups.push(unsubPermission)
+    }))
 
-    const unsubHistoryMeta = window.agentSdk.onHistoryMeta(sessionId, (meta) => {
+    cleanups.push(window.agentSdk.onHistoryMeta(sessionId, (meta) => {
       setHistoryMeta(meta)
-    })
-    cleanups.push(unsubHistoryMeta)
+    }))
 
-    return () => {
-      cleanups.forEach((fn) => fn())
-    }
+    return () => { cleanups.forEach((fn) => fn()) }
   }, [sessionId])
+
+  // --- Actions --------------------------------------------------------------
 
   const queuePrompt = useCallback((prompt: string) => {
     const trimmed = prompt.trim()
     if (!trimmed || !isRunningRef.current) return
-    useAgentChatStore.getState().addMessage(sessionId, {
-      id: nextUserMsgId(),
-      type: 'text',
-      timestamp: Date.now(),
-      text: trimmed,
-      queued: true,
-    })
+    addUserMessage(sessionId, trimmed, true)
     // The main process guards against missing sdkSessionId / inactive sessions.
     void window.agentSdk.inject(sessionId, trimmed)
   }, [sessionId])
@@ -154,18 +216,14 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
 
     // Intercept commands the SDK doesn't support
     if (trimmed === '/login') {
-      useAgentChatStore.getState().addMessage(sessionId, {
-        id: nextUserMsgId(), type: 'text', timestamp: Date.now(), text: trimmed,
-      })
+      addUserMessage(sessionId, trimmed)
       isRunningRef.current = true
       useAgentChatStore.getState().setState(sessionId, 'running')
       void window.agentSdk.login(sessionId)
       return
     }
     if (trimmed === '/status') {
-      useAgentChatStore.getState().addMessage(sessionId, {
-        id: nextUserMsgId(), type: 'text', timestamp: Date.now(), text: trimmed,
-      })
+      addUserMessage(sessionId, trimmed)
       void window.agentSdk.status(sessionId, env)
       return
     }
@@ -175,23 +233,22 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
     useAgentChatStore.getState().setError(sessionId, null)
     useSessionStore.getState().updateAgentMonitor(sessionId, { status: 'working' })
 
-    useAgentChatStore.getState().addMessage(sessionId, {
-      id: nextUserMsgId(),
-      type: 'text',
-      timestamp: Date.now(),
-      text: prompt,
-    })
+    addUserMessage(sessionId, prompt)
 
     if (hasStartedRef.current) {
       // Session exists in main process — send creates a new query with resume.
       // Pass cwd/env/permissionMode so if the main process lost the session
       // (e.g. after hot reload), it can start a new one with correct params.
-      void window.agentSdk.send(sessionId, prompt, { cwd, permissionMode, env, model, effort,
-        sdkSessionId: useSessionStore.getState().sessions.find(s => s.id === sessionId)?.sdkSessionId })
+      void window.agentSdk.send(sessionId, prompt, {
+        cwd, permissionMode, env, model, effort,
+        sdkSessionId: getStoredSdkSessionId(sessionId),
+      })
     } else {
       // First message — create a new query (with resume if we have a stored session)
-      const storedId = useSessionStore.getState().sessions.find(s => s.id === sessionId)?.sdkSessionId
-      const resumeId = storedId && storedId.length > 0 ? storedId : (sdkSessionId && sdkSessionId.length > 0 ? sdkSessionId : undefined)
+      const storedId = getStoredSdkSessionId(sessionId)
+      const resumeId = (storedId && storedId.length > 0)
+        ? storedId
+        : (sdkSessionId && sdkSessionId.length > 0 ? sdkSessionId : undefined)
       hasStartedRef.current = true
       void window.agentSdk.start({
         id: sessionId,
@@ -223,14 +280,12 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
   }, [sessionId])
 
   const loadFullHistory = useCallback(() => {
-    const stored = useSessionStore.getState().sessions.find(s => s.id === sessionId)
-    const sdkId = stored?.sdkSessionId
+    const sdkId = getStoredSdkSessionId(sessionId)
     if (sdkId && sdkId.length > 0) {
-      useAgentChatStore.getState().clearSession(sessionId)
       setHistoryMeta(null)
-      void window.agentSdk.loadHistory(sdkId, sessionId, env, 9999)
+      startHistoryLoad(sdkId, 9999)
     }
-  }, [sessionId, env])
+  }, [sessionId, startHistoryLoad])
 
   return { sendPrompt, queuePrompt, stopAgent, respondToPermission, availableCommands, historyMeta, loadFullHistory }
 }

--- a/src/renderer/panels/agent/hooks/useAgentSdk.ts
+++ b/src/renderer/panels/agent/hooks/useAgentSdk.ts
@@ -272,6 +272,8 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
         effort,
       })
     } else {
+      // Use getStoredSdkSessionId (not resolveResumeId) — the send() path only
+      // fires after a session has been started, so the prop fallback is unnecessary.
       void window.agentSdk.send(sessionId, prompt, {
         cwd, permissionMode, env, model, effort,
         sdkSessionId: getStoredSdkSessionId(sessionId),

--- a/src/renderer/panels/agent/hooks/useAgentSdk.ts
+++ b/src/renderer/panels/agent/hooks/useAgentSdk.ts
@@ -5,6 +5,16 @@
  * conversations.  First message triggers agentSdk:start; follow-ups use
  * agentSdk:send which creates a new query with resume — token-efficient,
  * no replayed history.
+ *
+ * ## Turn phase state machine
+ *
+ *   ┌─────┐  sendPrompt   ┌────────┐  onDone / onError   ┌──────┐
+ *   │ new │ ──(start())──▶ │ active │ ──────────────────▶  │ idle │
+ *   └─────┘                └────────┘                      └──────┘
+ *      ▲                       ▲  │                           │
+ *      │                       │  └──── sendPrompt (queues) ──┘
+ *      │                       └─────── sendPrompt (send()) ──┘
+ *      └──────────── stop ─── (any)
  */
 import { useEffect, useCallback, useRef, useState } from 'react'
 import { useAgentChatStore } from '../../../store/agentChat'
@@ -36,9 +46,30 @@ function addUserMessage(sessionId: string, text: string, queued?: boolean): void
   })
 }
 
+/**
+ * Resolve the SDK session ID to use for resume.
+ * Prefers the persisted value from the store; falls back to the prop.
+ * Returns undefined if neither has a non-empty value.
+ */
+function resolveResumeId(sessionId: string, sdkSessionIdProp?: string): string | undefined {
+  const stored = getStoredSdkSessionId(sessionId)
+  if (stored && stored.length > 0) return stored
+  if (sdkSessionIdProp && sdkSessionIdProp.length > 0) return sdkSessionIdProp
+  return undefined
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/**
+ * Turn phase tracks the lifecycle of the agent session in the main process.
+ *
+ * - `new`:    No query created yet (or session was stopped). Next send uses start().
+ * - `idle`:   A query has completed. Next send uses send() (token-efficient resume).
+ * - `active`: A query is currently running. Sends are queued via inject().
+ */
+type TurnPhase = 'new' | 'idle' | 'active'
 
 interface UseAgentSdkOptions {
   sessionId: string
@@ -77,44 +108,42 @@ interface UseAgentSdkReturn {
 export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
   const { sessionId, cwd, sdkSessionId, permissionMode, env, model, effort } = options
 
-  // Lifecycle refs — track whether the agent turn is active and whether
-  // at least one query has been created in the main process.
-  const isRunningRef = useRef(false)
-  const hasStartedRef = useRef(false)
+  const phaseRef = useRef<TurnPhase>('new')
 
   const [availableCommands, setAvailableCommands] = useState<CommandInfo[]>([])
   const [historyMeta, setHistoryMeta] = useState<HistoryMeta | null>(null)
 
-  // --- History loading state ------------------------------------------------
-  // History messages from the SDK transcript are buffered into
-  // `historyBufferRef`, then atomically replace existing messages via
-  // `replaceMessages` once the load completes. If the load fails, existing
-  // messages are left untouched and the guard key is reset so the next
-  // mount/visit can retry.
+  // --- History loading ------------------------------------------------------
+  //
+  // History messages are buffered into `historyBufferRef` and atomically
+  // replace existing messages via `replaceMessages` when the load completes.
+  // If the load fails, existing messages are left untouched and the guard key
+  // is reset so the next mount/visit can retry.
+  //
+  // A generation counter (`loadGenRef`) ensures that if a second load starts
+  // while the first is in-flight, the first load's callbacks become no-ops.
+
   const historyLoadedRef = useRef<string | null>(null)
   const historyBufferRef = useRef<AgentSdkMessage[]>([])
   const isLoadingHistoryRef = useRef(false)
   const loadGenRef = useRef(0)
 
-  /** Shared logic for loading history from the SDK transcript. */
   const startHistoryLoad = useCallback((sdkId: string, limit?: number) => {
-    // Bump the generation so any in-flight load's callbacks become no-ops.
     const gen = ++loadGenRef.current
     historyBufferRef.current = []
     isLoadingHistoryRef.current = true
 
     window.agentSdk.loadHistory(sdkId, sessionId, env, limit)
       .then(() => {
-        if (loadGenRef.current !== gen) return // superseded by a newer load
+        if (loadGenRef.current !== gen) return
         useAgentChatStore.getState().replaceMessages(sessionId, historyBufferRef.current)
       })
       .catch(() => {
-        if (loadGenRef.current !== gen) return // superseded
-        // Load failed — keep existing messages, allow retry on next visit
+        if (loadGenRef.current !== gen) return
         historyLoadedRef.current = null
       })
       .finally(() => {
-        if (loadGenRef.current !== gen) return // superseded
+        if (loadGenRef.current !== gen) return
         isLoadingHistoryRef.current = false
         historyBufferRef.current = []
       })
@@ -122,12 +151,10 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
 
   // --- Effects --------------------------------------------------------------
 
-  // Fetch available slash commands on mount and when cwd changes
   useEffect(() => {
     void window.agentSdk.commands(cwd, env).then(setAvailableCommands)
   }, [cwd, env])
 
-  // Load message history from the SDK transcript on mount.
   useEffect(() => {
     const currentSdkId = getStoredSdkSessionId(sessionId) ?? sdkSessionId
     if (!currentSdkId || currentSdkId.length === 0) return
@@ -137,7 +164,6 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
     startHistoryLoad(currentSdkId)
   }, [sessionId, sdkSessionId, env, startHistoryLoad])
 
-  // Subscribe to IPC events from the main process.
   useEffect(() => {
     const cleanups: (() => void)[] = []
 
@@ -145,7 +171,6 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
       const isHistory = msg.id.startsWith('history-')
 
       if (isHistory && isLoadingHistoryRef.current) {
-        // Buffer history messages for atomic replacement when load completes
         historyBufferRef.current.push(msg)
       } else {
         useAgentChatStore.getState().addMessage(sessionId, msg)
@@ -160,7 +185,7 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
     }))
 
     cleanups.push(window.agentSdk.onDone(sessionId, (returnedSdkSessionId: string) => {
-      isRunningRef.current = false
+      phaseRef.current = 'idle'
       useAgentChatStore.getState().clearQueuedFlag(sessionId)
       useAgentChatStore.getState().setState(sessionId, 'idle')
       useSessionStore.getState().updateAgentMonitor(sessionId, { status: 'idle' })
@@ -170,10 +195,10 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
     }))
 
     cleanups.push(window.agentSdk.onError(sessionId, (error: string) => {
-      isRunningRef.current = false
-      // Do NOT clear sdkSessionId — errors are transient, the session is still
-      // resumable and clearing it permanently destroys the history link.
-      // Do NOT reset hasStartedRef — the session still exists in the main process.
+      // Transition to idle, NOT back to new — the session still exists in the
+      // main process and errors are transient (rate limits, timeouts, etc.).
+      // We intentionally preserve sdkSessionId to keep the history link.
+      phaseRef.current = 'idle'
       useAgentChatStore.getState().setError(sessionId, error)
       useAgentChatStore.getState().addMessage(sessionId, {
         id: `error-${String(Date.now())}`,
@@ -199,15 +224,13 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
 
   const queuePrompt = useCallback((prompt: string) => {
     const trimmed = prompt.trim()
-    if (!trimmed || !isRunningRef.current) return
+    if (!trimmed || phaseRef.current !== 'active') return
     addUserMessage(sessionId, trimmed, true)
-    // The main process guards against missing sdkSessionId / inactive sessions.
     void window.agentSdk.inject(sessionId, trimmed)
   }, [sessionId])
 
   const sendPrompt = useCallback((prompt: string) => {
-    if (isRunningRef.current) {
-      // Agent is still running (e.g. executing a tool) — queue instead of dropping
+    if (phaseRef.current === 'active') {
       queuePrompt(prompt)
       return
     }
@@ -217,7 +240,7 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
     // Intercept commands the SDK doesn't support
     if (trimmed === '/login') {
       addUserMessage(sessionId, trimmed)
-      isRunningRef.current = true
+      phaseRef.current = 'active'
       useAgentChatStore.getState().setState(sessionId, 'running')
       void window.agentSdk.login(sessionId)
       return
@@ -228,45 +251,37 @@ export function useAgentSdk(options: UseAgentSdkOptions): UseAgentSdkReturn {
       return
     }
 
-    isRunningRef.current = true
+    // Capture the phase before transitioning — determines start() vs send().
+    const wasNew = phaseRef.current === 'new'
+    phaseRef.current = 'active'
+
     useAgentChatStore.getState().setState(sessionId, 'running')
     useAgentChatStore.getState().setError(sessionId, null)
     useSessionStore.getState().updateAgentMonitor(sessionId, { status: 'working' })
-
     addUserMessage(sessionId, prompt)
 
-    if (hasStartedRef.current) {
-      // Session exists in main process — send creates a new query with resume.
-      // Pass cwd/env/permissionMode so if the main process lost the session
-      // (e.g. after hot reload), it can start a new one with correct params.
-      void window.agentSdk.send(sessionId, prompt, {
-        cwd, permissionMode, env, model, effort,
-        sdkSessionId: getStoredSdkSessionId(sessionId),
-      })
-    } else {
-      // First message — create a new query (with resume if we have a stored session)
-      const storedId = getStoredSdkSessionId(sessionId)
-      const resumeId = (storedId && storedId.length > 0)
-        ? storedId
-        : (sdkSessionId && sdkSessionId.length > 0 ? sdkSessionId : undefined)
-      hasStartedRef.current = true
+    if (wasNew) {
       void window.agentSdk.start({
         id: sessionId,
         prompt,
         cwd,
-        sdkSessionId: resumeId,
+        sdkSessionId: resolveResumeId(sessionId, sdkSessionId),
         permissionMode,
         env,
         model,
         effort,
+      })
+    } else {
+      void window.agentSdk.send(sessionId, prompt, {
+        cwd, permissionMode, env, model, effort,
+        sdkSessionId: getStoredSdkSessionId(sessionId),
       })
     }
   }, [sessionId, cwd, sdkSessionId, permissionMode, env, model, effort, queuePrompt])
 
   const stopAgent = useCallback(() => {
     void window.agentSdk.stop(sessionId)
-    isRunningRef.current = false
-    hasStartedRef.current = false
+    phaseRef.current = 'new'
     useAgentChatStore.getState().setState(sessionId, 'idle')
     useSessionStore.getState().updateAgentMonitor(sessionId, { status: 'idle' })
   }, [sessionId])

--- a/src/renderer/store/agentChat.test.ts
+++ b/src/renderer/store/agentChat.test.ts
@@ -114,4 +114,39 @@ describe('useAgentChatStore', () => {
       expect(useAgentChatStore.getState().getSession('s2').messages).toHaveLength(1)
     })
   })
+
+  describe('replaceMessages', () => {
+    it('replaces messages in an existing session', () => {
+      useAgentChatStore.getState().addMessage('s1', makeMsg({ id: 'msg-1', text: 'old' }))
+      useAgentChatStore.getState().addMessage('s1', makeMsg({ id: 'msg-2', text: 'old2' }))
+      const newMsgs = [makeMsg({ id: 'new-1', text: 'new' })]
+      useAgentChatStore.getState().replaceMessages('s1', newMsgs)
+      const session = useAgentChatStore.getState().getSession('s1')
+      expect(session.messages).toHaveLength(1)
+      expect(session.messages[0].text).toBe('new')
+    })
+
+    it('creates a session if it does not exist', () => {
+      const msgs = [makeMsg({ id: 'a' }), makeMsg({ id: 'b' })]
+      useAgentChatStore.getState().replaceMessages('s1', msgs)
+      expect(useAgentChatStore.getState().getSession('s1').messages).toHaveLength(2)
+    })
+
+    it('preserves other session state', () => {
+      useAgentChatStore.getState().setState('s1', 'running')
+      useAgentChatStore.getState().setError('s1', 'some error')
+      useAgentChatStore.getState().replaceMessages('s1', [makeMsg({ id: 'x' })])
+      const session = useAgentChatStore.getState().getSession('s1')
+      expect(session.messages).toHaveLength(1)
+      // replaceMessages preserves state/error — it only touches messages
+      expect(session.error).toBe('some error')
+    })
+
+    it('does not affect other sessions', () => {
+      useAgentChatStore.getState().addMessage('s1', makeMsg({ id: 'msg-1' }))
+      useAgentChatStore.getState().addMessage('s2', makeMsg({ id: 'msg-2' }))
+      useAgentChatStore.getState().replaceMessages('s1', [])
+      expect(useAgentChatStore.getState().getSession('s2').messages).toHaveLength(1)
+    })
+  })
 })

--- a/src/renderer/store/agentChat.ts
+++ b/src/renderer/store/agentChat.ts
@@ -22,6 +22,7 @@ interface AgentChatStore {
   setPendingPermission: (sessionId: string, req: AgentSdkPermissionRequest | null) => void
   setError: (sessionId: string, error: string | null) => void
   clearSession: (sessionId: string) => void
+  replaceMessages: (sessionId: string, messages: AgentSdkMessage[]) => void
   clearQueuedFlag: (sessionId: string) => void
 }
 
@@ -108,6 +109,18 @@ export const useAgentChatStore = create<AgentChatStore>((set, get) => ({
     set((state) => {
       const { [sessionId]: _, ...rest } = state.sessions
       return { sessions: rest }
+    })
+  },
+
+  replaceMessages: (sessionId: string, messages: AgentSdkMessage[]) => {
+    set((state) => {
+      const session = state.sessions[sessionId] ?? { ...DEFAULT_SESSION }
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...session, messages },
+        },
+      }
     })
   },
 


### PR DESCRIPTION
## Background and Motivation

Users reported that returning to an SDK-based agent session sometimes showed a completely empty chat — all message history gone. Attempting to send new messages then failed with "No conversation found with session: [id]", leaving the session permanently broken.

## Root Cause

Three interacting bugs:

1. **History loading cleared messages before async reload** — the mount-time effect called `clearSession()` synchronously, then fired `loadHistory()` asynchronously. If the load failed (e.g. expired SDK session), messages were already wiped with no recovery path.

2. **Error handler destroyed the sdkSessionId** — transient errors (rate limits, timeouts) permanently wiped the SDK session ID needed to resume conversations and load history.

3. **Expired SDK sessions caused error loops** — when resume failed with "No conversation found", every subsequent send attempt repeated the same error because the stale session ID kept being passed.

## Design Decisions

- **Atomic history loading with generation counter**: History messages are buffered during load and atomically replace existing messages only on success. A generation counter ensures concurrent loads (e.g. user clicks "Load earlier" before mount-time load finishes) don't corrupt each other.

- **Preserve sdkSessionId across errors**: Errors transition the turn phase to `idle` (not `new`), keeping the session ID intact for both resume and history recovery.

- **Main process auto-retry without resume**: When the SDK reports "No conversation found" or "Session not found", `startTurn` silently retries without the `resume` option — the user's message goes through to a fresh session without ever seeing the error.

- **Explicit TurnPhase state machine**: Replaced two informal boolean refs (`isRunningRef` + `hasStartedRef`) with a single `TurnPhase` enum (`new` | `idle` | `active`), making all state transitions explicit and eliminating the previously invalid state combination.

## Proposed Changes

**Renderer — history loading** (`useAgentSdk.ts`, `agentChat.ts`):
- Added `replaceMessages` store action for atomic message replacement
- History messages buffered into a ref during load, applied atomically on success
- Load failures preserve existing messages and reset the guard for retry
- Generation counter prevents stale concurrent loads from applying

**Renderer — error resilience** (`useAgentSdk.ts`):
- Error handler no longer clears `sdkSessionId` or resets turn phase to `new`
- Extracted `getStoredSdkSessionId`, `addUserMessage`, `resolveResumeId` helpers
- Refactored to `TurnPhase` state machine with documented transitions

**Main process — resume retry** (`agentSdk.ts`):
- Added `ResumeFailedError` + `isSessionNotFoundError()` detection
- `runTurn` throws `ResumeFailedError` instead of sending error to renderer
- `startTurn` catches it and retries without resume (covers both construction and iteration errors)
- `loadHistory` handler now propagates errors to renderer instead of swallowing them

## Testing

- 17 new hook tests (`useAgentSdk.test.ts`) covering:
  - sdkSessionId preservation on error
  - Error → send() (not start()) lifecycle
  - Atomic history buffering and replacement on success
  - Message preservation on load failure
  - Retry after failure
  - Generation counter for concurrent loads
  - Live messages routing during history load
  - start/send/queue/stop state machine transitions
- 4 new store tests (`agentChat.test.ts`) for `replaceMessages`
- All 3264 unit tests pass, lint clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)