### PR TITLE
fix(file-viewer): make Cmd+S resilient to onSave identity changes

### DIFF
--- a/src/renderer/panels/fileViewer/viewers/MonacoViewer.test.tsx
+++ b/src/renderer/panels/fileViewer/viewers/MonacoViewer.test.tsx
@@ -367,6 +367,83 @@ describe('MonacoViewerComponent onMount lifecycle', () => {
     expect(onSave).not.toHaveBeenCalled()
   })
 
+  it('Cmd+S handler uses latest onSave after re-render (no stale closure)', async () => {
+    const onSave1 = vi.fn().mockResolvedValue(true)
+    const onSave2 = vi.fn().mockResolvedValue(true)
+    const { rerender } = render(
+      <MonacoViewerComponent filePath="/test/file.ts" content="original" onSave={onSave1} />
+    )
+    const props = getLastEditorProps()
+    const onMount = props.onMount as (editor: unknown, monaco: unknown) => void
+    const editor = makeMockEditorInstance()
+    editor.getValue.mockReturnValue('modified')
+    const monacoInst = makeMockMonaco()
+    onMount(editor, monacoInst)
+
+    // Parent re-renders with a new onSave (e.g., handleSave's identity changed
+    // because filePath or checkForExternalChanges changed)
+    rerender(
+      <MonacoViewerComponent filePath="/test/file.ts" content="original" onSave={onSave2} />
+    )
+
+    const saveCallback = editor.addCommand.mock.calls[0][1] as () => void
+    saveCallback()
+
+    await vi.waitFor(() => {
+      expect(onSave2).toHaveBeenCalledWith('modified')
+    })
+    expect(onSave1).not.toHaveBeenCalled()
+  })
+
+  it('Cmd+S handler is a no-op when onSave becomes undefined (e.g., diff-ref view)', () => {
+    const onSave = vi.fn().mockResolvedValue(true)
+    const { rerender } = render(
+      <MonacoViewerComponent filePath="/test/file.ts" content="original" onSave={onSave} />
+    )
+    const props = getLastEditorProps()
+    const onMount = props.onMount as (editor: unknown, monaco: unknown) => void
+    const editor = makeMockEditorInstance()
+    editor.getValue.mockReturnValue('modified')
+    const monacoInst = makeMockMonaco()
+    onMount(editor, monacoInst)
+
+    // Switch to a view where saving is disallowed (diffCurrentRef sets onSave to undefined)
+    rerender(
+      <MonacoViewerComponent filePath="/test/file.ts" content="original" />
+    )
+
+    const saveCallback = editor.addCommand.mock.calls[0][1] as () => void
+    saveCallback()
+
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('Cmd+S handler reports dirty=false on save success via the latest onDirtyChange', async () => {
+    const onSave = vi.fn().mockResolvedValue(true)
+    const onDirtyChange1 = vi.fn()
+    const onDirtyChange2 = vi.fn()
+    const { rerender } = render(
+      <MonacoViewerComponent filePath="/test/file.ts" content="original" onSave={onSave} onDirtyChange={onDirtyChange1} />
+    )
+    const props = getLastEditorProps()
+    const onMount = props.onMount as (editor: unknown, monaco: unknown) => void
+    const editor = makeMockEditorInstance()
+    editor.getValue.mockReturnValue('modified')
+    const monacoInst = makeMockMonaco()
+    onMount(editor, monacoInst)
+
+    rerender(
+      <MonacoViewerComponent filePath="/test/file.ts" content="original" onSave={onSave} onDirtyChange={onDirtyChange2} />
+    )
+
+    const saveCallback = editor.addCommand.mock.calls[0][1] as () => void
+    saveCallback()
+
+    await vi.waitFor(() => {
+      expect(onDirtyChange2).toHaveBeenCalledWith(false, 'modified')
+    })
+  })
+
   it('registers glyph margin click handler when reviewContext is provided', () => {
     render(
       <MonacoViewerComponent

--- a/src/renderer/panels/fileViewer/viewers/MonacoViewer.tsx
+++ b/src/renderer/panels/fileViewer/viewers/MonacoViewer.tsx
@@ -191,6 +191,14 @@ function MonacoViewerComponent({ filePath, content, onSave, onDirtyChange, scrol
   const searchHighlightRef = useRef(searchHighlight)
   const onOpenFileRef = useRef(onOpenFile)
   onOpenFileRef.current = onOpenFile
+  // Refs for callbacks used inside Monaco's editor.addCommand. addCommand is
+  // registered once on mount and the @monaco-editor/react Editor reuses the
+  // same instance across files, so a direct closure capture would go stale
+  // whenever the parent re-issues handleSave (e.g., after filePath changes).
+  const onSaveRef = useRef(onSave)
+  const onDirtyChangeRef = useRef(onDirtyChange)
+  onSaveRef.current = onSave
+  onDirtyChangeRef.current = onDirtyChange
 
   const { commentLine, setCommentLine, commentText, setCommentText, handleAddComment } = useMonacoComments({
     filePath,
@@ -232,13 +240,14 @@ function MonacoViewerComponent({ filePath, content, onSave, onDirtyChange, scrol
     // Add Cmd/Ctrl+S save handler
     editor.addCommand(monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS, () => {
       const editorContent = editor.getValue()
-      if (onSave && editorContent !== originalContentRef.current) {
-        void onSave(editorContent).then((saved) => {
+      const save = onSaveRef.current
+      if (save && editorContent !== originalContentRef.current) {
+        void save(editorContent).then((saved) => {
           // Only reset dirty state if the save actually went through
           // (it may be aborted if the file changed on disk)
           if (saved) {
             originalContentRef.current = editorContent
-            onDirtyChange?.(false, editorContent)
+            onDirtyChangeRef.current?.(false, editorContent)
           }
         })
       }


### PR DESCRIPTION
## Background and Motivation

Cmd-S in the file viewer was intermittent — sometimes saved, sometimes silently did nothing, even with the cursor inside the Monaco editor. The breakpoint was "once you'd been editing for a while or switched files," which pointed at a stale closure.

`MonacoViewer` registers Cmd-S via `editor.addCommand(...)` inside `handleEditorDidMount`. That mount handler runs **once** because `@monaco-editor/react` reuses the same underlying editor instance and just swaps the model when `path` changes. The callback closed over the `onSave` / `onDirtyChange` props captured at mount time. Whenever the parent re-issued a new `handleSave` — which `useFileViewer` does whenever `filePath`, `onSaveComplete`, or `checkForExternalChanges` changes — Cmd-S kept calling the old function. Best case: the stale `checkForExternalChanges` thought the active file was modified externally and aborted with `false`, looking like Cmd-S did nothing. Worst case: a stale `filePath` would write the new buffer to the previously-open file.

## Design Decisions

- **Use the existing ref-mutation pattern.** `MonacoViewer.tsx:192-193` already does this for `onOpenFile` for exactly the same reason (Monaco's `registerEditorOpener` is registered once per mount). Mirroring the pattern keeps the file internally consistent.
- **Don't move Cmd-S to a window-level handler.** Tempting, but the existing Monaco-scoped handler is correct: it only fires when Monaco has focus, and the diff-ref "viewing historical content" mode legitimately wants Cmd-S to be a no-op (`onSave` is set to `undefined` upstream). A global handler would either need to replicate that gate or risk saving in modes where saving is wrong.
- **Add a why-comment, not a what-comment.** The new comment on the refs explains the constraint ("Editor reuses the same instance across files") so future readers don't reintroduce a direct closure capture.
- **Leave `react-hooks/exhaustive-deps` disabled.** It is currently off in `eslint.config.js`. Even enabled, it would not have caught this bug — `handleEditorDidMount` is a regular function passed to `<Editor onMount={…}>`, not a React hook callback, and the rule only inspects `useEffect` / `useCallback` / `useMemo`.

## Proposed Changes

**Stale-closure fix in `MonacoViewer.tsx`**
- Add `onSaveRef` / `onDirtyChangeRef`, updated each render alongside the existing `onOpenFileRef`.
- The Cmd-S `addCommand` callback reads `onSaveRef.current` and `onDirtyChangeRef.current` instead of the captured props.

**Regression tests in `MonacoViewer.test.tsx`**
- "uses latest onSave after re-render (no stale closure)" — mounts, swaps `onSave`, fires Cmd-S, asserts the new fn was called.
- "is a no-op when onSave becomes undefined (diff-ref view)" — verifies the historical-view gate still works.
- "reports dirty=false on save success via the latest onDirtyChange" — covers the `onDirtyChange` ref path too.

I also audited every `useEffect(…, [])`, `addEventListener`, `addCommand`, `onDid*`, IPC subscription, and `register*` call in `src/renderer/`. Two looked superficially similar:
- `useSessionLifecycle.ts:113-144` — the keydown listener has `[activeSession]` in its deps so it re-registers; not stale.
- `MonacoDiffViewer.tsx:139-143` — `onDidUpdateDiff` captures `scrollToLine`, but the disposable is one-shot and a follow-up `useEffect` covers later changes.

No other instances of this bug shape were found.

## Testing

- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 72/72 passed
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm check:all` — passed
- `pnpm test:unit` — 3343/3343 passed across 192 files
- Coverage — 90.73% lines (above the 90% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)