### PR TITLE
fix: tree-kill PTY descendants and sweep orphans on startup

### DIFF
--- a/src/main/handlers/pty.test.ts
+++ b/src/main/handlers/pty.test.ts
@@ -4,7 +4,6 @@ import { E2EScenario, type HandlerContext } from './types'
 // Mock node-pty
 const mockPtyWrite = vi.fn()
 const mockPtyResize = vi.fn()
-const mockPtyKill = vi.fn()
 const mockPtyOnData = vi.fn()
 const mockPtyOnExit = vi.fn()
 const mockPtySpawn = vi.fn()
@@ -55,11 +54,24 @@ vi.mock('../platform', () => ({
   enhancedPath: (p: string) => p || '',
 }))
 
+// Mock treeKill — every PTY teardown path goes through it now
+const mockTreeKill = vi.fn(async (_pid: number) => {})
+vi.mock('../treeKill', () => ({
+  treeKill: (pid: number) => mockTreeKill(pid),
+}))
+
+// Mock marker file I/O so tests don't touch ~/.broomy/pids
+vi.mock('../ptyMarkers', () => ({
+  recordPtyMarker: vi.fn(),
+  removePtyMarker: vi.fn(),
+}))
+
+let nextMockPid = 1000
 function createMockPtyProcess() {
   return {
+    pid: ++nextMockPid,
     write: mockPtyWrite,
     resize: mockPtyResize,
-    kill: mockPtyKill,
     onData: mockPtyOnData,
     onExit: mockPtyOnExit,
   }
@@ -517,7 +529,7 @@ describe('pty handlers', () => {
         cwd: '/tmp',
       })
 
-      expect(existingProcess.kill).toHaveBeenCalled()
+      expect(mockTreeKill).toHaveBeenCalledWith(existingProcess.pid)
       expect(ctx.ptyProcesses.get('dup-id')).toBe(newProcess)
     })
   })
