### PR TITLE
fix: reload webview when re-clicking URL already shown

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -217,7 +217,7 @@ function AppContent() {
 
   const {
     openFileInDiffMode, scrollToLine, searchHighlight, diffBaseRef, diffCurrentRef, diffLabel,
-    setIsFileViewerDirty, pendingNavigation, navigateToFile,
+    setIsFileViewerDirty, pendingNavigation, navigateToFile, navigationToken,
     handlePendingSave, handlePendingDiscard, handlePendingCancel,
     registerSaveFunction, unregisterSaveFunction,
   } = useFileNavigation({
@@ -289,7 +289,7 @@ function AppContent() {
     sessions, activeSessionId, activeSession,
     activeSessionGitStatus, activeSessionGitStatusResult, selectedFileStatus,
     navigateToFile, openFileInDiffMode, scrollToLine, searchHighlight,
-    diffBaseRef, diffCurrentRef, diffLabel, setIsFileViewerDirty,
+    diffBaseRef, diffCurrentRef, diffLabel, navigationToken, setIsFileViewerDirty,
     registerSaveFunction, unregisterSaveFunction,
     handleSelectSession, handleNewSession,
     removeSession: (id, deleteWorktree) => { handleDeleteSession(id, deleteWorktree) },

--- a/src/renderer/hooks/usePanelsMap.test.tsx
+++ b/src/renderer/hooks/usePanelsMap.test.tsx
@@ -79,6 +79,7 @@ function makeConfig(overrides: Partial<PanelsMapConfig> = {}): PanelsMapConfig {
     diffBaseRef: undefined,
     diffCurrentRef: undefined,
     diffLabel: undefined,
+    navigationToken: 0,
     setIsFileViewerDirty: vi.fn(),
     registerSaveFunction: vi.fn(),
     unregisterSaveFunction: vi.fn(),

--- a/src/renderer/hooks/usePanelsMap.tsx
+++ b/src/renderer/hooks/usePanelsMap.tsx
@@ -71,6 +71,7 @@ export interface PanelsMapConfig {
   diffBaseRef: string | undefined
   diffCurrentRef: string | undefined
   diffLabel: string | undefined
+  navigationToken: number
   setIsFileViewerDirty: (sessionId: string, dirty: boolean) => void
   registerSaveFunction: (sessionId: string, fn: (() => Promise<void>) | null) => void
   unregisterSaveFunction: (sessionId: string) => void
@@ -171,7 +172,7 @@ function useExplorerPanel(config: PanelsMapConfig) {
 function useFileViewerPanel(config: PanelsMapConfig) {
   const {
     sessions, activeSessionId, navigateToFile, openFileInDiffMode, scrollToLine, searchHighlight,
-    diffBaseRef, diffCurrentRef, diffLabel, setIsFileViewerDirty,
+    diffBaseRef, diffCurrentRef, diffLabel, navigationToken, setIsFileViewerDirty,
     registerSaveFunction,
     handleToggleFileViewer, handleFileViewerPositionChange, selectedFileStatus, fetchGitStatus,
     closeCommandsEditor,
@@ -242,6 +243,7 @@ function useFileViewerPanel(config: PanelsMapConfig) {
                 diffBaseRef={isActive ? diffBaseRef : undefined}
                 diffCurrentRef={isActive ? diffCurrentRef : undefined}
                 diffLabel={isActive ? diffLabel : undefined}
+                navigationToken={isActive ? navigationToken : undefined}
                 isActive={isActive}
                 reviewContext={session.sessionType === 'review' ? {
                   sessionDirectory: session.directory,
@@ -255,7 +257,7 @@ function useFileViewerPanel(config: PanelsMapConfig) {
         })}
       </div>
     )
-  }, [sessions, activeSessionId, selectedFileStatus, sessionViewModes, scrollToLine, searchHighlight, diffBaseRef, diffCurrentRef, diffLabel, fetchGitStatus, handleToggleFileViewer, handleFileViewerPositionChange, navigateToFile, tmpdir, setIsFileViewerDirty, makeSaveFunctionCallback, closeCommandsEditor])
+  }, [sessions, activeSessionId, selectedFileStatus, sessionViewModes, scrollToLine, searchHighlight, diffBaseRef, diffCurrentRef, diffLabel, navigationToken, fetchGitStatus, handleToggleFileViewer, handleFileViewerPositionChange, navigateToFile, tmpdir, setIsFileViewerDirty, makeSaveFunctionCallback, closeCommandsEditor])
 }
 
 export function usePanelsMap(config: PanelsMapConfig) {

--- a/src/renderer/panels/fileViewer/FileViewer.tsx
+++ b/src/renderer/panels/fileViewer/FileViewer.tsx
@@ -32,6 +32,7 @@ interface FileViewerProps {
   initialViewMode?: ViewMode // Initial view mode when opening a file
   scrollToLine?: number // Line number to scroll to
   searchHighlight?: string // Text to highlight in the file
+  navigationToken?: number // Bumps on each explicit navigation; webview viewer uses it to force a reload back to filePath
   onDirtyStateChange?: (isDirty: boolean) => void // Report dirty state to parent
   onSaveFunctionChange?: (fn: (() => Promise<void>) | null) => void // Callback for parent to receive save function
   diffBaseRef?: string // Git ref to compare against (e.g. 'origin/main' for branch changes)
@@ -43,7 +44,7 @@ interface FileViewerProps {
   isActive?: boolean // Whether this session is the active one (controls file watcher)
 }
 
-export default function FileViewer({ filePath, position = 'top', onPositionChange, onClose, fileStatus, directory, onSaveComplete, initialViewMode = 'latest', scrollToLine, searchHighlight, onDirtyStateChange, onSaveFunctionChange, diffBaseRef, diffCurrentRef, diffLabel, reviewContext, prFilesUrl, onOpenFile, isActive }: FileViewerProps) {
+export default function FileViewer({ filePath, position = 'top', onPositionChange, onClose, fileStatus, directory, onSaveComplete, initialViewMode = 'latest', scrollToLine, searchHighlight, navigationToken, onDirtyStateChange, onSaveFunctionChange, diffBaseRef, diffCurrentRef, diffLabel, reviewContext, prFilesUrl, onOpenFile, isActive }: FileViewerProps) {
   const viewer = useFileViewer({
     filePath,
     fileStatus,
@@ -176,6 +177,7 @@ export default function FileViewer({ filePath, position = 'top', onPositionChang
               onDirtyChange={diffCurrentRef ? undefined : viewer.handleDirtyChange}
               scrollToLine={scrollToLine}
               searchHighlight={searchHighlight}
+              navigationToken={navigationToken}
               reviewContext={reviewContext}
               onEditorReady={viewer.setEditorActions}
               onOpenFile={onOpenFile}

--- a/src/renderer/panels/fileViewer/hooks/useFileNavigation.test.ts
+++ b/src/renderer/panels/fileViewer/hooks/useFileNavigation.test.ts
@@ -45,6 +45,45 @@ describe('useFileNavigation', () => {
     expect(result.current.diffCurrentRef).toBeUndefined()
     expect(result.current.diffLabel).toBeUndefined()
     expect(result.current.pendingNavigation).toBeNull()
+    expect(result.current.navigationToken).toBe(0)
+  })
+
+  // --- navigationToken increments on every navigateToFile call ---
+  it('increments navigationToken on navigate and update-scroll, including same-path re-clicks', () => {
+    vi.mocked(resolveNavigation).mockReturnValueOnce({
+      action: 'navigate',
+      state: defaultState,
+      filePath: 'https://example.com',
+    }).mockReturnValueOnce({
+      action: 'update-scroll',
+      state: defaultState,
+    }).mockReturnValueOnce({
+      action: 'update-scroll',
+      state: defaultState,
+    })
+    const params = makeParams()
+    const { result } = renderHook(() => useFileNavigation(params))
+    const initial = result.current.navigationToken
+
+    act(() => result.current.navigateToFile({ filePath: 'https://example.com', openInDiffMode: false }))
+    const afterFirst = result.current.navigationToken
+    expect(afterFirst).toBe(initial + 1)
+
+    // Re-clicking the same URL still bumps the token so the webview can reload.
+    act(() => result.current.navigateToFile({ filePath: 'https://example.com', openInDiffMode: false }))
+    expect(result.current.navigationToken).toBe(afterFirst + 1)
+
+    act(() => result.current.navigateToFile({ filePath: 'https://example.com', openInDiffMode: false }))
+    expect(result.current.navigationToken).toBe(afterFirst + 2)
+  })
+
+  it('does not bump navigationToken when navigation goes pending (dirty file)', () => {
+    const target: NavigationTarget = { filePath: '/project/file.ts', openInDiffMode: false }
+    vi.mocked(resolveNavigation).mockReturnValue({ action: 'pending', target })
+    const { result } = renderHook(() => useFileNavigation(makeParams()))
+    const initial = result.current.navigationToken
+    act(() => result.current.navigateToFile(target))
+    expect(result.current.navigationToken).toBe(initial)
   })
 
   // --- navigateToFile with 'navigate' action ---

--- a/src/renderer/panels/fileViewer/hooks/useFileNavigation.ts
+++ b/src/renderer/panels/fileViewer/hooks/useFileNavigation.ts
@@ -20,6 +20,11 @@ export function useFileNavigation({
   const [diffCurrentRef, setDiffCurrentRef] = useState<string | undefined>(undefined)
   const [diffLabel, setDiffLabel] = useState<string | undefined>(undefined)
   const [pendingNavigation, setPendingNavigation] = useState<NavigationTarget | null>(null)
+  // Increments on every explicit navigateToFile call so viewers can detect a
+  // re-click of the same path. The webview viewer uses this to force a reload
+  // back to the originally requested URL when the user has navigated away
+  // inside the page.
+  const [navigationToken, setNavigationToken] = useState(0)
 
   // Reset diff-related state when switching sessions so diff mode from one
   // session doesn't leak into another.
@@ -74,6 +79,7 @@ export function useFileNavigation({
       setDiffBaseRef(result.state.diffBaseRef)
       setDiffCurrentRef(result.state.diffCurrentRef)
       setDiffLabel(result.state.diffLabel)
+      setNavigationToken(t => t + 1)
     }
     if (result.action === 'navigate') {
       lastNavigatedFileRef.current = result.filePath
@@ -160,6 +166,7 @@ export function useFileNavigation({
     diffCurrentRef: sessionSwitchPending ? undefined : diffCurrentRef,
     diffLabel: sessionSwitchPending ? undefined : diffLabel,
     pendingNavigation,
+    navigationToken,
     navigateToFile,
     handlePendingSave,
     handlePendingDiscard,

--- a/src/renderer/panels/fileViewer/viewers/WebviewViewer.test.tsx
+++ b/src/renderer/panels/fileViewer/viewers/WebviewViewer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import '../../../../test/react-setup'
 import { WebviewViewer } from './WebviewViewer'
@@ -44,6 +44,53 @@ describe('WebviewViewer', () => {
       const btn = container.querySelector('[title="Open in browser"]')!
       fireEvent.click(btn)
       expect(window.shell.openExternal).toHaveBeenCalledWith('https://github.com/org/repo')
+    })
+
+    describe('navigationToken reload', () => {
+      // jsdom doesn't implement <webview>, but the ref still resolves to an HTMLElement.
+      // Stub loadURL on the prototype so the effect's call lands on a spy.
+      afterEach(() => {
+        // @ts-expect-error cleaning up the test stub
+        delete HTMLElement.prototype.loadURL
+      })
+      function setupLoadUrlSpy() {
+        const spy = vi.fn()
+        // @ts-expect-error attaching a fake Electron API to the DOM prototype for the test
+        HTMLElement.prototype.loadURL = spy
+        return spy
+      }
+
+      it('does not call loadURL on initial mount with a token', () => {
+        const spy = setupLoadUrlSpy()
+        render(<Component filePath="https://example.com" content="" navigationToken={1} />)
+        expect(spy).not.toHaveBeenCalled()
+      })
+
+      it('calls loadURL when navigationToken changes (re-click of same URL)', () => {
+        const spy = setupLoadUrlSpy()
+        const { rerender } = render(<Component filePath="https://example.com" content="" navigationToken={1} />)
+        expect(spy).not.toHaveBeenCalled()
+        rerender(<Component filePath="https://example.com" content="" navigationToken={2} />)
+        expect(spy).toHaveBeenCalledWith('https://example.com')
+      })
+
+      it('does not call loadURL when only filePath changes (src attribute handles it)', () => {
+        const spy = setupLoadUrlSpy()
+        const { rerender } = render(<Component filePath="https://example.com" content="" navigationToken={1} />)
+        rerender(<Component filePath="https://example.org" content="" navigationToken={1} />)
+        expect(spy).not.toHaveBeenCalled()
+      })
+
+      it('treats first activation after undefined as a baseline (no reload)', () => {
+        // Simulates a session becoming active: navigationToken transitions from undefined to a value.
+        const spy = setupLoadUrlSpy()
+        const { rerender } = render(<Component filePath="https://example.com" content="" />)
+        rerender(<Component filePath="https://example.com" content="" navigationToken={5} />)
+        expect(spy).not.toHaveBeenCalled()
+        // Subsequent token bump while active should reload.
+        rerender(<Component filePath="https://example.com" content="" navigationToken={6} />)
+        expect(spy).toHaveBeenCalledWith('https://example.com')
+      })
     })
   })
 })

--- a/src/renderer/panels/fileViewer/viewers/WebviewViewer.tsx
+++ b/src/renderer/panels/fileViewer/viewers/WebviewViewer.tsx
@@ -7,7 +7,7 @@ import { useRef, useCallback, useState, useEffect } from 'react'
 import type { FileViewerPlugin, FileViewerComponentProps } from './types'
 import FindBar from './FindBar'
 
-function WebviewViewerComponent({ filePath, onEditorReady }: FileViewerComponentProps) {
+function WebviewViewerComponent({ filePath, navigationToken, onEditorReady }: FileViewerComponentProps) {
   const webviewRef = useRef<Electron.WebviewTag | null>(null)
   const findInputRef = useRef<HTMLInputElement | null>(null)
   const [canGoBack, setCanGoBack] = useState(false)
@@ -16,6 +16,26 @@ function WebviewViewerComponent({ filePath, onEditorReady }: FileViewerComponent
   const [showFindBar, setShowFindBar] = useState(false)
   const [findQuery, setFindQuery] = useState('')
   const [findResult, setFindResult] = useState<{ activeMatch: number; matches: number } | null>(null)
+
+  // When the user re-clicks a link to filePath, navigationToken bumps. Force the
+  // webview back to filePath in case the user has navigated away inside the page.
+  // The first observed token (mount or first activation after a session switch)
+  // is the baseline — the initial load is handled by <webview src={...}>.
+  const baselineTokenRef = useRef<number | null>(null)
+  useEffect(() => {
+    if (navigationToken === undefined) {
+      baselineTokenRef.current = null
+      return
+    }
+    if (baselineTokenRef.current === null) {
+      baselineTokenRef.current = navigationToken
+      return
+    }
+    if (baselineTokenRef.current !== navigationToken) {
+      baselineTokenRef.current = navigationToken
+      void webviewRef.current?.loadURL(filePath)
+    }
+  }, [navigationToken, filePath])
 
   useEffect(() => {
     const webview = webviewRef.current

--- a/src/renderer/panels/fileViewer/viewers/types.ts
+++ b/src/renderer/panels/fileViewer/viewers/types.ts
@@ -41,6 +41,8 @@ export interface FileViewerComponentProps {
   scrollToLine?: number
   /** Text to highlight in the file */
   searchHighlight?: string
+  /** Bumps each time the user explicitly navigates to this path. Viewers that hold internal navigation state (e.g. WebviewViewer) use it to detect re-clicks and force a reload back to filePath. */
+  navigationToken?: number
   /** Review context - present when viewing files in a review session */
   reviewContext?: {
     sessionDirectory: string


### PR DESCRIPTION
## Summary

- Bump a `navigationToken` counter on every `navigateToFile` call (including same-path re-clicks that resolve to `'update-scroll'`).
- Plumb the token through `App.tsx` → `usePanelsMap` → `FileViewer` → viewer plugin props, gated by `isActive` so only the active session's viewer reacts.
- In `WebviewViewer`, call `webview.loadURL(filePath)` whenever the token bumps relative to the established baseline. The first observed token (mount or first activation after a session switch) becomes the baseline, so the initial render's `<webview src={filePath}>` handles the load and we don't double-fire.

## Background

Previously, clicking a URL link that matched the file viewer's currently-open URL hit the same-file branch in `resolveNavigation` and returned `'update-scroll'` — a no-op for the webview. If the user had followed an in-page link inside the embedded browser, the click did nothing and they stayed stranded. Now the viewer always returns to the requested URL.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (3352 passing; new tests cover token-bump in `useFileNavigation` and `loadURL` invocation in `WebviewViewer` including the activation-baseline case)
- [x] Coverage 90.8% lines (above the 90% threshold)
- [x] Ran all E2E tests locally via `pnpm test:e2e` (72 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)