### PR TITLE
fix(clone): bullet-proof the clone repo dialog

### DIFF
--- a/src/main/handlers/gitBranch.test.ts
+++ b/src/main/handlers/gitBranch.test.ts
@@ -30,6 +30,10 @@ vi.mock('fs', () => ({
   existsSync: vi.fn(() => true),
 }))
 
+vi.mock('fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}))
+
 vi.mock('../platform', () => ({
   normalizePath: (p: string) => p.replace(/\\/g, '/'),
 }))
@@ -136,6 +140,30 @@ describe('gitBranch handlers', () => {
       const result = await handlers['git:clone'](null, 'url', '/target')
       expect(result.success).toBe(false)
       expect(result.error).toContain('generic error')
+    })
+
+    it('creates the parent directory before cloning', async () => {
+      const { mkdir } = await import('fs/promises')
+      vi.mocked(mkdir).mockResolvedValue(undefined)
+      mockGitInstance.clone.mockResolvedValue(undefined)
+
+      const handlers = setupHandlers()
+      const result = await handlers['git:clone'](null, 'https://github.com/org/repo.git', '/target/repo/main')
+      expect(result).toEqual({ success: true })
+      expect(mkdir).toHaveBeenCalledWith('/target/repo', { recursive: true })
+    })
+
+    it('returns clear error when parent directory cannot be created', async () => {
+      const { mkdir } = await import('fs/promises')
+      vi.mocked(mkdir).mockRejectedValueOnce(new Error('EACCES: permission denied'))
+
+      const handlers = setupHandlers()
+      const result = await handlers['git:clone'](null, 'url', '/forbidden/repo/main')
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('parent folder')
+      expect(result.error).toContain('permission denied')
+      // Should not have attempted the clone
+      expect(mockGitInstance.clone).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/handlers/gitBranch.ts
+++ b/src/main/handlers/gitBranch.ts
@@ -6,6 +6,8 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import simpleGit from 'simple-git'
 import { existsSync } from 'fs'
+import { mkdir } from 'fs/promises'
+import { dirname } from 'path'
 import { getCloneErrorHint, getGitAuthHint } from '../cloneErrorHint'
 import { normalizePath } from '../platform'
 import { HandlerContext, expandHomePath } from './types'
@@ -25,8 +27,19 @@ async function handleClone(ctx: HandlerContext, url: string, targetDir: string) 
     return { success: true }
   }
 
+  const expandedTarget = expandHomePath(targetDir)
+
   try {
-    await withNonInteractive(simpleGit()).clone(url, expandHomePath(targetDir))
+    // Ensure the parent directory exists. Without this, cloning into a path
+    // like ~/repos/foo/main when ~/repos doesn't exist fails with a cryptic
+    // git error. recursive:true is a no-op when the path already exists.
+    await mkdir(dirname(expandedTarget), { recursive: true })
+  } catch (error) {
+    return { success: false, error: `Could not create parent folder for clone: ${String(error)}` }
+  }
+
+  try {
+    await withNonInteractive(simpleGit()).clone(url, expandedTarget)
     return { success: true }
   } catch (error) {
     const errorStr = String(error)

--- a/src/renderer/features/sessions/newSession/CloneView.test.tsx
+++ b/src/renderer/features/sessions/newSession/CloneView.test.tsx
@@ -31,6 +31,10 @@ beforeEach(() => {
     defaultCloneDir: '~/repos',
     addRepo: vi.fn(),
   })
+  // Default: location exists, target folder does not (so Clone isn't blocked).
+  vi.mocked(window.fs.exists).mockImplementation((path: string) =>
+    Promise.resolve(path === '~/repos')
+  )
 })
 
 describe('CloneView', () => {
@@ -264,6 +268,95 @@ describe('CloneView', () => {
       expect(screen.queryByText('Install GitHub CLI')).toBeNull()
     })
 
+  })
+
+  describe('inline guidance', () => {
+    it('shows path preview with placeholder repo name when URL is empty', () => {
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      expect(screen.getByText(/<repo>\/main/)).toBeTruthy()
+    })
+
+    it('shows blocking reason when URL is empty', () => {
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      expect(screen.getByText(/Enter a repository URL/i)).toBeTruthy()
+    })
+
+    it('shows inline error for a GitHub tree URL', () => {
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      const urlInput = screen.getByPlaceholderText(/https:\/\/github\.com/)
+      fireEvent.change(urlInput, { target: { value: 'https://github.com/user/repo/tree/main' } })
+      // Error appears both under the input and above the button
+      expect(screen.getAllByText(/tree page/i).length).toBeGreaterThan(0)
+    })
+
+    it('shows blocking reason for invalid URL', () => {
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      const urlInput = screen.getByPlaceholderText(/https:\/\/github\.com/)
+      fireEvent.change(urlInput, { target: { value: 'not a url' } })
+      // Both inline (under input) and above button — at least one must appear
+      expect(screen.getAllByText(/HTTPS URL/i).length).toBeGreaterThan(0)
+    })
+
+    it('disables Clone for an invalid URL', () => {
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      const urlInput = screen.getByPlaceholderText(/https:\/\/github\.com/)
+      fireEvent.change(urlInput, { target: { value: 'https://github.com/user/repo/tree/main' } })
+      expect(screen.getByText('Clone').hasAttribute('disabled')).toBe(true)
+    })
+
+    it('shows "folder will be created" hint when location does not exist', async () => {
+      vi.mocked(window.fs.exists).mockResolvedValue(false)
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      await waitFor(() => {
+        expect(screen.getByText(/will be created/i)).toBeTruthy()
+      })
+    })
+
+    it('blocks Clone when target folder already exists', async () => {
+      vi.mocked(window.fs.exists).mockResolvedValue(true)
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      const urlInput = screen.getByPlaceholderText(/https:\/\/github\.com/)
+      fireEvent.change(urlInput, { target: { value: 'https://github.com/user/test.git' } })
+      await waitFor(() => {
+        expect(screen.getAllByText(/already exists/i).length).toBeGreaterThan(0)
+      })
+      expect(screen.getByText('Clone').hasAttribute('disabled')).toBe(true)
+    })
+
+    it('triggers clone when Enter is pressed in the URL field', async () => {
+      vi.mocked(window.git.clone).mockResolvedValue({ success: true })
+      vi.mocked(window.git.defaultBranch).mockResolvedValue('main')
+      vi.mocked(window.git.remoteUrl).mockResolvedValue('https://github.com/user/test.git')
+      vi.mocked(window.gh.hasWriteAccess).mockResolvedValue(true)
+      vi.mocked(window.config.load).mockResolvedValue({ agents: [], sessions: [], repos: [{ id: 'repo-1', name: 'test', remoteUrl: 'https://github.com/user/test.git', rootDir: '~/repos/test', defaultBranch: 'main' }] })
+
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      const urlInput = screen.getByPlaceholderText(/https:\/\/github\.com/)
+      fireEvent.change(urlInput, { target: { value: 'https://github.com/user/test.git' } })
+      fireEvent.keyDown(urlInput, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(window.git.clone).toHaveBeenCalled()
+      })
+    })
+
+    it('does not trigger clone when Enter is pressed and Clone is blocked', () => {
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      const urlInput = screen.getByPlaceholderText(/https:\/\/github\.com/)
+      fireEvent.keyDown(urlInput, { key: 'Enter' })
+      expect(window.git.clone).not.toHaveBeenCalled()
+    })
+
+    it('accepts owner/repo shorthand', () => {
+      render(<CloneView onBack={vi.fn()} onComplete={vi.fn()} />)
+      const urlInput = screen.getByPlaceholderText(/https:\/\/github\.com/)
+      fireEvent.change(urlInput, { target: { value: 'user/my-repo' } })
+      expect(screen.getByText(/my-repo\/main/)).toBeTruthy()
+      expect(screen.getByText('Clone').hasAttribute('disabled')).toBe(false)
+    })
+  })
+
+  describe('auth terminal flow', () => {
     it('creates PTY and shows auth terminal when gh available and auth button clicked', async () => {
       vi.mocked(window.git.clone).mockResolvedValue({ success: false, error: 'fatal: could not read Username' })
       vi.mocked(window.app.homedir).mockResolvedValue('/home/user')

--- a/src/renderer/features/sessions/newSession/CloneView.tsx
+++ b/src/renderer/features/sessions/newSession/CloneView.tsx
@@ -7,7 +7,9 @@ import { useRepoStore } from '../../../store/repos'
 import { DialogErrorBanner } from '../../../shared/components/ErrorBanner'
 import { AuthSetupSection } from '../../../shared/components/AuthSetupSection'
 import { IsolationSettings } from '../../../shared/components/IsolationSettings'
-import type { DevcontainerStatus } from '../../../../preload/index'
+import type { DevcontainerStatus, AgentData } from '../../../../preload/index'
+import { parseCloneUrl, type ParsedCloneUrl } from './cloneUrl'
+import { useLocationStatus, type LocationStatus } from './useLocationStatus'
 
 function NoWriteAccessBanner({ onContinue }: { onContinue?: () => void }) {
   return (
@@ -27,6 +29,200 @@ function NoWriteAccessBanner({ onContinue }: { onContinue?: () => void }) {
       )}
     </div>
   )
+}
+
+function UrlField({
+  url, setUrl, parsed, onSubmit,
+}: {
+  url: string
+  setUrl: (v: string) => void
+  parsed: ParsedCloneUrl
+  onSubmit: () => void
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-text-secondary mb-1">Repository URL</label>
+      <input
+        type="text"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            onSubmit()
+          }
+        }}
+        placeholder="https://github.com/user/repo.git or git@github.com:user/repo.git"
+        className="w-full px-3 py-2 text-sm rounded border border-border bg-bg-primary text-text-primary placeholder-text-secondary focus:outline-none focus:border-accent"
+        autoFocus
+      />
+      {url.trim() && parsed.error ? (
+        <p className="text-xs text-red-400 mt-1">{parsed.error}</p>
+      ) : (
+        <p className="text-xs text-text-secondary mt-1">HTTPS (https://github.com/...), SSH (git@github.com:...), or owner/repo</p>
+      )}
+    </div>
+  )
+}
+
+function LocationField({
+  location, setLocation, status, repoName, onBrowse,
+}: {
+  location: string
+  setLocation: (v: string) => void
+  status: LocationStatus
+  repoName: string
+  onBrowse: () => void
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-text-secondary mb-1">Location</label>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          className="flex-1 px-3 py-2 text-sm rounded border border-border bg-bg-primary text-text-primary focus:outline-none focus:border-accent"
+        />
+        <button
+          onClick={onBrowse}
+          className="px-3 py-2 text-sm rounded border border-border bg-bg-primary hover:bg-bg-tertiary text-text-secondary transition-colors"
+        >
+          Browse
+        </button>
+      </div>
+      {status.kind === 'will-create' && (
+        <p className="text-xs text-text-secondary mt-1">
+          <span className="text-yellow-400">⚠</span> This folder doesn't exist yet — it will be created.
+        </p>
+      )}
+      {status.kind === 'target-exists' && (
+        <p className="text-xs text-red-400 mt-1">
+          A folder named "{repoName}" already exists here. Pick a different location or remove the existing folder.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function PathPreview({ path }: { path: string }) {
+  return (
+    <div className="text-xs text-text-secondary">
+      Will clone to: <span className="font-mono text-text-primary">{path}</span>
+      <span className="text-text-secondary" title="Broomy keeps the main checkout in a 'main/' subfolder so additional worktrees (parallel branches) can sit alongside it.">
+        {' '}<span className="underline decoration-dotted cursor-help">Why /main/?</span>
+      </span>
+    </div>
+  )
+}
+
+function AgentField({
+  agents, selectedAgentId, setSelectedAgentId,
+}: {
+  agents: AgentData[]
+  selectedAgentId: string | null
+  setSelectedAgentId: (id: string | null) => void
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-text-secondary mb-1">Agent</label>
+      <select
+        value={selectedAgentId || ''}
+        onChange={(e) => setSelectedAgentId(e.target.value || null)}
+        className="w-full px-3 py-2 text-sm rounded border border-border bg-bg-primary text-text-primary focus:outline-none focus:border-accent"
+      >
+        {agents.map((a) => (
+          <option key={a.id} value={a.id}>{a.name}</option>
+        ))}
+        <option value="">Shell Only</option>
+      </select>
+    </div>
+  )
+}
+
+function InitScriptField({
+  initScript, setInitScript, show, setShow,
+}: {
+  initScript: string
+  setInitScript: (v: string) => void
+  show: boolean
+  setShow: (v: boolean) => void
+}) {
+  return (
+    <div>
+      <button
+        onClick={() => setShow(!show)}
+        className="text-xs text-text-secondary hover:text-text-primary transition-colors flex items-center gap-1"
+      >
+        <svg className={`w-3 h-3 transition-transform ${show ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+        Init Script
+      </button>
+      {show && (
+        <textarea
+          value={initScript}
+          onChange={(e) => setInitScript(e.target.value)}
+          placeholder="#!/bin/bash&#10;# Runs in each new worktree&#10;cp ../main/.env .env"
+          className="w-full mt-1 px-3 py-2 text-xs font-mono rounded border border-border bg-bg-primary text-text-primary placeholder-text-secondary focus:outline-none focus:border-accent resize-y"
+          rows={3}
+        />
+      )}
+    </div>
+  )
+}
+
+function CloneFooter({
+  blockingReason, canClone, loading, onBack, onClone,
+}: {
+  blockingReason: string | null
+  canClone: boolean
+  loading: boolean
+  onBack: () => void
+  onClone: () => void
+}) {
+  return (
+    <div className="px-4 py-3 border-t border-border">
+      {blockingReason && (
+        <p className="text-xs text-text-secondary mb-2 text-right">{blockingReason}</p>
+      )}
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={onBack}
+          className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onClone}
+          disabled={!canClone}
+          className="px-4 py-2 text-sm rounded bg-accent text-white hover:bg-accent/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {loading ? 'Cloning...' : 'Clone'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function computeBlockingReason(args: {
+  loading: boolean
+  url: string
+  parsed: ParsedCloneUrl
+  cleanedLocation: string
+  repoName: string
+  status: LocationStatus
+}): string | null {
+  const { loading, url, parsed, cleanedLocation, repoName, status } = args
+  if (loading) return null
+  if (!url.trim()) return 'Enter a repository URL to continue.'
+  if (parsed.error) return parsed.error
+  if (!repoName) return 'Could not derive a folder name from this URL.'
+  if (!cleanedLocation) return 'Choose a location to clone into.'
+  if (status.kind === 'target-exists') {
+    return `A folder named "${repoName}" already exists at this location. Pick a different location or remove the existing folder.`
+  }
+  return null
 }
 
 export function CloneView({
@@ -58,35 +254,36 @@ export function CloneView({
     }
   }, [isolated])
 
-  // Derive repo name from URL
-  const repoName = url
-    .replace(/\.git$/, '')
-    .split('/')
-    .pop()
-    ?.replace(/[^a-zA-Z0-9._-]/g, '') || ''
+  const parsed = parseCloneUrl(url)
+  const repoName = parsed.repoName
+  const cleanedLocation = location.trim().replace(/\/+$/, '')
+  const previewRepoName = repoName || '<repo>'
+  const previewPath = cleanedLocation
+    ? `${cleanedLocation}/${previewRepoName}/main/`
+    : `<location>/${previewRepoName}/main/`
+  const locationStatus = useLocationStatus(cleanedLocation, repoName)
+  const blockingReason = computeBlockingReason({ loading, url, parsed, cleanedLocation, repoName, status: locationStatus })
+  const canClone = blockingReason === null && !loading
 
   const handleClone = async () => {
-    if (!url || !location || !repoName) return
+    if (!canClone) return
     setLoading(true)
     setError(null)
     setNoWriteAccess(false)
     setPendingComplete(null)
 
     try {
-      const rootDir = `${location}/${repoName}`
+      const rootDir = `${cleanedLocation}/${repoName}`
       const mainDir = `${rootDir}/main`
 
-      // Clone into rootDir/main/
-      const cloneResult = await window.git.clone(url, mainDir)
+      const cloneResult = await window.git.clone(parsed.url, mainDir)
       if (!cloneResult.success) {
         throw new Error(cloneResult.error || 'Clone failed')
       }
 
-      // Detect default branch and remote URL
       const defaultBranch = await window.git.defaultBranch(mainDir)
-      const remoteUrl = await window.git.remoteUrl(mainDir) || url
+      const remoteUrl = await window.git.remoteUrl(mainDir) || parsed.url
 
-      // Check write access to enable merge button by default
       let hasWriteAccess = false
       try {
         hasWriteAccess = await window.gh.hasWriteAccess(mainDir)
@@ -98,7 +295,6 @@ export function CloneView({
         setNoWriteAccess(true)
       }
 
-      // Save managed repo with default agent
       addRepo({
         name: repoName,
         remoteUrl,
@@ -110,17 +306,14 @@ export function CloneView({
         skipApproval: skipApproval || undefined,
       })
 
-      // Get the repo ID that was just created
       const config = await window.config.load()
       const newRepo = config.repos?.find((r: { name: string }) => r.name === repoName)
       const repoId = newRepo?.id
 
-      // Optionally save and run init script
       if (initScript.trim() && repoId) {
         await window.repos.saveInitScript(repoId, initScript)
       }
 
-      // If no write access, pause to show warning before completing
       if (!hasWriteAccess) {
         setPendingComplete({ dir: mainDir, agentId: selectedAgentId, extra: { repoId, name: repoName } })
         return
@@ -139,6 +332,10 @@ export function CloneView({
     if (folder) setLocation(folder)
   }
 
+  const triggerCloneFromKey = () => {
+    if (canClone) void handleClone()
+  }
+
   return (
     <>
       <div className="px-4 py-3 border-b border-border flex items-center gap-2">
@@ -151,113 +348,33 @@ export function CloneView({
       </div>
 
       <div className="p-4 space-y-3">
-        <div>
-          <label className="block text-xs font-medium text-text-secondary mb-1">Repository URL</label>
-          <input
-            type="text"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            placeholder="https://github.com/user/repo.git or git@github.com:user/repo.git"
-            className="w-full px-3 py-2 text-sm rounded border border-border bg-bg-primary text-text-primary placeholder-text-secondary focus:outline-none focus:border-accent"
-            autoFocus
-          />
-          <p className="text-xs text-text-secondary mt-1">HTTPS (https://github.com/...) or SSH (git@github.com:...)</p>
-        </div>
-
-        <div>
-          <label className="block text-xs font-medium text-text-secondary mb-1">Location</label>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
-              className="flex-1 px-3 py-2 text-sm rounded border border-border bg-bg-primary text-text-primary focus:outline-none focus:border-accent"
-            />
-            <button
-              onClick={handleBrowseLocation}
-              className="px-3 py-2 text-sm rounded border border-border bg-bg-primary hover:bg-bg-tertiary text-text-secondary transition-colors"
-            >
-              Browse
-            </button>
-          </div>
-        </div>
-
-        {repoName && (
-          <div className="text-xs text-text-secondary">
-            Will clone to: <span className="font-mono text-text-primary">{location}/{repoName}/main/</span>
-          </div>
-        )}
-
-        <div>
-          <label className="block text-xs font-medium text-text-secondary mb-1">Agent</label>
-          <select
-            value={selectedAgentId || ''}
-            onChange={(e) => setSelectedAgentId(e.target.value || null)}
-            className="w-full px-3 py-2 text-sm rounded border border-border bg-bg-primary text-text-primary focus:outline-none focus:border-accent"
-          >
-            {agents.map((a) => (
-              <option key={a.id} value={a.id}>{a.name}</option>
-            ))}
-            <option value="">Shell Only</option>
-          </select>
-        </div>
-
+        <UrlField url={url} setUrl={setUrl} parsed={parsed} onSubmit={triggerCloneFromKey} />
+        <LocationField location={location} setLocation={setLocation} status={locationStatus} repoName={repoName} onBrowse={() => void handleBrowseLocation()} />
+        <PathPreview path={previewPath} />
+        <AgentField agents={agents} selectedAgentId={selectedAgentId} setSelectedAgentId={setSelectedAgentId} />
         <IsolationSettings
           isolated={isolated} skipApproval={skipApproval}
           dockerStatus={null} devcontainerStatus={devcontainerStatus}
           hasDevcontainerConfig={null}
           onIsolatedChange={setIsolated} onSkipApprovalChange={setSkipApproval}
         />
-
-        <div>
-          <button
-            onClick={() => setShowInitScript(!showInitScript)}
-            className="text-xs text-text-secondary hover:text-text-primary transition-colors flex items-center gap-1"
-          >
-            <svg className={`w-3 h-3 transition-transform ${showInitScript ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-            Init Script
-          </button>
-          {showInitScript && (
-            <textarea
-              value={initScript}
-              onChange={(e) => setInitScript(e.target.value)}
-              placeholder="#!/bin/bash&#10;# Runs in each new worktree&#10;cp ../main/.env .env"
-              className="w-full mt-1 px-3 py-2 text-xs font-mono rounded border border-border bg-bg-primary text-text-primary placeholder-text-secondary focus:outline-none focus:border-accent resize-y"
-              rows={3}
-            />
-          )}
-        </div>
-
-        {error && (
-          <DialogErrorBanner error={error} onDismiss={() => setError(null)} />
-        )}
-
+        <InitScriptField initScript={initScript} setInitScript={setInitScript} show={showInitScript} setShow={setShowInitScript} />
+        {error && <DialogErrorBanner error={error} onDismiss={() => setError(null)} />}
         {noWriteAccess && (
           <NoWriteAccessBanner
             onContinue={pendingComplete ? () => onComplete(pendingComplete.dir, pendingComplete.agentId, pendingComplete.extra) : undefined}
           />
         )}
-
         <AuthSetupSection error={error} ghAvailable={ghAvailable} onRetry={handleClone} retryLabel="Retry Clone" />
       </div>
 
-      <div className="px-4 py-3 border-t border-border flex justify-end gap-2">
-        <button
-          onClick={onBack}
-          className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={handleClone}
-          disabled={!url || !location || !repoName || loading}
-          className="px-4 py-2 text-sm rounded bg-accent text-white hover:bg-accent/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {loading ? 'Cloning...' : 'Clone'}
-        </button>
-      </div>
+      <CloneFooter
+        blockingReason={blockingReason}
+        canClone={canClone}
+        loading={loading}
+        onBack={onBack}
+        onClone={() => void handleClone()}
+      />
     </>
   )
 }

--- a/src/renderer/features/sessions/newSession/cloneUrl.test.ts
+++ b/src/renderer/features/sessions/newSession/cloneUrl.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { parseCloneUrl } from './cloneUrl'
+
+describe('parseCloneUrl', () => {
+  it('returns empty (no error) for empty input', () => {
+    const r = parseCloneUrl('')
+    expect(r).toEqual({ url: '', repoName: '', error: null })
+  })
+
+  it('returns empty (no error) for whitespace only', () => {
+    const r = parseCloneUrl('   ')
+    expect(r).toEqual({ url: '', repoName: '', error: null })
+  })
+
+  it('parses an HTTPS .git URL', () => {
+    const r = parseCloneUrl('https://github.com/user/my-repo.git')
+    expect(r).toEqual({
+      url: 'https://github.com/user/my-repo.git',
+      repoName: 'my-repo',
+      error: null,
+    })
+  })
+
+  it('parses an HTTPS URL without .git suffix', () => {
+    const r = parseCloneUrl('https://github.com/user/my-repo')
+    expect(r.url).toBe('https://github.com/user/my-repo')
+    expect(r.repoName).toBe('my-repo')
+    expect(r.error).toBeNull()
+  })
+
+  it('strips trailing slash and surrounding whitespace', () => {
+    const r = parseCloneUrl('  https://github.com/user/my-repo/  ')
+    expect(r.url).toBe('https://github.com/user/my-repo')
+    expect(r.repoName).toBe('my-repo')
+    expect(r.error).toBeNull()
+  })
+
+  it('strips surrounding quotes (common when copy-pasting)', () => {
+    const r = parseCloneUrl('"https://github.com/user/my-repo.git"')
+    expect(r.url).toBe('https://github.com/user/my-repo.git')
+    expect(r.repoName).toBe('my-repo')
+  })
+
+  it('parses an SSH URL', () => {
+    const r = parseCloneUrl('git@github.com:user/my-repo.git')
+    expect(r).toEqual({
+      url: 'git@github.com:user/my-repo.git',
+      repoName: 'my-repo',
+      error: null,
+    })
+  })
+
+  it('parses an SSH URL without .git suffix', () => {
+    const r = parseCloneUrl('git@github.com:user/my-repo')
+    expect(r.repoName).toBe('my-repo')
+    expect(r.error).toBeNull()
+  })
+
+  it('expands user/repo shorthand to GitHub HTTPS', () => {
+    const r = parseCloneUrl('user/my-repo')
+    expect(r.url).toBe('https://github.com/user/my-repo.git')
+    expect(r.repoName).toBe('my-repo')
+    expect(r.error).toBeNull()
+  })
+
+  it('rejects GitHub tree URLs with a clear error', () => {
+    const r = parseCloneUrl('https://github.com/user/my-repo/tree/main')
+    expect(r.url).toBe('')
+    expect(r.repoName).toBe('')
+    expect(r.error).toMatch(/tree page/)
+    expect(r.error).toMatch(/my-repo/)
+  })
+
+  it('rejects GitHub blob URLs', () => {
+    const r = parseCloneUrl('https://github.com/user/my-repo/blob/main/README.md')
+    expect(r.error).toMatch(/blob page/)
+  })
+
+  it('rejects GitHub pulls URLs', () => {
+    const r = parseCloneUrl('https://github.com/user/my-repo/pulls')
+    expect(r.error).toMatch(/pulls page/)
+  })
+
+  it('rejects GitHub issues URLs', () => {
+    const r = parseCloneUrl('https://github.com/user/my-repo/issues/42')
+    expect(r.error).toMatch(/issues page/)
+  })
+
+  it('rejects URL missing repository path', () => {
+    const r = parseCloneUrl('https://github.com/user')
+    expect(r.error).toMatch(/missing the repository path/i)
+  })
+
+  it('rejects garbage input with explanation', () => {
+    const r = parseCloneUrl('not a url at all')
+    expect(r.error).toMatch(/HTTPS URL/i)
+  })
+
+  it('rejects an SSH URL missing the repo segment', () => {
+    const r = parseCloneUrl('git@github.com:user')
+    expect(r.error).toMatch(/missing the repository path/i)
+  })
+
+  it('handles GitLab/Bitbucket nested paths (group/subgroup/repo)', () => {
+    const r = parseCloneUrl('https://gitlab.com/group/subgroup/my-repo.git')
+    expect(r.url).toBe('https://gitlab.com/group/subgroup/my-repo.git')
+    expect(r.repoName).toBe('my-repo')
+    expect(r.error).toBeNull()
+  })
+})

--- a/src/renderer/features/sessions/newSession/cloneUrl.ts
+++ b/src/renderer/features/sessions/newSession/cloneUrl.ts
@@ -1,0 +1,100 @@
+/**
+ * Parse and validate clone URLs entered by the user.
+ *
+ * Accepts HTTPS, SSH, and `user/repo` shorthand. Rejects GitHub web-UI
+ * sub-paths (tree/blob/pulls/etc.) so we don't end up with a "branch" or
+ * "issues" folder name. Returns the normalized URL, the derived repo name,
+ * and a human-readable error if the input isn't usable.
+ */
+
+const GITHUB_WEB_PATHS = new Set([
+  'tree', 'blob', 'pulls', 'pull', 'issues', 'issue',
+  'wiki', 'actions', 'commits', 'commit', 'branches',
+  'tags', 'releases', 'compare', 'projects', 'discussions',
+  'security', 'settings',
+])
+
+export type ParsedCloneUrl = {
+  /** URL ready to pass to `git clone`. Empty when input is empty/invalid. */
+  url: string
+  /** Folder name to use for the clone destination. */
+  repoName: string
+  /** Human-readable reason input is unusable, or null when valid. */
+  error: string | null
+}
+
+export function parseCloneUrl(input: string): ParsedCloneUrl {
+  const trimmed = input.trim().replace(/^["']|["']$/g, '')
+  if (!trimmed) {
+    return { url: '', repoName: '', error: null }
+  }
+
+  // user/repo shorthand → assume GitHub
+  if (/^[\w.-]+\/[\w.-]+$/.test(trimmed)) {
+    const repoName = trimmed.split('/')[1].replace(/\.git$/, '')
+    return {
+      url: `https://github.com/${trimmed.replace(/\.git$/, '')}.git`,
+      repoName: sanitizeRepoName(repoName),
+      error: null,
+    }
+  }
+
+  // SSH form: git@host:owner/repo(.git)
+  const sshMatch = /^[\w.-]+@[\w.-]+:([^/].*?)\/?$/.exec(trimmed)
+  if (sshMatch) {
+    const path = sshMatch[1].replace(/\.git$/, '')
+    const segments = path.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      return { url: '', repoName: '', error: 'SSH URL is missing the repository path (expected git@host:owner/repo.git).' }
+    }
+    const repoName = sanitizeRepoName(segments[segments.length - 1])
+    if (!repoName) {
+      return { url: '', repoName: '', error: 'Could not derive a folder name from this URL.' }
+    }
+    return { url: trimmed, repoName, error: null }
+  }
+
+  // HTTPS / git:// / ssh:// — anything URL-shaped
+  if (/^(https?|git|ssh):\/\//.test(trimmed)) {
+    let parsed: URL
+    try {
+      parsed = new URL(trimmed)
+    } catch {
+      return { url: '', repoName: '', error: 'That doesn\'t look like a valid URL.' }
+    }
+
+    const segments = parsed.pathname.replace(/\/$/, '').split('/').filter(Boolean)
+    if (segments.length < 2) {
+      return { url: '', repoName: '', error: 'URL is missing the repository path (expected https://host/owner/repo).' }
+    }
+
+    // Reject GitHub web-UI sub-paths like /user/repo/tree/branch
+    if (segments.length > 2 && GITHUB_WEB_PATHS.has(segments[2].toLowerCase())) {
+      return {
+        url: '',
+        repoName: '',
+        error: `This is a GitHub ${segments[2]} page, not a clone URL. Use https://${parsed.host}/${segments[0]}/${segments[1]}.git`,
+      }
+    }
+
+    const lastSegment = segments[segments.length - 1].replace(/\.git$/, '')
+    const repoName = sanitizeRepoName(lastSegment)
+    if (!repoName) {
+      return { url: '', repoName: '', error: 'Could not derive a folder name from this URL.' }
+    }
+
+    // Strip any trailing slash from the URL but keep the rest intact
+    const url = trimmed.replace(/\/+$/, '')
+    return { url, repoName, error: null }
+  }
+
+  return {
+    url: '',
+    repoName: '',
+    error: 'Enter an HTTPS URL (https://github.com/owner/repo), SSH URL (git@github.com:owner/repo.git), or owner/repo shorthand.',
+  }
+}
+
+function sanitizeRepoName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '')
+}

--- a/src/renderer/features/sessions/newSession/useLocationStatus.test.ts
+++ b/src/renderer/features/sessions/newSession/useLocationStatus.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+import '../../../../test/react-setup'
+import { useLocationStatus } from './useLocationStatus'
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  vi.mocked(window.fs.exists).mockReset()
+})
+
+describe('useLocationStatus', () => {
+  it('returns "unknown" when location is empty', () => {
+    const { result } = renderHook(() => useLocationStatus('', 'repo'))
+    expect(result.current.kind).toBe('unknown')
+  })
+
+  it('returns "will-create" when location does not exist', async () => {
+    vi.mocked(window.fs.exists).mockResolvedValue(false)
+    const { result } = renderHook(() => useLocationStatus('/some/path', 'repo'))
+    await waitFor(() => {
+      expect(result.current.kind).toBe('will-create')
+    })
+  })
+
+  it('returns "ok" when location exists and target does not', async () => {
+    vi.mocked(window.fs.exists).mockImplementation((p: string) =>
+      Promise.resolve(p === '/some/path')
+    )
+    const { result } = renderHook(() => useLocationStatus('/some/path', 'repo'))
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ok')
+    })
+  })
+
+  it('returns "target-exists" when both location and target exist', async () => {
+    vi.mocked(window.fs.exists).mockResolvedValue(true)
+    const { result } = renderHook(() => useLocationStatus('/some/path', 'repo'))
+    await waitFor(() => {
+      expect(result.current.kind).toBe('target-exists')
+    })
+  })
+
+  it('returns "ok" when location exists and repoName is empty', async () => {
+    vi.mocked(window.fs.exists).mockResolvedValue(true)
+    const { result } = renderHook(() => useLocationStatus('/some/path', ''))
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ok')
+    })
+  })
+
+  it('returns "unknown" if fs.exists rejects', async () => {
+    vi.mocked(window.fs.exists).mockRejectedValue(new Error('boom'))
+    const { result } = renderHook(() => useLocationStatus('/some/path', 'repo'))
+    // Wait long enough for the 200ms debounce + the rejected promise to flush
+    await new Promise((r) => setTimeout(r, 300))
+    expect(result.current.kind).toBe('unknown')
+  })
+
+  it('cancels pending check when unmounted before timer fires', async () => {
+    vi.mocked(window.fs.exists).mockResolvedValue(true)
+    const { unmount } = renderHook(() => useLocationStatus('/some/path', 'repo'))
+    unmount()
+    await new Promise((r) => setTimeout(r, 250))
+    expect(window.fs.exists).not.toHaveBeenCalled()
+  })
+
+  it('does not update state if aborted between awaits', async () => {
+    let resolveSecond: ((v: boolean) => void) | undefined
+    const calls: string[] = []
+    vi.mocked(window.fs.exists).mockImplementation((p: string) => {
+      calls.push(p)
+      if (p === '/some/path') return Promise.resolve(true)
+      return new Promise<boolean>((r) => { resolveSecond = r })
+    })
+
+    const { result, unmount } = renderHook(() => useLocationStatus('/some/path', 'repo'))
+    // Wait for first call to land and second call to start
+    await waitFor(() => expect(calls).toContain('/some/path/repo'))
+
+    // Unmount aborts; resolving after abort should be a no-op
+    unmount()
+    resolveSecond?.(true)
+    await new Promise((r) => setTimeout(r, 50))
+
+    // Should remain "unknown" — set state was never called after abort
+    expect(result.current.kind).toBe('unknown')
+  })
+})

