### PR TITLE
fix: disable Agent SDK functionality by default

### DIFF
--- a/src/main/handlers/types.ts
+++ b/src/main/handlers/types.ts
@@ -74,7 +74,7 @@ export function getProfileInitScriptsDir(profileId: string): string {
 
 // Default agents
 export const DEFAULT_AGENTS = [
-  { id: 'claude', name: 'Claude Code', command: 'claude', color: '#D97757', skipApprovalFlag: '--dangerously-skip-permissions', connectionMode: 'api' as const },
+  { id: 'claude', name: 'Claude Code', command: 'claude', color: '#D97757', skipApprovalFlag: '--dangerously-skip-permissions' },
   { id: 'codex', name: 'Codex', command: 'codex', color: '#10A37F', skipApprovalFlag: '--approval-mode full-auto' },
   { id: 'gemini', name: 'Gemini CLI', command: 'gemini', color: '#4285F4' },
   { id: 'copilot', name: 'GitHub Copilot', command: 'copilot', color: '#6E40C9' },

--- a/src/renderer/features/commands/actionExecutor.ts
+++ b/src/renderer/features/commands/actionExecutor.ts
@@ -11,6 +11,7 @@ import { useAgentStore, type AgentConfig } from '../../store/agents'
 import { useAgentChatStore } from '../../store/agentChat'
 import { useSessionStore } from '../../store/sessions'
 import { useRepoStore } from '../../store/repos'
+import { ENABLE_AGENT_SDK } from '../../../shared/featureFlags'
 
 export interface ActionExecutionContext {
   directory: string
@@ -63,6 +64,7 @@ async function executeShellAction(
  */
 /** Check if the active session is using API mode (Agent SDK) instead of terminal. */
 function getApiModeSessionId(agentId?: string | null): string | null {
+  if (!ENABLE_AGENT_SDK) return null
   if (!agentId) return null
   const agent = useAgentStore.getState().agents.find((a: AgentConfig) => a.id === agentId)
   if (agent?.connectionMode !== 'api') return null

--- a/src/renderer/panels/agent/TabbedTerminal.tsx
+++ b/src/renderer/panels/agent/TabbedTerminal.tsx
@@ -13,6 +13,7 @@ import TerminalTabBar from './TerminalTabBar'
 import { AgentChat } from './AgentChat'
 import ContainerInfoPanel from '../../shared/components/ContainerInfoPanel'
 import PanelErrorBoundary from '../../shared/components/PanelErrorBoundary'
+import { ENABLE_AGENT_SDK } from '../../../shared/featureFlags'
 import { useSessionStore } from '../../store/sessions'
 import type { TerminalTab } from '../../store/sessions'
 
@@ -199,7 +200,7 @@ const TerminalPanels = React.memo(function TerminalPanels({ sessionId, cwd, acti
   sdkSessionId?: string
 }) {
   // API mode runs on the host — incompatible with devcontainers (which need docker exec)
-  const useApiMode = connectionMode === 'api' && !!agentCommand && !isolated
+  const useApiMode = ENABLE_AGENT_SDK && connectionMode === 'api' && !!agentCommand && !isolated
 
   return (
     <div className="flex-1 relative min-h-0">

--- a/src/renderer/panels/settings/AgentSettingsAgentTab.tsx
+++ b/src/renderer/panels/settings/AgentSettingsAgentTab.tsx
@@ -6,6 +6,7 @@ import type { AgentConfig } from '../../store/agents'
 import type { SdkModelInfo } from '../../../preload/apis/types'
 import { EnvVarEditor, type EnvVarEditorRef } from './EnvVarEditor'
 import { useSdkModels, DEFAULT_MODEL } from '../../shared/hooks/useSdkModels'
+import { ENABLE_AGENT_SDK } from '../../../shared/featureFlags'
 
 interface AgentSettingsAgentTabProps {
   agents: AgentConfig[]
@@ -146,29 +147,33 @@ export function AgentSettingsAgentTab({
             placeholder="Color (optional, e.g., #4a9eff)"
             className="w-full px-3 py-2 bg-bg-secondary border border-border rounded text-sm text-text-primary placeholder-text-secondary focus:outline-none focus:border-accent"
           />
-          <div className="space-y-1">
-            <label className="text-xs text-text-secondary">Connection mode</label>
-            <select
-              value={connectionMode}
-              onChange={(e) => onConnectionModeChange(e.target.value as 'terminal' | 'api')}
-              className="w-full px-3 py-2 bg-bg-secondary border border-border rounded text-sm text-text-primary focus:outline-none focus:border-accent"
-            >
-              <option value="terminal">Terminal (PTY)</option>
-              <option value="api">API (Agent SDK)</option>
-            </select>
-            <p className="text-xs text-text-tertiary">
-              API mode uses the Claude Agent SDK for structured output instead of terminal.
-            </p>
-          </div>
-          {connectionMode === 'api' && (
-            <ApiModeOptions
-              model={model}
-              effort={effort}
-              models={models}
-              modelsLoading={loading}
-              onModelChange={onModelChange}
-              onEffortChange={onEffortChange}
-            />
+          {ENABLE_AGENT_SDK && (
+            <>
+              <div className="space-y-1">
+                <label className="text-xs text-text-secondary">Connection mode</label>
+                <select
+                  value={connectionMode}
+                  onChange={(e) => onConnectionModeChange(e.target.value as 'terminal' | 'api')}
+                  className="w-full px-3 py-2 bg-bg-secondary border border-border rounded text-sm text-text-primary focus:outline-none focus:border-accent"
+                >
+                  <option value="terminal">Terminal (PTY)</option>
+                  <option value="api">API (Agent SDK)</option>
+                </select>
+                <p className="text-xs text-text-tertiary">
+                  API mode uses the Claude Agent SDK for structured output instead of terminal.
+                </p>
+              </div>
+              {connectionMode === 'api' && (
+                <ApiModeOptions
+                  model={model}
+                  effort={effort}
+                  models={models}
+                  modelsLoading={loading}
+                  onModelChange={onModelChange}
+                  onEffortChange={onEffortChange}
+                />
+              )}
+            </>
           )}
           <EnvVarEditor ref={envEditorRef} env={env} onChange={onEnvChange} command={command} />
           <div className="space-y-1">
@@ -285,26 +290,30 @@ function AgentEditForm({
         placeholder="Color (optional, e.g., #4a9eff)"
         className="w-full px-3 py-2 bg-bg-secondary border border-border rounded text-sm text-text-primary placeholder-text-secondary focus:outline-none focus:border-accent"
       />
-      <div className="space-y-1">
-        <label className="text-xs text-text-secondary">Connection mode</label>
-        <select
-          value={connectionMode}
-          onChange={(e) => onConnectionModeChange(e.target.value as 'terminal' | 'api')}
-          className="w-full px-3 py-2 bg-bg-secondary border border-border rounded text-sm text-text-primary focus:outline-none focus:border-accent"
-        >
-          <option value="terminal">Terminal (PTY)</option>
-          <option value="api">API (Agent SDK)</option>
-        </select>
-      </div>
-      {connectionMode === 'api' && (
-        <ApiModeOptions
-          model={model}
-          effort={effort}
-          models={models}
-          modelsLoading={modelsLoading}
-          onModelChange={onModelChange}
-          onEffortChange={onEffortChange}
-        />
+      {ENABLE_AGENT_SDK && (
+        <>
+          <div className="space-y-1">
+            <label className="text-xs text-text-secondary">Connection mode</label>
+            <select
+              value={connectionMode}
+              onChange={(e) => onConnectionModeChange(e.target.value as 'terminal' | 'api')}
+              className="w-full px-3 py-2 bg-bg-secondary border border-border rounded text-sm text-text-primary focus:outline-none focus:border-accent"
+            >
+              <option value="terminal">Terminal (PTY)</option>
+              <option value="api">API (Agent SDK)</option>
+            </select>
+          </div>
+          {connectionMode === 'api' && (
+            <ApiModeOptions
+              model={model}
+              effort={effort}
+              models={models}
+              modelsLoading={modelsLoading}
+              onModelChange={onModelChange}
+              onEffortChange={onEffortChange}
+            />
+          )}
+        </>
       )}
       <EnvVarEditor ref={envEditorRef} env={env} onChange={onEnvChange} command={command} />
       <div className="space-y-1">
@@ -413,11 +422,11 @@ function AgentRow({
   onEdit: (agent: AgentConfig) => void
   onDelete: (id: string) => void
 }) {
-  const modelInfo = agent.connectionMode === 'api' && agent.model
+  const modelInfo = ENABLE_AGENT_SDK && agent.connectionMode === 'api' && agent.model
     ? models.find((m) => m.value === agent.model)
     : null
-  const modelLabel = modelInfo?.displayName ?? (agent.connectionMode === 'api' && agent.model ? agent.model : null)
-  const effortLabel = agent.connectionMode === 'api' && agent.effort ? agent.effort : null
+  const modelLabel = modelInfo?.displayName ?? (ENABLE_AGENT_SDK && agent.connectionMode === 'api' && agent.model ? agent.model : null)
+  const effortLabel = ENABLE_AGENT_SDK && agent.connectionMode === 'api' && agent.effort ? agent.effort : null
 
   return (
     <div className="flex items-center justify-between">
@@ -431,7 +440,7 @@ function AgentRow({
         <div>
           <div className="font-medium text-sm text-text-primary flex items-center gap-2">
             {agent.name}
-            {agent.connectionMode === 'api' && (
+            {ENABLE_AGENT_SDK && agent.connectionMode === 'api' && (
               <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 font-normal">API</span>
             )}
             {agent.skipApprovalFlag && (

--- a/src/renderer/shared/components/ActionButtons.tsx
+++ b/src/renderer/shared/components/ActionButtons.tsx
@@ -7,6 +7,7 @@ import type { ActionDefinition, ConditionState, TemplateVars } from '../../featu
 import { evaluateShowWhen, resolveTemplateVars, getDefaultCommandsConfig, matchesSurface } from '../../features/commands/commandsConfig'
 import { executeAction, type ActionExecutionContext } from '../../features/commands/actionExecutor'
 import { useAgentStore } from '../../store/agents'
+import { ENABLE_AGENT_SDK } from '../../../shared/featureFlags'
 import { DialogErrorBanner } from './ErrorBanner'
 
 interface ActionButtonsProps {
@@ -95,7 +96,7 @@ export function ActionButtons({
         const error = actionErrors[action.id]
         const style = STYLE_CLASSES[action.style ?? 'secondary']
         const label = resolveTemplateVars(action.label, templateVars)
-        const isApiMode = agentId ? useAgentStore.getState().agents.find(a => a.id === agentId)?.connectionMode === 'api' : false
+        const isApiMode = ENABLE_AGENT_SDK && agentId ? useAgentStore.getState().agents.find(a => a.id === agentId)?.connectionMode === 'api' : false
         const isDisabled = isLoading || (action.type === 'agent' && !agentPtyId && !isApiMode)
 
         return (

--- a/src/shared/featureFlags.ts
+++ b/src/shared/featureFlags.ts
@@ -1,0 +1,11 @@
+/**
+ * Code-level feature flags.
+ *
+ * Flip these to enable/disable features at build time.
+ * They are simple boolean constants so bundlers can tree-shake
+ * dead branches when the flag is `false`.
+ */
+
+/** When false, all Agent SDK / API-mode functionality is hidden and inactive. */
+// eslint-disable-next-line @typescript-eslint/no-inferrable-types -- explicit type prevents literal narrowing so feature-flag checks don't trigger no-unnecessary-condition
+export const ENABLE_AGENT_SDK: boolean = false


### PR DESCRIPTION
## Background and Motivation

Anthropic is discouraging use of the Agent SDK with subscriptions. This PR disables all Agent SDK / API-mode functionality by default without removing any code, making it easy to re-enable later.

## Design Decisions

- **Feature flag approach**: A single `ENABLE_AGENT_SDK` boolean in `src/shared/featureFlags.ts` gates all SDK code paths. No code is deleted — flip the flag to `true` to restore full functionality.
- **Explicit `boolean` type annotation**: Prevents TypeScript from narrowing the constant to literal `false`, which would trigger `no-unnecessary-condition` lint errors on every guarded branch.

## Proposed Changes

- **New file `src/shared/featureFlags.ts`**: Central feature flags module with `ENABLE_AGENT_SDK = false`.
- **Default agent config** (`src/main/handlers/types.ts`): Removed `connectionMode: 'api'` from the default Claude agent so new installs use terminal mode.
- **UI gating** (`AgentSettingsAgentTab.tsx`): Connection mode selector, API-mode options, API badge, and model/effort labels are hidden when the flag is off — in both the add and edit forms.
- **Runtime gating** (`TabbedTerminal.tsx`, `actionExecutor.ts`, `ActionButtons.tsx`): API-mode activation checks now require `ENABLE_AGENT_SDK` to be truthy, ensuring the SDK chat UI and action routing never engage.

## Testing

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm check:all` — clean
- `pnpm test:unit` — 187/188 suites pass, 3264 tests pass (1 pre-existing Electron binary issue unrelated to this change)
- `pnpm test:e2e` — 72/72 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)