### PR TITLE
fix(file-viewer): live reload + stop spurious dirty diagnosis

### DIFF
--- a/src/renderer/panels/fileViewer/hooks/useFileViewer.test.ts
+++ b/src/renderer/panels/fileViewer/hooks/useFileViewer.test.ts
@@ -228,6 +228,30 @@ describe('useFileViewer', () => {
       expect(saveResult).toBe(true)
       expect(window.fs.writeFile).toHaveBeenCalledWith('/test/file.ts', 'new content')
     })
+
+    it('notifies onDirtyStateChange(false) after a successful save (regression)', async () => {
+      // Without this notification, the per-session dirtyMap stays true after save,
+      // and the next file switch falsely prompts "discard unsaved changes".
+      vi.mocked(window.fs.writeFile).mockResolvedValue({ success: true })
+      const onDirtyStateChange = vi.fn()
+
+      const { result } = renderHook(() =>
+        useFileViewer({ filePath: '/test/file.ts', onDirtyStateChange })
+      )
+
+      // Mark dirty first.
+      act(() => {
+        result.current.handleDirtyChange(true, 'edited')
+      })
+      expect(onDirtyStateChange).toHaveBeenLastCalledWith(true)
+
+      onDirtyStateChange.mockClear()
+      await act(async () => {
+        await result.current.handleSave('edited')
+      })
+
+      expect(onDirtyStateChange).toHaveBeenCalledWith(false)
+    })
   })
 
   describe('handleSaveButton', () => {
@@ -582,6 +606,21 @@ describe('useFileViewer', () => {
 
       rerender({ filePath: '/test/file2.ts' })
       expect(result.current.isDirty).toBe(false)
+    })
+
+    it('notifies onDirtyStateChange(false) when filePath changes (regression)', () => {
+      // Defensive reset — the per-session dirtyMap must be cleared on file
+      // change, not just our local state, otherwise the next navigation can
+      // see a stale dirty=true and prompt to discard.
+      const onDirtyStateChange = vi.fn()
+      const { rerender } = renderHook(
+        ({ filePath }) => useFileViewer({ filePath, onDirtyStateChange }),
+        { initialProps: { filePath: '/test/file1.ts' as string | null } }
+      )
+
+      onDirtyStateChange.mockClear()
+      rerender({ filePath: '/test/file2.ts' })
+      expect(onDirtyStateChange).toHaveBeenCalledWith(false)
     })
 
     it('resets editorActions when filePath changes', () => {

--- a/src/renderer/panels/fileViewer/hooks/useFileViewer.ts
+++ b/src/renderer/panels/fileViewer/hooks/useFileViewer.ts
@@ -105,11 +105,12 @@ export function useFileViewer({
   useEffect(() => {
     if (prevFilePathRef.current !== filePath) {
       setIsDirty(false)
+      onDirtyStateChange?.(false)
       prevFilePathRef.current = filePath
     }
     const shouldUseDiffMode = canShowDiff && (fileStatus === 'deleted' || initialViewMode === 'diff')
     setViewMode(shouldUseDiffMode ? 'diff' : 'latest')
-  }, [filePath, initialViewMode, canShowDiff, fileStatus])
+  }, [filePath, initialViewMode, canShowDiff, fileStatus, onDirtyStateChange])
 
   // Safety guard: viewMode must never be 'diff' when diffs are unavailable.
   // This catches any race condition or stale state that could leave the viewer
@@ -134,12 +135,13 @@ export function useFileViewer({
       setContent(newContent)
       setEditedContent(newContent)
       setIsDirty(false)
+      onDirtyStateChange?.(false)
       onSaveComplete?.()
       return true
     } finally {
       setIsSaving(false)
     }
-  }, [filePath, onSaveComplete, checkForExternalChanges])
+  }, [filePath, onSaveComplete, onDirtyStateChange, checkForExternalChanges])
 
   // Expose save function to parent via callback
   useEffect(() => {

--- a/src/renderer/panels/fileViewer/hooks/useFileWatcher.test.ts
+++ b/src/renderer/panels/fileViewer/hooks/useFileWatcher.test.ts
@@ -4,7 +4,7 @@ import { renderHook, act } from '@testing-library/react'
 import { useFileWatcher } from './useFileWatcher'
 
 describe('useFileWatcher', () => {
-  let onChangeCallback: ((filename?: string) => void) | null = null
+  let onChangeCallback: ((filename?: string | null) => void) | null = null
   const mockRemoveListener = vi.fn()
 
   beforeEach(() => {
@@ -12,9 +12,15 @@ describe('useFileWatcher', () => {
     vi.useFakeTimers()
     onChangeCallback = null
 
-    // Capture the onChange callback when registered
+    // Capture the onChange callback when registered. Default fires events for our
+    // watched file ('file.ts'); tests that simulate sibling-file changes pass an
+    // alternate filename explicitly. A null filename simulates platforms where
+    // the watcher omits filename info.
     vi.mocked(window.fs.onChange).mockImplementation((_watcherId, callback) => {
-      onChangeCallback = (filename?: string) => callback({ eventType: 'change', filename: filename ?? 'file.ts' })
+      onChangeCallback = (filename?: string | null) => callback({
+        eventType: 'change',
+        filename: filename === undefined ? 'file.ts' : filename,
+      })
       return mockRemoveListener
     })
     vi.mocked(window.fs.watch).mockResolvedValue({ success: true })
@@ -36,10 +42,10 @@ describe('useFileWatcher', () => {
   }
 
   describe('watcher setup', () => {
-    it('watches the file directly', () => {
+    it('watches the parent directory (not the file itself, for atomic-rename robustness)', () => {
       renderHook(() => useFileWatcher(defaultParams))
 
-      expect(window.fs.watch).toHaveBeenCalledWith('fileviewer-/test/file.ts', '/test/file.ts')
+      expect(window.fs.watch).toHaveBeenCalledWith('fileviewer-/test/file.ts', '/test')
       expect(window.fs.onChange).toHaveBeenCalledWith('fileviewer-/test/file.ts', expect.any(Function))
     })
 
@@ -175,6 +181,63 @@ describe('useFileWatcher', () => {
         await vi.advanceTimersByTimeAsync(300)
       })
     })
+
+    it('ignores events for sibling files in the same parent directory', async () => {
+      const setContent = vi.fn()
+      renderHook(() => useFileWatcher({ ...defaultParams, setContent }))
+
+      vi.mocked(window.fs.readFile).mockResolvedValue('new content')
+
+      // A different file in /test/ changes — we must not react.
+      onChangeCallback!('other.ts')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+
+      expect(window.fs.readFile).not.toHaveBeenCalled()
+      expect(setContent).not.toHaveBeenCalled()
+    })
+
+    it('still reacts when filename is null (platform did not provide one)', async () => {
+      const setContent = vi.fn()
+      renderHook(() => useFileWatcher({ ...defaultParams, setContent }))
+
+      vi.mocked(window.fs.readFile).mockResolvedValue('new content')
+
+      onChangeCallback!(null)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+
+      expect(setContent).toHaveBeenCalledWith('new content')
+    })
+
+    it('continues detecting changes after an atomic-rename event (regression)', async () => {
+      // Simulates an editor / CLI saving via temp-file-then-rename. With the
+      // previous file-path watcher, the inode reference died here and all later
+      // changes were silently lost. The parent-dir watcher must keep working.
+      const setContent = vi.fn()
+      renderHook(() => useFileWatcher({ ...defaultParams, setContent }))
+
+      vi.mocked(window.fs.readFile).mockResolvedValueOnce('content after rename')
+      onChangeCallback!('file.ts') // 'rename' event from atomic save
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      expect(setContent).toHaveBeenLastCalledWith('content after rename')
+
+      // A subsequent in-place change must still be observed.
+      vi.mocked(window.fs.readFile).mockResolvedValueOnce('content after second edit')
+      onChangeCallback!('file.ts')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      expect(setContent).toHaveBeenLastCalledWith('content after second edit')
+    })
   })
 
   describe('handleKeepLocalChanges', () => {
@@ -267,7 +330,7 @@ describe('useFileWatcher', () => {
     it('sets up watcher when enabled is true (default)', () => {
       renderHook(() => useFileWatcher(defaultParams))
 
-      expect(window.fs.watch).toHaveBeenCalledWith('fileviewer-/test/file.ts', '/test/file.ts')
+      expect(window.fs.watch).toHaveBeenCalledWith('fileviewer-/test/file.ts', '/test')
     })
 
     it('tears down watcher when enabled transitions to false', () => {
@@ -292,7 +355,7 @@ describe('useFileWatcher', () => {
 
       rerender({ enabled: true })
 
-      expect(window.fs.watch).toHaveBeenCalledWith('fileviewer-/test/file.ts', '/test/file.ts')
+      expect(window.fs.watch).toHaveBeenCalledWith('fileviewer-/test/file.ts', '/test')
     })
 
     it('checks for external changes when transitioning from disabled to enabled', async () => {

--- a/src/renderer/panels/fileViewer/hooks/useFileWatcher.ts
+++ b/src/renderer/panels/fileViewer/hooks/useFileWatcher.ts
@@ -2,6 +2,7 @@
  * Watches a file on disk for external changes and provides conflict resolution when the file is modified outside the editor.
  */
 import { useEffect, useCallback, useRef, useState } from 'react'
+import { dirname, basename } from 'path-browserify'
 
 interface UseFileWatcherParams {
   filePath: string | null
@@ -42,22 +43,29 @@ export function useFileWatcher({
     isDirtyRef.current = isDirty
   }, [isDirty])
 
-  // Watch the file directly for external changes
+  // Watch the parent directory and filter events by filename. Watching the file
+  // path directly is unreliable on macOS: atomic-rename saves (used by most editors
+  // and CLI tools) replace the file's inode, invalidating the watcher and silently
+  // dropping all subsequent events. Watching the parent dir survives this.
   useEffect(() => {
     if (!filePath || !enabled || filePath.startsWith('https://')) return
 
     const watcherId = `fileviewer-${filePath}`
+    const watchDir = dirname(filePath)
+    const targetName = basename(filePath)
     let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
-    void window.fs.watch(watcherId, filePath)
-    const removeListener = window.fs.onChange(watcherId, () => {
-      // Debounce to avoid multiple triggers
+    void window.fs.watch(watcherId, watchDir)
+    const removeListener = window.fs.onChange(watcherId, ({ filename }) => {
+      // Filter to events for our specific file. A null filename (some platforms
+      // don't always provide one) is treated as potentially-relevant.
+      if (filename && filename !== targetName) return
+
       if (debounceTimer) clearTimeout(debounceTimer)
       debounceTimer = setTimeout(() => {
         void (async () => {
           try {
             const newContent = await window.fs.readFile(filePath)
-            // Only trigger if content actually changed
             if (newContent !== contentRef.current) {
               if (isDirtyRef.current) {
                 setFileChangedOnDisk(true)

--- a/src/renderer/panels/fileViewer/viewers/MonacoViewer.test.tsx
+++ b/src/renderer/panels/fileViewer/viewers/MonacoViewer.test.tsx
@@ -265,6 +265,92 @@ describe('MonacoViewerComponent', () => {
     expect(onDirtyChange).toHaveBeenCalledWith(false, 'updated')
   })
 
+  it('does not flag dirty when Monaco fires onChange after a parent-driven content change (regression)', () => {
+    // Real-world scenario: file reloads from disk -> parent passes new content prop ->
+    // @monaco-editor/react's setValue effect fires onDidChangeModelContent ->
+    // our onChange handler runs with the NEW content. If originalContentRef hasn't
+    // been synced by then, we'd report dirty=true and poison the per-session
+    // dirtyMap, producing a spurious "discard unsaved changes" prompt on next nav.
+    const onDirtyChange = vi.fn()
+    const { rerender } = render(
+      <MonacoViewerComponent filePath="/test/file.ts" content="original" onDirtyChange={onDirtyChange} />
+    )
+
+    rerender(
+      <MonacoViewerComponent filePath="/test/file.ts" content="reloaded from disk" onDirtyChange={onDirtyChange} />
+    )
+
+    // Simulate Monaco's setValue effect firing onChange with the new value.
+    const onChangeCall = mockEditor.mock.calls[mockEditor.mock.calls.length - 1][0]
+    onDirtyChange.mockClear()
+    onChangeCall.onChange('reloaded from disk')
+
+    // Must NOT report dirty=true at any point.
+    expect(onDirtyChange).not.toHaveBeenCalledWith(true, expect.anything())
+    expect(onDirtyChange).toHaveBeenCalledWith(false, 'reloaded from disk')
+  })
+
+  it('still flags dirty when user actually edits after a content reload', () => {
+    // Counterpart to the regression test above: real edits must still mark dirty.
+    const onDirtyChange = vi.fn()
+    const { rerender } = render(
+      <MonacoViewerComponent filePath="/test/file.ts" content="original" onDirtyChange={onDirtyChange} />
+    )
+
+    rerender(
+      <MonacoViewerComponent filePath="/test/file.ts" content="reloaded" onDirtyChange={onDirtyChange} />
+    )
+
+    const onChangeCall = mockEditor.mock.calls[mockEditor.mock.calls.length - 1][0]
+    onDirtyChange.mockClear()
+
+    // User types something genuinely different.
+    onChangeCall.onChange('reloaded + my edit')
+
+    expect(onDirtyChange).toHaveBeenCalledWith(true, 'reloaded + my edit')
+  })
+
+  it('does not flag dirty when Monaco normalizes the content (BOM, line endings, etc.)', () => {
+    // Monaco strips BOMs and may normalize line endings, so editor.getValue()
+    // can differ from the file's raw bytes. The dirty baseline must come from
+    // the editor's actual value, not the prop, otherwise files with these
+    // characteristics show as dirty consistently before the user types anything.
+    const onDirtyChange = vi.fn()
+    render(
+      <MonacoViewerComponent
+        filePath="/test/file.json"
+        content={'﻿{"key": "value"}\r\n'}
+        onSave={vi.fn()}
+        onDirtyChange={onDirtyChange}
+      />
+    )
+
+    // After mount, simulate Monaco's actual stored value (BOM stripped, CRLF→LF).
+    const props = mockEditor.mock.calls[mockEditor.mock.calls.length - 1][0] as Record<string, unknown>
+    const onMount = props.onMount as (editor: unknown, monaco: unknown) => void
+    const normalizedValue = '{"key": "value"}\n'
+    const editor = {
+      addCommand: vi.fn(),
+      onMouseDown: vi.fn(),
+      focus: vi.fn(),
+      trigger: vi.fn(),
+      getValue: vi.fn().mockReturnValue(normalizedValue),
+      revealLineInCenter: vi.fn(),
+      getModel: vi.fn().mockReturnValue({ getLineContent: vi.fn() }),
+      setSelection: vi.fn(),
+      createDecorationsCollection: vi.fn(),
+    }
+    onMount(editor, { KeyMod: { CtrlCmd: 2048 }, KeyCode: { KeyS: 49 }, editor: { MouseTargetType: { GUTTER_GLYPH_MARGIN: 2 } } })
+
+    // Monaco's onChange fires with its normalized value (e.g. via the wrapper
+    // syncing the model on mount, or any code path that re-emits the value).
+    onDirtyChange.mockClear()
+    const onChangeCall = props.onChange as (value: string) => void
+    onChangeCall(normalizedValue)
+
+    expect(onDirtyChange).not.toHaveBeenCalledWith(true, expect.anything())
+  })
+
   it('passes filePath as path to Monaco', () => {
     render(
       <MonacoViewerComponent filePath="/test/file.ts" content="" />
@@ -334,10 +420,15 @@ describe('MonacoViewerComponent onMount lifecycle', () => {
     const props = getLastEditorProps()
     const onMount = props.onMount as (editor: unknown, monaco: unknown) => void
     const editor = makeMockEditorInstance()
-    editor.getValue.mockReturnValue('modified')
+    // At mount, the editor's value matches the initial content (the dirty
+    // baseline is anchored to getValue() here).
+    editor.getValue.mockReturnValue('original')
     const monacoInst = makeMockMonaco()
 
     onMount(editor, monacoInst)
+
+    // Now the user types — editor reports the new value.
+    editor.getValue.mockReturnValue('modified')
 
     // Get the save callback (second arg to addCommand)
     const saveCallback = editor.addCommand.mock.calls[0][1] as () => void
@@ -360,6 +451,7 @@ describe('MonacoViewerComponent onMount lifecycle', () => {
     const monacoInst = makeMockMonaco()
 
     onMount(editor, monacoInst)
+    // Editor's value never diverges from the mount baseline — Cmd+S is a no-op.
 
     const saveCallback = editor.addCommand.mock.calls[0][1] as () => void
     saveCallback()

--- a/src/renderer/panels/fileViewer/viewers/MonacoViewer.tsx
+++ b/src/renderer/panels/fileViewer/viewers/MonacoViewer.tsx
@@ -202,9 +202,29 @@ function MonacoViewerComponent({ filePath, content, onSave, onDirtyChange, scrol
   scrollToLineRef.current = scrollToLine
   searchHighlightRef.current = searchHighlight
 
-  // Update original content when file changes
-  useEffect(() => {
+  // Dirty detection baseline. Sync it to the parent's `content` prop on every
+  // render BEFORE child effects fire, so the wrapper's setValue-driven onChange
+  // (which is normally suppressed, but if it fires for any reason) compares
+  // against the latest parent content. We later overwrite this ref with
+  // editor.getValue() once Monaco has the content — Monaco may normalize
+  // content (line endings, BOM stripping, etc.) so its actual value can differ
+  // from the prop, and a stale-prop baseline would then consistently flag the
+  // file as dirty even when the user has not edited it.
+  if (originalContentRef.current !== content) {
     originalContentRef.current = content
+  }
+
+  // After parent updates content (file load, watcher reload, save), let Monaco
+  // process the new value, then reset the dirty baseline to whatever Monaco
+  // actually has in the editor. This is the core defense against false-positive
+  // dirty detection: regardless of any normalization Monaco applies (CRLF↔LF,
+  // BOM, trailing-newline behavior), getValue() === getValue() so the file
+  // shows as clean until the user actually types.
+  useEffect(() => {
+    const editor = editorRef.current
+    if (editor) {
+      originalContentRef.current = editor.getValue()
+    }
     onDirtyChange?.(false, content)
   }, [content, filePath])
 
@@ -223,6 +243,12 @@ function MonacoViewerComponent({ filePath, content, onSave, onDirtyChange, scrol
 
   const handleEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor, monacoInstance: Monaco) => {
     editorRef.current = editor
+    // Anchor the dirty-detection baseline to Monaco's actual editor value, not
+    // the content prop. Monaco may normalize the content (line endings, BOM,
+    // etc.); using its post-normalization value as the baseline guarantees the
+    // first onChange after mount can only fire as dirty if the user has
+    // genuinely edited the text.
+    originalContentRef.current = editor.getValue()
     // Apply pending scroll/highlight now that the editor is ready
     if (scrollToLineRef.current) {
       // Monaco editor is ready at onMount, but give it a moment for layout


### PR DESCRIPTION
## Background and Motivation

Two related bugs in the file viewer's edit/reload pipeline:

1. **External changes weren't reloading.** When an agent (or any tool) modified an open file on disk, the viewer would not refresh until the user switched to a different file and back. Users could accidentally save stale content over the agent's changes.
2. **Files were consistently flagged as dirty even with no edits.** Switching files would frequently pop a "discard unsaved changes?" prompt for files the user had only viewed, never typed in.

## Design Decisions

**Watch the parent directory, not the file.** On macOS, `fs.watch(filePath)` holds an inode reference that dies the first time the file is replaced via atomic rename — which is exactly how most editors and CLI tools (including Claude Code) save. Switching to a parent-directory watcher with a filename filter survives atomic renames. The renderer already receives `filename` in `onChange` events, so the filter is cheap. A `null` filename (some platforms omit it) is treated as potentially-relevant rather than ignored.

**Anchor the dirty baseline to `editor.getValue()`, not the `content` prop.** The original code compared Monaco's reported value against the raw `content` prop, but Monaco normalizes content (strips BOMs, normalizes line endings). For any file with those characteristics, `getValue() !== prop` is *consistently* true from the moment the editor mounts — producing a permanent false-positive dirty diagnosis. Using `editor.getValue()` itself as the baseline means `getValue() !== getValue()` is impossible until the user genuinely types.

**Defensive `onDirtyStateChange(false)` notifications.** The per-session `dirtyMap` is updated through a callback chain that goes through `MonacoViewer`. In two paths (`handleSave` and `filePath` change in `useFileViewer`), local `setIsDirty(false)` was called without the corresponding parent notification, so the map could go stale via paths that bypass the viewer chain.

## Proposed Changes

**`useFileWatcher.ts` — atomic-rename-resilient watcher**
- Watch `dirname(filePath)` instead of the file itself
- Filter `onChange` events by `basename(filePath)`
- Treat `filename === null` as "potentially relevant" (don't drop the event)

**`MonacoViewer.tsx` — `getValue()`-anchored dirty baseline**
- Set `originalContentRef.current = editor.getValue()` in `handleEditorDidMount`
- Refresh that ref in the `[content, filePath]` `useEffect` (after Monaco has the new content)
- Sync the ref to the prop during render as a fallback for environments where the editor isn't mounted yet (tests, pre-mount frame)

**`useFileViewer.ts` — close the dirty-state notification gaps**
- Call `onDirtyStateChange?.(false)` in `handleSave` after a successful write
- Call `onDirtyStateChange?.(false)` in the `filePath`-change effect

**Tests added**
- `useFileWatcher.test.ts`: parent-dir watcher target, filename filter rejects sibling-file events, `null` filename still triggers, atomic-rename simulation continues detecting subsequent changes (regression test for the watcher dying after a rename)
- `MonacoViewer.test.tsx`: `does not flag dirty when Monaco normalizes the content (BOM, line endings, etc.)` — the core regression for the false-positive dirty bug; counterpart `still flags dirty when user actually edits` confirms real edits still trigger; updated existing Cmd+S test to reflect the new mount-time baseline semantics
- `useFileViewer.test.ts`: `onDirtyStateChange(false)` is fired on save and on `filePath` change

## Testing

- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 72/72 passed
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm vitest run src/renderer/panels/fileViewer` — 333 tests pass

## Test plan

- [ ] Open a file, have the agent modify it on disk, verify the viewer reloads automatically (no need to switch files)
- [ ] Edit a file, then have the agent modify it on disk — verify the "file changed on disk" banner appears (not silent reload)
- [ ] Open a file with a BOM or CRLF line endings, switch to another file — verify no "discard unsaved changes" prompt
- [ ] Edit a file, switch to another file — verify the prompt does still appear (real dirty state preserved)
- [ ] Save a file via Cmd+S, then switch files — verify no prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)