### PR TITLE
fix: narrow PR FAILED/FEEDBACK chip triggers to genuine signals

### DIFF
--- a/src/main/handlers/ghComments.test.ts
+++ b/src/main/handlers/ghComments.test.ts
@@ -375,4 +375,98 @@ describe('ghComments handlers', () => {
       expect(result).toBeNull()
     })
   })
+
+  describe('gh:prFeedbackStatus', () => {
+    // The handler runs two setup calls in parallel (repo slug + user login),
+    // then five more calls in parallel (reviews, requested_reviewers, last push,
+    // pr comments, issue comments). Because execFile is mocked, the stdout we
+    // return is treated as already-jq-filtered output.
+    function mockFeedbackCalls(opts: {
+      slug?: string
+      login?: string
+      reviews?: unknown[]
+      requestedReviewers?: string[]
+      lastPushTime?: string
+      prComments?: string[]
+      issueComments?: string[]
+    }) {
+      const slug = opts.slug ?? 'user/repo'
+      const login = opts.login ?? 'octocat'
+      vi.mocked(execFile)
+        .mockReturnValueOnce({ stdout: `${slug}\n`, stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: `${login}\n`, stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify(opts.reviews ?? []), stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify(opts.requestedReviewers ?? []), stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: `${opts.lastPushTime ?? '2024-01-01T00:00:00Z'}\n`, stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify(opts.prComments ?? []), stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify(opts.issueComments ?? []), stderr: '' } as never)
+    }
+
+    it('returns false in E2E mode', async () => {
+      const handlers = setupHandlers(createMockCtx({ isE2ETest: true }))
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(false)
+    })
+
+    it('returns true when a reviewer requested changes and has not been re-requested', async () => {
+      mockFeedbackCalls({
+        reviews: [{ author: 'reviewer1', state: 'CHANGES_REQUESTED' }],
+        requestedReviewers: [],
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(true)
+    })
+
+    it('returns false when changes-requested reviewer has been re-requested', async () => {
+      mockFeedbackCalls({
+        reviews: [{ author: 'reviewer1', state: 'CHANGES_REQUESTED' }],
+        requestedReviewers: ['reviewer1'],
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(false)
+    })
+
+    it('returns true when a human comment was posted after the last push', async () => {
+      mockFeedbackCalls({
+        lastPushTime: '2024-01-01T00:00:00Z',
+        issueComments: ['2024-01-02T00:00:00Z'],
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(true)
+    })
+
+    it('returns false when all comments predate the last push', async () => {
+      mockFeedbackCalls({
+        lastPushTime: '2024-02-01T00:00:00Z',
+        issueComments: ['2024-01-02T00:00:00Z'],
+        prComments: ['2024-01-15T00:00:00Z'],
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(false)
+    })
+
+    it('excludes bot accounts in the jq filters', async () => {
+      mockFeedbackCalls({})
+      const handlers = setupHandlers()
+      await handlers['gh:prFeedbackStatus'](null, '/repo', 42)
+
+      const calls = vi.mocked(execFile).mock.calls
+      const jqArgs = calls.flatMap(call => (call[1] as string[]) ?? [])
+      const jqFilters = jqArgs.filter(arg => arg.includes('.user'))
+
+      // Reviews query excludes bots
+      expect(jqFilters.some(f => f.includes('.user.type != "Bot"') && f.includes('.state'))).toBe(true)
+      // Both comment queries (review + issue) include the bot exclusion
+      const commentFilters = jqFilters.filter(f => f.includes('.created_at'))
+      expect(commentFilters).toHaveLength(2)
+      expect(commentFilters.every(f => f.includes('.user.type != "Bot"'))).toBe(true)
+    })
+
+    it('returns false on error', async () => {
+      vi.mocked(execFile).mockImplementation(() => {
+        throw new Error('network error')
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(false)
+    })
+  })
 })

--- a/src/main/handlers/ghComments.ts
+++ b/src/main/handlers/ghComments.ts
@@ -29,12 +29,18 @@ async function fetchPrFeedbackStatus(repoDir: string, prNumber: number): Promise
     const login = userResult.stdout.trim()
     if (!slug || !login) return false
 
+    // Exclude the PR author and bot accounts. Bots (GitHub Apps like
+    // github-actions[bot], dependabot[bot], deployment bots announcing a
+    // staging URL) have .user.type == "Bot" and are not actionable reviewer
+    // feedback.
+    const humanReviewerFilter = `select(.user.login != "${login}" and .user.type != "Bot")`
+
     // Fetch in parallel: reviews, requested reviewers, last push time, comments
     const [reviewsResult, requestedResult, lastPushResult, prCommentsResult, issueCommentsResult] = await Promise.all([
-      // All reviews on this PR
+      // All reviews on this PR (exclude bot reviews)
       execFileAsync('gh', [
         'api', `repos/${slug}/pulls/${prNumber}/reviews`, '--jq',
-        '[.[] | {author: .user.login, state: .state}]',
+        '[.[] | select(.user.type != "Bot") | {author: .user.login, state: .state}]',
       ], { cwd: dir, encoding: 'utf-8', timeout: 15000 }),
       // Currently requested reviewers
       execFileAsync('gh', [
@@ -49,12 +55,12 @@ async function fetchPrFeedbackStatus(repoDir: string, prNumber: number): Promise
       // Review comments (inline code comments)
       execFileAsync('gh', [
         'api', `repos/${slug}/pulls/${prNumber}/comments`, '--jq',
-        `[.[] | select(.user.login != "${login}") | .created_at]`,
+        `[.[] | ${humanReviewerFilter} | .created_at]`,
       ], { cwd: dir, encoding: 'utf-8', timeout: 15000 }),
       // Issue comments (top-level PR comments)
       execFileAsync('gh', [
         'api', `repos/${slug}/issues/${prNumber}/comments`, '--jq',
-        `[.[] | select(.user.login != "${login}") | .created_at]`,
+        `[.[] | ${humanReviewerFilter} | .created_at]`,
       ], { cwd: dir, encoding: 'utf-8', timeout: 15000 }),
     ])
 

--- a/src/main/handlers/ghCore.test.ts
+++ b/src/main/handlers/ghCore.test.ts
@@ -353,6 +353,48 @@ describe('ghCore handlers', () => {
       expect(result).toBe('failed')
     })
 
+    it('returns passed when a check is skipped', async () => {
+      vi.mocked(execFile).mockResolvedValue({ stdout: 'SUCCESS\nSKIPPED\n', stderr: '' } as never)
+      const handlers = setupHandlers()
+      const result = await handlers['gh:prChecksStatus'](null, '/repo')
+      expect(result).toBe('passed')
+    })
+
+    it('returns passed when a check is neutral', async () => {
+      vi.mocked(execFile).mockResolvedValue({ stdout: 'SUCCESS\nNEUTRAL\n', stderr: '' } as never)
+      const handlers = setupHandlers()
+      const result = await handlers['gh:prChecksStatus'](null, '/repo')
+      expect(result).toBe('passed')
+    })
+
+    it('returns passed when a check is stale (superseded by newer push)', async () => {
+      vi.mocked(execFile).mockResolvedValue({ stdout: 'SUCCESS\nSTALE\n', stderr: '' } as never)
+      const handlers = setupHandlers()
+      const result = await handlers['gh:prChecksStatus'](null, '/repo')
+      expect(result).toBe('passed')
+    })
+
+    it('returns passed when a check is cancelled', async () => {
+      vi.mocked(execFile).mockResolvedValue({ stdout: 'SUCCESS\nCANCELLED\n', stderr: '' } as never)
+      const handlers = setupHandlers()
+      const result = await handlers['gh:prChecksStatus'](null, '/repo')
+      expect(result).toBe('passed')
+    })
+
+    it('returns failed for ERROR state', async () => {
+      vi.mocked(execFile).mockResolvedValue({ stdout: 'SUCCESS\nERROR\n', stderr: '' } as never)
+      const handlers = setupHandlers()
+      const result = await handlers['gh:prChecksStatus'](null, '/repo')
+      expect(result).toBe('failed')
+    })
+
+    it('returns failed for TIMED_OUT conclusion', async () => {
+      vi.mocked(execFile).mockResolvedValue({ stdout: 'SUCCESS\nTIMED_OUT\n', stderr: '' } as never)
+      const handlers = setupHandlers()
+      const result = await handlers['gh:prChecksStatus'](null, '/repo')
+      expect(result).toBe('failed')
+    })
+
     it('returns none when no checks exist', async () => {
       vi.mocked(execFile).mockResolvedValue({ stdout: '', stderr: '' } as never)
       const handlers = setupHandlers()

--- a/src/main/handlers/ghCore.ts
+++ b/src/main/handlers/ghCore.ts
@@ -234,18 +234,22 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
         timeout: 15000,
       })
 
-      const lines = result.trim().split('\n').filter(Boolean)
+      const lines = result.trim().split('\n').filter(Boolean).map(l => l.trim().toUpperCase())
 
       // No checks configured
       if (lines.length === 0) return 'none'
 
       // Any check still running
-      if (lines.some(l => ['PENDING', 'QUEUED', 'IN_PROGRESS', ''].includes(l.trim().toUpperCase()))) return 'pending'
+      const PENDING_STATES = new Set(['PENDING', 'QUEUED', 'IN_PROGRESS', 'WAITING', 'REQUESTED', ''])
+      if (lines.some(l => PENDING_STATES.has(l))) return 'pending'
 
-      // All checks must have succeeded
-      if (lines.every(l => l.trim().toUpperCase() === 'SUCCESS')) return 'passed'
+      // Only real failures count. SKIPPED, NEUTRAL, STALE, and CANCELLED are not
+      // genuine failures — skipped/neutral checks intentionally don't fail the
+      // build, and stale/cancelled runs have been superseded by newer pushes.
+      const FAILURE_STATES = new Set(['FAILURE', 'ERROR', 'TIMED_OUT', 'STARTUP_FAILURE', 'ACTION_REQUIRED'])
+      if (lines.some(l => FAILURE_STATES.has(l))) return 'failed'
 
-      return 'failed'
+      return 'passed'
     } catch {
       // No PR or gh error — treat as no checks
       return 'none'


### PR DESCRIPTION
## Background and Motivation

Broomy's session status chips were over-reporting two states:

- **FAILED** was appearing on PRs whose CI had not genuinely failed. Investigation showed `prChecksStatus` treated any non-`SUCCESS`, non-pending check conclusion as a failure — so `SKIPPED`, `NEUTRAL`, `STALE` (superseded by newer push), and `CANCELLED` checks all tripped the red FAILED badge.
- **FEEDBACK** was appearing for PRs whose only new activity was from bots. The jq filter in `prFeedbackStatus` only excluded the current user's own comments, so GitHub App bot comments (staging-deploy notices, `github-actions[bot]`, `vercel[bot]`, etc.) counted as reviewer feedback.

FEEDBACK should only fire on comments from actual human reviewers. FAILED should only fire on genuine CI failures.

## Design Decisions

- **Failure conclusions are now an explicit allow-list.** Rather than "everything that isn't a success or pending state," only `FAILURE`, `ERROR`, `TIMED_OUT`, `STARTUP_FAILURE`, and `ACTION_REQUIRED` count. `SKIPPED` and `NEUTRAL` are intentional non-failures; `STALE` and `CANCELLED` typically mean a newer push has superseded the run and the old status is no longer meaningful.
- **Bot filtering uses GitHub's authoritative `.user.type == "Bot"` field** rather than pattern-matching `[bot]` suffixes on login names. This correctly catches all GitHub App identities without maintaining a hand-curated list.
- Bot filtering is applied in three places: the reviews endpoint (unlikely but possible that a GitHub App submits a formal review), and both comment endpoints (`/pulls/.../comments` for inline review comments, `/issues/.../comments` for top-level PR comments).
- The pending state set was also broadened to include `WAITING` and `REQUESTED`, which are valid in-flight states on some GitHub App status contexts.

## Proposed Changes

**`src/main/handlers/ghCore.ts` — `gh:prChecksStatus` handler**
- Normalize check conclusions once up front (uppercase + trim).
- Switch from "only SUCCESS passes" to an explicit `FAILURE_STATES` allow-list; anything else non-pending is treated as passing.
- Add `WAITING` and `REQUESTED` to the pending-state set.

**`src/main/handlers/ghComments.ts` — `fetchPrFeedbackStatus`**
- Hoist the human-reviewer jq predicate into a single shared string that filters out both the PR author's own comments and any account with `.user.type == "Bot"`.
- Apply bot exclusion to the reviews query as well.

## Testing

- Extended `ghCore.test.ts` with cases confirming `SKIPPED`, `NEUTRAL`, `STALE`, and `CANCELLED` resolve to `passed`, while `ERROR` and `TIMED_OUT` resolve to `failed`.
- Added a new `gh:prFeedbackStatus` test block (previously untested) covering: E2E short-circuit, unresolved `CHANGES_REQUESTED` → `true`, resolved-by-re-request → `false`, post-push human comments → `true`, pre-push comments → `false`, jq-filter inspection to assert `.user.type != "Bot"` appears in the reviews + both comment queries, and error handling.
- Full suite: 3301 unit tests passing, lint clean, typecheck clean, `check:all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)