--- a/src/renderer/features/sessions/newSession/useLocationStatus.ts
+++ b/src/renderer/features/sessions/newSession/useLocationStatus.ts
@@ -1,0 +1,62 @@
+/**
+ * Reactively check whether the clone location and target folder exist,
+ * so the UI can show "this folder will be created" and "target already exists"
+ * before the user clicks Clone.
+ */
+import { useEffect, useState } from 'react'
+
+export type LocationStatus =
+  | { kind: 'unknown' }
+  | { kind: 'ok' }
+  | { kind: 'will-create' }
+  | { kind: 'target-exists'; targetPath: string }
+
+export function useLocationStatus(cleanedLocation: string, repoName: string): LocationStatus {
+  const [status, setStatus] = useState<LocationStatus>({ kind: 'unknown' })
+
+  useEffect(() => {
+    if (!cleanedLocation) {
+      setStatus({ kind: 'unknown' })
+      return
+    }
+    const ac = new AbortController()
+    const handle = setTimeout(() => {
+      void checkPaths(cleanedLocation, repoName, ac.signal, setStatus)
+    }, 200)
+    return () => {
+      ac.abort()
+      clearTimeout(handle)
+    }
+  }, [cleanedLocation, repoName])
+
+  return status
+}
+
+async function checkPaths(
+  cleanedLocation: string,
+  repoName: string,
+  signal: AbortSignal,
+  setStatus: (s: LocationStatus) => void,
+): Promise<void> {
+  // Wrap aborted access in a function so the lint rule doesn't infer
+  // signal.aborted as a constant within this scope.
+  const isAborted = () => signal.aborted
+  try {
+    const locExists = await window.fs.exists(cleanedLocation)
+    if (isAborted()) return
+    if (!locExists) {
+      setStatus({ kind: 'will-create' })
+      return
+    }
+    if (!repoName) {
+      setStatus({ kind: 'ok' })
+      return
+    }
+    const targetPath = `${cleanedLocation}/${repoName}`
+    const targetExists = await window.fs.exists(targetPath)
+    if (isAborted()) return
+    setStatus(targetExists ? { kind: 'target-exists', targetPath } : { kind: 'ok' })
+  } catch {
+    if (!isAborted()) setStatus({ kind: 'unknown' })
+  }
+}