@@ -783,7 +795,7 @@ describe('pty handlers', () => {
   })
 
   describe('pty:kill', () => {
-    it('kills the pty process and removes from context', async () => {
+    it('tree-kills the pty process and removes from context', async () => {
       const { register } = await import('./pty')
       const ctx = createCtx()
       register(mockIpcMain as never, ctx)
@@ -792,7 +804,7 @@ describe('pty handlers', () => {
       ctx.ptyProcesses.set('kill-1', mockProcess as never)
 
       await handlers['pty:kill'](mockEvent, 'kill-1')
-      expect(mockPtyKill).toHaveBeenCalled()
+      expect(mockTreeKill).toHaveBeenCalledWith(mockProcess.pid)
       expect(ctx.ptyProcesses.has('kill-1')).toBe(false)
     })
 
@@ -802,7 +814,7 @@ describe('pty handlers', () => {
       register(mockIpcMain as never, ctx)
 
       await handlers['pty:kill'](mockEvent, 'nonexistent')
-      expect(mockPtyKill).not.toHaveBeenCalled()
+      expect(mockTreeKill).not.toHaveBeenCalled()
     })
 
     it('disposes event listeners when killing a PTY', async () => {

--- a/src/main/handlers/pty.ts
+++ b/src/main/handlers/pty.ts
@@ -14,6 +14,8 @@ import { HandlerContext } from './types'
 import { getScenarioData } from './scenarios'
 import { isDockerAvailable, dockerSetupMessage, ensureAgentInstalled, acquireSetupLock } from '../containerUtils'
 import { isDevcontainerCliAvailable, hasDevcontainerConfig, devcontainerUp, buildDevcontainerExecArgs, devcontainerSetupMessage } from '../devcontainer'
+import { treeKill } from '../treeKill'
+import { recordPtyMarker, removePtyMarker } from '../ptyMarkers'
 
 /**
  * Resolve the base command to its full path so agents installed outside
@@ -63,6 +65,8 @@ function disposePtyListeners(id: string) {
 function wirePtyEvents(ctx: HandlerContext, ptyProcess: IPty, id: string, senderWindow: BrowserWindow | null) {
   ctx.ptyProcesses.set(id, ptyProcess)
   if (senderWindow) ctx.ptyOwnerWindows.set(id, senderWindow)
+  // Drop a marker so a future Broomy startup can sweep this shell if we crash
+  recordPtyMarker(id, ptyProcess.pid)
 
   const dataDisposable = ptyProcess.onData((data) => {
     try {
@@ -87,6 +91,7 @@ function wirePtyEvents(ctx: HandlerContext, ptyProcess: IPty, id: string, sender
     disposePtyListeners(id)
     ctx.ptyProcesses.delete(id)
     ctx.ptyOwnerWindows.delete(id)
+    removePtyMarker(id)
   })
 
   ptyDisposables.set(id, [dataDisposable, exitDisposable])
@@ -262,10 +267,12 @@ function createDevcontainerPty(
     }
     const earlyExitDisposable = ptyProcess.onExit(() => {}) // prevent unhandled-exit crashes
 
-    // Final check: session may have been killed between spawn and wire
+    // Final check: session may have been killed between spawn and wire.
+    // wirePtyEvents hasn't run yet so no marker exists — just kill the docker
+    // exec process tree.
     if (!pendingSetups.has(id)) {
       earlyExitDisposable.dispose()
-      ptyProcess.kill()
+      void treeKill(ptyProcess.pid)
       return
     }
     pendingSetups.delete(id)
@@ -331,14 +338,15 @@ function resolveShellConfig(
 const pendingSetups = new Set<string>()
 
 export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
-  ipcMain.handle('pty:create', (_event, options: { id: string; cwd: string; command?: string; sessionId?: string; env?: Record<string, string>; shell?: string; isolated?: boolean; repoRootDir?: string }) => {
+  ipcMain.handle('pty:create', async (_event, options: { id: string; cwd: string; command?: string; sessionId?: string; env?: Record<string, string>; shell?: string; isolated?: boolean; repoRootDir?: string }) => {
     // Kill any existing PTY with the same ID (e.g. React strict mode double-mount)
     const existing = ctx.ptyProcesses.get(options.id)
     if (existing) {
       disposePtyListeners(options.id)
-      existing.kill()
       ctx.ptyProcesses.delete(options.id)
       ctx.ptyOwnerWindows.delete(options.id)
+      await treeKill(existing.pid)
+      removePtyMarker(options.id)
     }
 
     const senderWindow = BrowserWindow.fromWebContents(_event.sender)
@@ -423,15 +431,16 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
     }
   })
 
-  ipcMain.handle('pty:kill', (_event, id: string) => {
+  ipcMain.handle('pty:kill', async (_event, id: string) => {
     // Cancel any in-flight async container setup for this ID
     pendingSetups.delete(id)
     const ptyProcess = ctx.ptyProcesses.get(id)
     if (ptyProcess) {
       disposePtyListeners(id)
-      ptyProcess.kill()
       ctx.ptyProcesses.delete(id)
       ctx.ptyOwnerWindows.delete(id)
+      await treeKill(ptyProcess.pid)
+      removePtyMarker(id)
     }
   })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,8 @@ import { registerAllHandlers, HandlerContext, PROFILES_FILE } from './handlers'
 import { resolveShellEnv } from './shellEnv'
 import { writeCrashLog, appendErrorLog } from './crashLog'
 import { disposePtyListenersForWindow, disposeAllPtyListeners } from './handlers/pty'
+import { treeKill } from './treeKill'
+import { sweepOrphanedPtys, clearOwnMarkers } from './ptyMarkers'
 
 // Ensure app name is correct (in dev mode Electron defaults to "Electron")
 app.name = 'Broomy'
@@ -214,28 +216,9 @@ function createWindow(profileId?: string): BrowserWindow {
     // Only clean up on same-origin navigation (reload), not initial load
     const currentUrl = window.webContents.getURL()
     if (currentUrl && currentUrl !== url) return
-    // Dispose native event listeners before killing PTY processes
     disposePtyListenersForWindow(ptyOwnerWindows, window)
-    for (const [id, owner] of ptyOwnerWindows) {
-      if (owner === window) {
-        const proc = ptyProcesses.get(id)
-        if (proc) {
-          proc.kill()
-          ptyProcesses.delete(id)
-        }
-        ptyOwnerWindows.delete(id)
-      }
-    }
-    for (const [id, owner] of watcherOwnerWindows) {
-      if (owner === window) {
-        const watcher = fileWatchers.get(id)
-        if (watcher) {
-          watcher.close()
-          fileWatchers.delete(id)
-        }
-        watcherOwnerWindows.delete(id)
-      }
-    }
+    void killPtysForWindow(window)
+    closeWatchersForWindow(window)
   })
 
   // Prevent navigation to external URLs — open them in the default browser instead
@@ -254,34 +237,12 @@ function createWindow(profileId?: string): BrowserWindow {
 
   // Cleanup when window is closing
   window.on('close', () => {
-    // Remove from profileWindows tracking
     if (profileId) {
       profileWindows.delete(profileId)
     }
-    // Dispose native event listeners before killing PTY processes
     disposePtyListenersForWindow(ptyOwnerWindows, window)
-    // Kill PTY processes belonging to this window only
-    for (const [id, owner] of ptyOwnerWindows) {
-      if (owner === window) {
-        const ptyProcess = ptyProcesses.get(id)
-        if (ptyProcess) {
-          ptyProcess.kill()
-          ptyProcesses.delete(id)
-        }
-        ptyOwnerWindows.delete(id)
-      }
-    }
-    // Close file watchers belonging to this window only
-    for (const [id, owner] of watcherOwnerWindows) {
-      if (owner === window) {
-        const watcher = fileWatchers.get(id)
-        if (watcher) {
-          watcher.close()
-          fileWatchers.delete(id)
-        }
-        watcherOwnerWindows.delete(id)
-      }
-    }
+    void killPtysForWindow(window)
+    closeWatchersForWindow(window)
     if (window === mainWindow) {
       mainWindow = null
     }
@@ -479,6 +440,17 @@ function buildAppMenu() {
   void app.whenReady().then(async () => {
     await resolveShellEnv()
 
+    // Reap PTY trees left behind by previous Broomy main-process crashes
+    // before any new PTYs are spawned. Best-effort — never blocks startup.
+    if (!isE2ETest) {
+      try {
+        const swept = await sweepOrphanedPtys()
+        if (swept > 0) console.log(`[broomy] swept ${swept} orphaned PTY tree(s) from prior crash`)
+      } catch (err) {
+        console.warn('[broomy] orphan sweep failed:', err)
+      }
+    }
+
     // Build the application menu
     buildAppMenu()
   // Determine the initial profile to open
@@ -506,28 +478,86 @@ function buildAppMenu() {
 })
 
 
-app.on('window-all-closed', () => {
-  // Dispose all native PTY event listeners before killing processes
+/**
+ * Tree-kill every PTY owned by the given window. Tree-kill catches detached
+ * descendants (firebase, expo, jest workers) that ignore SIGHUP. Returns a
+ * promise so quit-time callers can await full cleanup before exit; per-window
+ * callers can void the result.
+ */
+function killPtysForWindow(window: BrowserWindow): Promise<unknown> {
+  const pids: number[] = []
+  for (const [id, owner] of ptyOwnerWindows) {
+    if (owner !== window) continue
+    const proc = ptyProcesses.get(id)
+    if (proc) {
+      pids.push(proc.pid)
+      ptyProcesses.delete(id)
+    }
+    ptyOwnerWindows.delete(id)
+  }
+  return Promise.all(pids.map((pid) => treeKill(pid)))
+}
+
+/** Close every file watcher owned by the given window. */
+function closeWatchersForWindow(window: BrowserWindow): void {
+  for (const [id, owner] of watcherOwnerWindows) {
+    if (owner !== window) continue
+    const watcher = fileWatchers.get(id)
+    if (watcher) {
+      watcher.close()
+      fileWatchers.delete(id)
+    }
+    watcherOwnerWindows.delete(id)
+  }
+}
+
+/** Tree-kill every tracked PTY across all windows. Awaits SIGKILL fallbacks. */
+async function killAllPtys(): Promise<void> {
   disposeAllPtyListeners()
-  // Kill all PTY processes
+  const pids: number[] = []
   for (const [id, ptyProcess] of ptyProcesses) {
-    ptyProcess.kill()
+    pids.push(ptyProcess.pid)
     ptyProcesses.delete(id)
   }
-  // Close all file watchers
+  await Promise.all(pids.map((pid) => treeKill(pid)))
+}
+
+/** Close every tracked file watcher across all windows. */
+function closeAllWatchers(): void {
   for (const [id, watcher] of fileWatchers) {
     watcher.close()
     fileWatchers.delete(id)
   }
-  stopDockerContainers()
+}
+
+app.on('window-all-closed', () => {
+  // Fire-and-forget on macOS where the app stays in the dock. On other
+  // platforms, before-quit will await cleanup before the process exits.
+  closeAllWatchers()
+  void killAllPtys().then(() => stopDockerContainers())
   if (process.platform !== 'darwin') {
     app.quit()
   }
 })
 
-// Also stop containers on Cmd+Q / Quit (macOS doesn't always fire window-all-closed)
-app.on('will-quit', () => {
-  stopDockerContainers()
+// Delay quit until PTY descendants have been SIGKILLed. Without this the
+// Electron process exits right after sending SIGTERM and the OS never
+// delivers our follow-up SIGKILL to stragglers.
+let quitCleanupDone = false
+app.on('before-quit', (event) => {
+  if (quitCleanupDone) return
+  event.preventDefault()
+  void (async () => {
+    try {
+      closeAllWatchers()
+      await killAllPtys()
+      stopDockerContainers()
+      clearOwnMarkers()
+    } finally {
+      quitCleanupDone = true
+      app.quit()
+    }
+  })()
 })
 
 function stopDockerContainers() {

--- a/src/main/ptyMarkers.test.ts
+++ b/src/main/ptyMarkers.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync, readdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return { ...actual, homedir: () => join(actual.tmpdir(), 'broomy-pid-markers-test', 'home') }
+})
+
+const treeKillCalls: number[] = []
+vi.mock('./treeKill', () => ({
+  treeKill: async (pid: number) => { treeKillCalls.push(pid) },
+}))
+
+import { recordPtyMarker, removePtyMarker, clearOwnMarkers, sweepOrphanedPtys, MARKERS_ROOT } from './ptyMarkers'
+
+const fakeRoot = join(tmpdir(), 'broomy-pid-markers-test')
+
+beforeEach(() => {
+  treeKillCalls.length = 0
+  rmSync(fakeRoot, { recursive: true, force: true })
+  mkdirSync(MARKERS_ROOT, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(fakeRoot, { recursive: true, force: true })
+})
+
+describe('recordPtyMarker / removePtyMarker', () => {
+  it('writes a file under <markers-root>/<main-pid>/<encoded-id>', () => {
+    recordPtyMarker('session-1', 4242)
+    const dir = join(MARKERS_ROOT, String(process.pid))
+    expect(readdirSync(dir)).toEqual(['session-1'])
+  })
+
+  it('encodes ids that contain path separators', () => {
+    recordPtyMarker('weird/id', 99)
+    const dir = join(MARKERS_ROOT, String(process.pid))
+    expect(readdirSync(dir)).toEqual([encodeURIComponent('weird/id')])
+  })
+
+  it('removePtyMarker is a no-op for missing files', () => {
+    expect(() => removePtyMarker('never-existed')).not.toThrow()
+  })
+
+  it('clearOwnMarkers wipes only this process\'s directory', () => {
+    recordPtyMarker('a', 1)
+    mkdirSync(join(MARKERS_ROOT, '999999'), { recursive: true })
+    clearOwnMarkers()
+    expect(existsSync(join(MARKERS_ROOT, String(process.pid)))).toBe(false)
+    expect(existsSync(join(MARKERS_ROOT, '999999'))).toBe(true)
+  })
+})
+
+describe('sweepOrphanedPtys', () => {
+  it('returns 0 when the markers root is missing', async () => {
+    rmSync(MARKERS_ROOT, { recursive: true, force: true })
+    expect(await sweepOrphanedPtys()).toBe(0)
+  })
+
+  it('skips the current process\'s own directory', async () => {
+    recordPtyMarker('mine', 12345)
+    expect(await sweepOrphanedPtys()).toBe(0)
+    expect(treeKillCalls).toEqual([])
+    expect(existsSync(join(MARKERS_ROOT, String(process.pid)))).toBe(true)
+  })
+
+  it('skips directories whose owner main-pid is still alive', async () => {
+    const liveDir = join(MARKERS_ROOT, String(process.ppid))
+    mkdirSync(liveDir, { recursive: true })
+    writeFileSync(join(liveDir, 'pty-1'), '777', 'utf-8')
+    expect(await sweepOrphanedPtys()).toBe(0)
+    expect(existsSync(liveDir)).toBe(true)
+  })
+
+  it('tree-kills every shell pid in dead-owner directories and removes them', async () => {
+    const deadOwnerDir = join(MARKERS_ROOT, '999999')
+    mkdirSync(deadOwnerDir, { recursive: true })
+    writeFileSync(join(deadOwnerDir, 'pty-a'), '111', 'utf-8')
+    writeFileSync(join(deadOwnerDir, 'pty-b'), '222', 'utf-8')
+    const swept = await sweepOrphanedPtys()
+    expect(swept).toBe(2)
+    expect(treeKillCalls.sort()).toEqual([111, 222])
+    expect(existsSync(deadOwnerDir)).toBe(false)
+  })
+
+  it('ignores non-numeric directory entries', async () => {
+    mkdirSync(join(MARKERS_ROOT, 'README'), { recursive: true })
+    expect(await sweepOrphanedPtys()).toBe(0)
+  })
+})

--- a/src/main/ptyMarkers.ts
+++ b/src/main/ptyMarkers.ts
@@ -1,0 +1,100 @@
+/**
+ * On-disk PTY ownership markers used to recover from Electron main-process
+ * crashes.
+ *
+ * Each spawned shell drops a file at `~/.broomy/pids/<main-pid>/<pty-id>` whose
+ * contents are the shell PID. When Broomy starts up, `sweepOrphanedPtys` looks
+ * for marker directories whose owner main-process is no longer alive and
+ * tree-kills the recorded shells. This catches the case where Electron exits
+ * uncleanly (crash, force-quit) without firing the cleanup handlers.
+ */
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import { treeKill } from './treeKill'
+
+export const MARKERS_ROOT = join(homedir(), '.broomy', 'pids')
+
+function markerDir(mainPid: number = process.pid): string {
+  return join(MARKERS_ROOT, String(mainPid))
+}
+
+function markerPath(ptyId: string, mainPid: number = process.pid): string {
+  return join(markerDir(mainPid), encodeURIComponent(ptyId))
+}
+
+/** Record that this main process owns a PTY shell. Best-effort — never throws. */
+export function recordPtyMarker(ptyId: string, shellPid: number): void {
+  try {
+    mkdirSync(markerDir(), { recursive: true })
+    writeFileSync(markerPath(ptyId), String(shellPid), 'utf-8')
+  } catch {
+    // Marker is a recovery hint, not a correctness requirement
+  }
+}
+
+/** Remove a marker once a PTY has been killed cleanly. */
+export function removePtyMarker(ptyId: string): void {
+  try {
+    rmSync(markerPath(ptyId), { force: true })
+  } catch {
+    // Already gone
+  }
+}
+
+/** Remove this main process's entire marker directory (called at clean exit). */
+export function clearOwnMarkers(): void {
+  try {
+    rmSync(markerDir(), { recursive: true, force: true })
+  } catch {
+    // ignore
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 1) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Find marker directories whose owning main-process is dead, tree-kill every
+ * shell PID inside, and remove the directory. Safe to call at startup before
+ * any new PTYs are created. Returns the number of orphan trees swept.
+ */
+export async function sweepOrphanedPtys(): Promise<number> {
+  let entries: string[]
+  try {
+    entries = readdirSync(MARKERS_ROOT)
+  } catch {
+    return 0
+  }
+  let swept = 0
+  for (const entry of entries) {
+    const ownerPid = Number(entry)
+    if (!Number.isInteger(ownerPid)) continue
+    if (ownerPid === process.pid) continue
+    if (isPidAlive(ownerPid)) continue
+
+    const dir = join(MARKERS_ROOT, entry)
+    let markerFiles: string[] = []
+    try { markerFiles = readdirSync(dir) } catch { /* ignore */ }
+    const pids: number[] = []
+    for (const file of markerFiles) {
+      try {
+        const pid = parseInt(readFileSync(join(dir, file), 'utf-8').trim(), 10)
+        if (Number.isInteger(pid) && pid > 1) pids.push(pid)
+      } catch {
+        // Marker unreadable — skip
+      }
+    }
+    await Promise.all(pids.map((pid) => treeKill(pid)))
+    swept += pids.length
+    try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
+  }
+  return swept
+}

--- a/src/main/treeKill.test.ts
+++ b/src/main/treeKill.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+  execFile: vi.fn((_cmd, _args, _opts, cb: () => void) => { cb() }),
+}))
+
+vi.mock('./platform', () => ({ isWindows: false }))
+
+import { execFileSync } from 'child_process'
+import { parsePsSnapshot, collectDescendants, treeKill } from './treeKill'
+
+describe('parsePsSnapshot', () => {
+  it('parses well-formed lines and ignores junk', () => {
+    const out = '  100  1  100\n  200  100  100\nnot a row\n  300  200  300\n'
+    expect(parsePsSnapshot(out)).toEqual([
+      { pid: 100, ppid: 1, pgid: 100 },
+      { pid: 200, ppid: 100, pgid: 100 },
+      { pid: 300, ppid: 200, pgid: 300 },
+    ])
+  })
+})
+
+describe('collectDescendants', () => {
+  const snapshot = [
+    { pid: 100, ppid: 1, pgid: 100 },     // shell
+    { pid: 200, ppid: 100, pgid: 100 },   // direct child
+    { pid: 300, ppid: 200, pgid: 100 },   // grandchild, still in shell's group
+    { pid: 400, ppid: 1, pgid: 100 },     // orphaned to init but in shell's group (the firebase case)
+    { pid: 500, ppid: 200, pgid: 500 },   // grandchild that called setsid
+    { pid: 999, ppid: 1, pgid: 999 },     // unrelated process
+  ]
+
+  it('walks the parent-pid tree from the root', () => {
+    const result = collectDescendants(snapshot, 100)
+    expect(result.has(100)).toBe(true)
+    expect(result.has(200)).toBe(true)
+    expect(result.has(300)).toBe(true)
+    expect(result.has(500)).toBe(true)
+  })
+
+  it('includes processes orphaned to init that share the root PGID', () => {
+    const result = collectDescendants(snapshot, 100)
+    expect(result.has(400)).toBe(true)
+  })
+
+  it('excludes unrelated processes', () => {
+    const result = collectDescendants(snapshot, 100)
+    expect(result.has(999)).toBe(false)
+  })
+
+  it('returns just the root when there are no descendants', () => {
+    expect(collectDescendants([], 42)).toEqual(new Set([42]))
+  })
+})
+
+describe('treeKill', () => {
+  let killSpy: ReturnType<typeof vi.spyOn>
+  const killed: { pid: number; signal: string | number }[] = []
+
+  beforeEach(() => {
+    killed.length = 0
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((pid: number, signal?: string | number) => {
+      killed.push({ pid, signal: signal ?? 'SIGTERM' })
+      return true
+    })
+    vi.mocked(execFileSync).mockReturnValue(
+      '  100  1  100\n  200  100  100\n  300  200  100\n  400  1  100\n'
+    )
+  })
+
+  afterEach(() => {
+    killSpy.mockRestore()
+    vi.clearAllMocks()
+  })
+
+  it('SIGTERMs all descendants then SIGKILLs survivors', async () => {
+    await treeKill(100, 0)
+    const terms = killed.filter((k) => k.signal === 'SIGTERM').map((k) => k.pid).sort()
+    expect(terms).toEqual([100, 200, 300, 400])
+    const kills = killed.filter((k) => k.signal === 'SIGKILL').map((k) => k.pid).sort()
+    expect(kills).toEqual([100, 200, 300, 400])
+  })
+
+  it('does not SIGKILL processes that already exited', async () => {
+    killSpy.mockRestore()
+    const exited = new Set([200, 300])
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((pid: number, signal?: string | number) => {
+      killed.push({ pid, signal: signal ?? 'SIGTERM' })
+      if (signal === 0 && exited.has(pid)) throw new Error('ESRCH')
+      return true
+    })
+    await treeKill(100, 0)
+    const kills = killed.filter((k) => k.signal === 'SIGKILL').map((k) => k.pid).sort()
+    expect(kills).toEqual([100, 400])
+  })
+
+  it('refuses to signal init or invalid PIDs', async () => {
+    await treeKill(0)
+    await treeKill(1)
+    await treeKill(NaN)
+    expect(killed).toEqual([])
+  })
+
+  it('swallows errors from individual kill calls', async () => {
+    killSpy.mockRestore()
+    killSpy = vi.spyOn(process, 'kill').mockImplementation(() => { throw new Error('EPERM') })
+    await expect(treeKill(100, 0)).resolves.toBeUndefined()
+  })
+})

--- a/src/main/treeKill.ts
+++ b/src/main/treeKill.ts
@@ -1,0 +1,110 @@
+/**
+ * Tree-kill helper for PTY shells.
+ *
+ * node-pty's `IPty.kill()` only sends SIGHUP to the shell. Daemons that detach
+ * from the controlling terminal (firebase emulators, expo dev server, jest
+ * workers, anything using `setsid` or `detached: true`) ignore that signal and
+ * survive as orphans adopted by init. Over time these accumulate and exhaust
+ * memory.
+ *
+ * `treeKill` collects every descendant of the shell PID (by walking parent-pid
+ * chains AND by union-ing in the shell's process group), sends SIGTERM, then
+ * SIGKILLs any stragglers after a grace period.
+ */
+import { execFile, execFileSync } from 'child_process'
+import { isWindows } from './platform'
+
+export type PsSnapshot = readonly { pid: number; ppid: number; pgid: number }[]
+
+const PS_LINE_RE = /^(\d+)\s+(\d+)\s+(\d+)$/
+
+/** Parse `ps -axo pid=,ppid=,pgid=` output into a structured snapshot. */
+export function parsePsSnapshot(stdout: string): PsSnapshot {
+  const rows: { pid: number; ppid: number; pgid: number }[] = []
+  for (const line of stdout.split('\n')) {
+    const m = PS_LINE_RE.exec(line.trim())
+    if (!m) continue
+    rows.push({ pid: parseInt(m[1], 10), ppid: parseInt(m[2], 10), pgid: parseInt(m[3], 10) })
+  }
+  return rows
+}
+
+/**
+ * Given a process snapshot and a root PID, return the set of PIDs to kill:
+ * the root itself, every descendant by parent-pid chain, and every process
+ * sharing the root's process group. The PGID union catches daemons that have
+ * been reparented to init but still belong to the original shell's group.
+ */
+export function collectDescendants(snapshot: PsSnapshot, rootPid: number): Set<number> {
+  const childrenOf = new Map<number, number[]>()
+  for (const row of snapshot) {
+    const arr = childrenOf.get(row.ppid) || []
+    arr.push(row.pid)
+    childrenOf.set(row.ppid, arr)
+  }
+  const result = new Set<number>([rootPid])
+  const stack = [rootPid]
+  while (stack.length) {
+    const p = stack.pop()!
+    for (const child of childrenOf.get(p) || []) {
+      if (!result.has(child)) {
+        result.add(child)
+        stack.push(child)
+      }
+    }
+  }
+  for (const row of snapshot) {
+    if (row.pgid === rootPid) result.add(row.pid)
+  }
+  return result
+}
+
+/** Capture a process snapshot via `ps`. Returns empty array on failure. */
+function snapshotProcesses(): PsSnapshot {
+  try {
+    const stdout = execFileSync('ps', ['-axo', 'pid=,ppid=,pgid='], { encoding: 'utf-8', timeout: 5000 })
+    return parsePsSnapshot(stdout)
+  } catch {
+    return []
+  }
+}
+
+function safeSignal(pid: number, signal: NodeJS.Signals | 0): boolean {
+  try {
+    process.kill(pid, signal)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Kill a PTY shell and every descendant. Resolves once stragglers have been
+ * SIGKILLed (Unix) or after taskkill returns (Windows). Always resolves —
+ * never throws — so callers can treat cleanup as best-effort.
+ *
+ * @param rootPid PID of the shell spawned by node-pty
+ * @param graceMs Time to wait between SIGTERM and SIGKILL (default 1500ms)
+ */
+export async function treeKill(rootPid: number, graceMs = 1500): Promise<void> {
+  if (!Number.isInteger(rootPid) || rootPid <= 1) return
+
+  if (isWindows) {
+    await new Promise<void>((resolve) => {
+      execFile('taskkill', ['/T', '/F', '/PID', String(rootPid)], { timeout: 5000 }, () => resolve())
+    })
+    return
+  }
+
+  const snapshot = snapshotProcesses()
+  const targets = collectDescendants(snapshot, rootPid)
+  for (const pid of targets) safeSignal(pid, 'SIGTERM')
+
+  await sleep(graceMs)
+
+  for (const pid of targets) {
+    if (safeSignal(pid, 0)) safeSignal(pid, 'SIGKILL')
+  }
+}


### PR DESCRIPTION
## Summary

- **Replace `ptyProcess.kill()` with `treeKill()` in every PTY teardown path** — node-pty's kill only sends SIGHUP to the shell; daemons that detach from the controlling TTY ignore it and survive as orphans
- **`treeKill` walks every descendant of the shell PID** by combining a PPID-chain walk with a PGID union, then SIGTERMs all of them and SIGKILLs stragglers after a 1.5 s grace
- **`before-quit` now `event.preventDefault()`s and awaits cleanup** so the SIGKILL fallback actually fires before the Electron process exits
- **New on-disk PTY markers + startup sweeper** at `~/.broomy/pids/<main-pid>/<pty-id>` recover from prior Electron crashes — at startup we tree-kill every shell PID recorded under a marker dir whose owner main-process is dead
- **Refactor duplicated per-window cleanup loops in `index.ts`** into `killPtysForWindow`, `closeWatchersForWindow`, `killAllPtys`, `closeAllWatchers`

## Background and Motivation

Investigation showed 708 leftover node processes consuming **13.75 GB** of RAM, accumulated from sessions stretching back ~20 days. 60 process groups whose original PTY shell was long dead still had 5–19 surviving descendants each — `firebase emulators:start`, `pnpm expo start --web`, `jest-worker/processChild.js`. Many had `PPID=1`, having been reparented to init.

Root cause: every PTY-kill path in Broomy called `ptyProcess.kill()` (SIGHUP-only). Detached daemons ignore SIGHUP. The accumulated orphans were silent until they exhausted system memory.

Six call sites needed updating: the `pty:create` "kill existing with same id" branch, the `pty:kill` IPC handler, the devcontainer early-abort, the renderer-reload `did-start-navigation` handler, `window.on('close')`, and `window-all-closed`.

## Design Decisions

- **PPID walk + PGID union, not just one or the other**: The PPID chain catches grandchildren that called `setsid` (their PGID changed but their PPID lineage is intact). The PGID union catches daemons that have been reparented to init (PPID=1) but still belong to the original shell's group. Either approach alone misses cases observed in the orphan zoo.
- **`before-quit` instead of `will-quit`**: tree-kill is async (TERM, sleep, KILL). Without `event.preventDefault()` Electron exits immediately after dispatching SIGTERM and the OS never delivers our SIGKILL.
- **Marker files instead of env-var scanning**: `ps eww` env parsing is platform-fragile. Marker files at `~/.broomy/pids/<main-pid>/<pty-id>` give a deterministic, portable recovery mechanism — directory name encodes the owner main-pid, so liveness check is `process.kill(pid, 0)`.
- **Best-effort, never throws**: `treeKill` and the marker helpers swallow errors. Cleanup is a recovery hint, not a correctness requirement; throwing during teardown just creates new failure modes.

## Testing

- All 3288 unit tests pass (190 files)
- All 72 E2E tests pass
- Lint and typecheck clean
- Coverage 90.27% overall — `treeKill.ts` 90.69%, `ptyMarkers.ts` 100%
- Verified manually: killed 707 of 708 orphan node processes on the host using the same PGID/tree-walk strategy `treeKill` implements, reclaiming ~13.7 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)