--- a/tests/features/clone-dialog-fixes/clone-dialog-fixes.spec.ts
+++ b/tests/features/clone-dialog-fixes/clone-dialog-fixes.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * Feature Documentation: Clone Repo Dialog — Bullet-Proof UX
+ *
+ * Walks through the inline guidance, validation, and folder hints that
+ * keep first-time users from getting stuck on the Clone Repository view
+ * inside the New Session dialog.
+ *
+ * Run with: pnpm test:feature-docs clone-dialog-fixes
+ */
+import { test, expect, resetApp } from '../_shared/electron-fixture'
+import type { Page, ElectronApplication } from '@playwright/test'
+import path from 'path'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+import { screenshotElement } from '../_shared/screenshot-helpers'
+import { generateFeaturePage, generateIndex, FeatureStep } from '../_shared/template'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const FEATURE_DIR = __dirname
+const SCREENSHOTS = path.join(FEATURE_DIR, 'screenshots')
+const FEATURES_ROOT = path.join(__dirname, '..')
+
+let page: Page
+let electronApp: ElectronApplication
+const steps: FeatureStep[] = []
+
+/** Replace an IPC handler in the main process with a custom response. */
+async function overrideIpcHandler(channel: string, response: unknown) {
+  await electronApp.evaluate(({ ipcMain }, { ch, resp }) => {
+    ipcMain.removeHandler(ch)
+    ipcMain.handle(ch, () => resp)
+  }, { ch: channel, resp: response })
+}
+
+/**
+ * Replace fs:exists with a function that returns true only for paths matching
+ * the given predicate. Use this to drive the "folder will be created" and
+ * "target already exists" UI states without touching the real filesystem.
+ */
+async function overrideFsExists(matcher: 'all' | 'none' | 'location-only' | 'target-only', location: string, repoName: string) {
+  await electronApp.evaluate(({ ipcMain }, args) => {
+    ipcMain.removeHandler('fs:exists')
+    const target = `${args.location}/${args.repoName}`
+    ipcMain.handle('fs:exists', (_event, p: string) => {
+      if (args.matcher === 'all') return true
+      if (args.matcher === 'none') return false
+      if (args.matcher === 'location-only') return p === args.location
+      if (args.matcher === 'target-only') return p === target
+      return false
+    })
+  }, { matcher, location, repoName })
+}
+
+async function restoreFsExists() {
+  await electronApp.evaluate(({ ipcMain }) => {
+    ipcMain.removeHandler('fs:exists')
+    // Default E2E mock returns true (exists)
+    ipcMain.handle('fs:exists', () => true)
+  })
+}
+
+test.beforeAll(async () => {
+  await fs.promises.mkdir(SCREENSHOTS, { recursive: true })
+  ;({ page, electronApp } = await resetApp())
+})
+
+test.afterAll(async () => {
+  await restoreFsExists()
+  await generateFeaturePage(
+    {
+      title: 'Clone Dialog — Bullet-Proof UX',
+      description:
+        'The Clone Repository view inside the New Session dialog now guides users through ' +
+        'every common mistake. The path preview is always visible (with placeholders before ' +
+        'fields are filled), the disabled Clone button always explains why it\'s disabled, ' +
+        'and the location field tells you whether the folder will be created, already exists, ' +
+        'or collides with an existing target.',
+      steps,
+    },
+    FEATURE_DIR,
+  )
+  await generateIndex(FEATURES_ROOT)
+})
+
+async function openCloneDialog() {
+  const newSessionBtn = page.locator('button:has-text("+ New Session")')
+  await newSessionBtn.click()
+  await expect(page.locator('h2:has-text("New Session")')).toBeVisible()
+  await page.locator('button:has-text("Clone")').click()
+  await expect(page.locator('h2:has-text("Clone Repository")')).toBeVisible()
+}
+
+async function closeDialog() {
+  await page.keyboard.press('Escape')
+  await page.keyboard.press('Escape')
+}
+
+test.describe.serial('Feature: Clone Dialog Fixes', () => {
+  test('Step 1: Empty form — preview placeholder + blocking reason', async () => {
+    await openCloneDialog()
+
+    // Path preview is visible from the start, even with no URL typed.
+    await expect(page.getByText('<repo>/main', { exact: false })).toBeVisible()
+    // Blocking reason explains why Clone is disabled.
+    await expect(page.getByText(/Enter a repository URL/i)).toBeVisible()
+
+    const dialog = page.locator('.fixed.inset-0').first()
+    await screenshotElement(page, dialog, path.join(SCREENSHOTS, '01-empty-form.png'))
+    steps.push({
+      screenshotPath: 'screenshots/01-empty-form.png',
+      caption: 'Initial state — preview placeholder and inline blocking reason',
+      description:
+        'With no URL entered, the path preview shows the location with <repo>/main/ as ' +
+        'a placeholder so the user can see exactly where the clone will land. The text ' +
+        'above the disabled Clone button explains it\'s waiting for a URL — no more silent ' +
+        'greyed-out button.',
+    })
+  })
+
+  test('Step 2: Pasting a GitHub tree URL produces a specific error', async () => {
+    const urlInput = page.locator('input[placeholder*="https://github.com"]')
+    await urlInput.fill('https://github.com/user/my-repo/tree/main')
+
+    // Inline error appears under the URL input.
+    await expect(page.getByText(/tree page, not a clone URL/i).first()).toBeVisible()
+    // Clone button stays disabled.
+    const cloneBtn = page.locator('button:has-text("Clone")').last()
+    await expect(cloneBtn).toBeDisabled()
+
+    const dialog = page.locator('.fixed.inset-0').first()
+    await screenshotElement(page, dialog, path.join(SCREENSHOTS, '02-tree-url-rejected.png'))
+    steps.push({
+      screenshotPath: 'screenshots/02-tree-url-rejected.png',
+      caption: 'GitHub web-UI URLs are rejected with a helpful suggestion',
+      description:
+        'Pasting a /tree/, /blob/, /pulls/, or /issues/ URL is a common mistake — git ' +
+        'clone would fail with a cryptic 404. Broomy detects these and points to the ' +
+        'correct clone URL inline.',
+    })
+  })
+
+  test('Step 3: Valid URL with non-existent location — "folder will be created"', async () => {
+    // Force fs:exists to return false so we get the "will be created" hint.
+    await overrideFsExists('none', '', '')
+
+    const urlInput = page.locator('input[placeholder*="https://github.com"]')
+    await urlInput.fill('https://github.com/user/my-repo.git')
+
+    // Path preview now shows the actual repo name.
+    await expect(page.getByText(/my-repo\/main/).first()).toBeVisible()
+    // "Folder will be created" hint appears under the location field.
+    await expect(page.getByText(/will be created/i)).toBeVisible({ timeout: 3000 })
+
+    const dialog = page.locator('.fixed.inset-0').first()
+    await screenshotElement(page, dialog, path.join(SCREENSHOTS, '03-folder-will-be-created.png'))
+    steps.push({
+      screenshotPath: 'screenshots/03-folder-will-be-created.png',
+      caption: 'Missing parent folder is announced — and the IPC handler creates it',
+      description:
+        'When the chosen location doesn\'t exist yet, the dialog says so explicitly. ' +
+        'Previously, clone would silently fail with a cryptic git error. The clone ' +
+        'handler now mkdir -p\'s the parent before invoking simple-git.',
+    })
+  })
+
+  test('Step 4: Target folder collision — clear blocker', async () => {
+    // Both location AND target exist — should block with collision message.
+    await overrideFsExists('all', '', '')
+
+    // Force a re-evaluation by tweaking the URL.
+    const urlInput = page.locator('input[placeholder*="https://github.com"]')
+    await urlInput.fill('')
+    await urlInput.fill('https://github.com/user/my-repo.git')
+
+    await expect(page.getByText(/already exists/i).first()).toBeVisible({ timeout: 3000 })
+    const cloneBtn = page.locator('button:has-text("Clone")').last()
+    await expect(cloneBtn).toBeDisabled()
+
+    const dialog = page.locator('.fixed.inset-0').first()
+    await screenshotElement(page, dialog, path.join(SCREENSHOTS, '04-target-exists.png'))
+    steps.push({
+      screenshotPath: 'screenshots/04-target-exists.png',
+      caption: 'Target folder collision blocks Clone with a specific message',
+      description:
+        'If a folder with the same repo name already lives at the location, the dialog ' +
+        'flags the collision and disables Clone. The blocking reason above the button ' +
+        'tells the user to pick a different location or remove the existing folder.',
+    })
+  })
+
+  test('Step 5: Ready to clone — preview shows full destination path', async () => {
+    // Restore so location exists, target does not — clean ready state.
+    await overrideFsExists('location-only', '/Users/test/repos', 'my-repo')
+
+    const locationInput = page.locator('input').nth(1)
+    await locationInput.fill('/Users/test/repos')
+
+    const urlInput = page.locator('input[placeholder*="https://github.com"]')
+    await urlInput.fill('')
+    await urlInput.fill('https://github.com/user/my-repo.git')
+
+    // Path preview shows the precise destination, including /main/.
+    await expect(page.locator('span.font-mono').filter({ hasText: /my-repo\/main\/$/ })).toBeVisible({ timeout: 3000 })
+    const cloneBtn = page.locator('button:has-text("Clone")').last()
+    await expect(cloneBtn).toBeEnabled()
+
+    const dialog = page.locator('.fixed.inset-0').first()
+    await screenshotElement(page, dialog, path.join(SCREENSHOTS, '05-ready-to-clone.png'))
+    steps.push({
+      screenshotPath: 'screenshots/05-ready-to-clone.png',
+      caption: 'All inputs valid — Clone button is enabled and the path is unambiguous',
+      description:
+        'With a valid URL, an existing location, and no target collision, the Clone ' +
+        'button enables and the preview shows the full destination path. The "Why /main/?" ' +
+        'tooltip explains the worktree convention so users aren\'t surprised by the subfolder.',
+    })
+
+    await closeDialog()
+  })
+})


### PR DESCRIPTION
## Summary

A first-time user trying to clone a repo via the New Session dialog hit several silent failures and confusing UI states. This PR makes the dialog robust to the most common mistakes and adds inline guidance so users can self-correct without needing the developer console.

## Background and Motivation

Three concrete usability bugs reported from a fresh user:

1. **Missing parent folder silently failed.** Default clone location was \`~/repos\`, but the user didn't have that folder yet. The clone IPC handler called \`simpleGit().clone()\` directly with no \`mkdir -p\`, so git emitted a cryptic error and the user assumed Broomy was broken.
2. **Confusion about the destination path.** The dialog cloned to \`{location}/{repoName}/main/\` but only revealed the path *after* a valid URL was typed, and never explained the \`/main/\` subfolder. Users couldn't predict where their files would land.
3. **Greyed-out Clone button with no reason.** A single \`disabled={!url || !location || !repoName || loading}\` collapsed three independent failure modes into a silent disabled state.

While in here, I also found and fixed several adjacent rough edges (URL parsing of GitHub web-UI sub-paths, \`Enter\` key not submitting, target folder collisions, etc.).

## Design Decisions

- **URL parsing pulled out into a pure helper** (\`cloneUrl.ts\`). Returns \`{ url, repoName, error }\` so the renderer can show field-level validation without coupling to the input element. Accepts HTTPS, SSH, and \`owner/repo\` shorthand; rejects \`/tree/\`, \`/blob/\`, \`/pulls\`, \`/issues\` web-UI URLs with a specific message that suggests the right URL.
- **Folder existence check via debounced hook** (\`useLocationStatus.ts\`). Uses an \`AbortController\` to cancel in-flight \`fs.exists\` calls when the location/repo changes mid-flight. Returns one of four states (\`unknown | ok | will-create | target-exists\`) so the UI can show the right hint.
- **Inline blocking-reason text above the Clone button** instead of a silent disabled state. Each precondition (no URL, unparseable URL, no location, target exists) gets its own message.
- **\`mkdir -p\` happens in the main-process handler**, not the renderer. The renderer doesn't have access to \`fs/promises\`, and centralizing it means future call sites (e.g. the Add Existing Repo flow, if it ever clones) get the same behavior for free.
- **Used \`onKeyDown\` Enter handler instead of wrapping inputs in \`<form>\`.** A form would have made the AuthSetupSection's buttons default to \`type=\"submit\"\`, accidentally re-triggering Clone when the user clicked \"Set up Git Authentication\". The shared component lives outside this dialog so I didn't want to push \`type=\"button\"\` into it.
- **Refactored \`CloneView\` into smaller sub-components** (\`UrlField\`, \`LocationField\`, \`PathPreview\`, \`AgentField\`, \`InitScriptField\`, \`CloneFooter\`) to keep the main function under the project's 200-line limit and make the JSX readable.

## Proposed Changes

**URL handling**
- New \`parseCloneUrl()\` trims, strips quotes, and normalizes input. Accepts HTTPS, SSH, and \`user/repo\` shorthand. Rejects GitHub web-UI sub-paths with a hint to use the clone URL instead.
- Inline error appears under the URL input when the URL is unusable.

**Path preview**
- Always visible — uses \`<repo>\` and \`<location>\` placeholders before the user fills in the fields.
- Tooltip explains the \`/main/\` subfolder convention (so additional worktrees can sit alongside).

**Folder feedback**
- \"This folder will be created\" hint when the location doesn't exist yet.
- \"A folder named X already exists here\" blocking message when the target collides.

**Disabled-button transparency**
- \`computeBlockingReason()\` returns a specific message for each unmet precondition.
- The message renders directly above the Clone button so users always know what to do next.

**Handler robustness**
- \`gitBranch.ts handleClone\` now \`mkdir -p\`s the parent directory before invoking \`simpleGit().clone()\`. Pre-existing folders are a no-op (\`recursive: true\`); permission failures surface as a clear error.

**Submission ergonomics**
- Pressing Enter in the URL field triggers Clone (when valid).

**Testing**
- New \`cloneUrl.test.ts\` (16 cases) covers the parser including edge cases like trailing slashes, surrounding quotes, GitLab nested groups, and the various GitHub web-UI sub-paths.
- New \`useLocationStatus.test.ts\` (8 cases) covers all four states plus abort-mid-flight and unmount-before-debounce cancellation.
- New \`gitBranch.test.ts\` cases verify \`mkdir\` is called with the parent directory and that \`mkdir\` failure short-circuits the clone with a clear error.
- Extended \`CloneView.test.tsx\` with 9 cases for the new inline guidance, blocking states, and Enter-key submission.

## Testing

- [x] \`pnpm validate\` — lint, typecheck, check:all, unit (3,338 tests pass), coverage (90.71% lines, above the 90% threshold)
- [x] Ran all E2E tests locally (72/72 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)