### PR TITLE
chore: add PR template and require E2E in validation

### DIFF
--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -7,11 +7,12 @@ Run the full verification checklist and fix any failures.
 3. Run `pnpm check:all`. If any project-specific checks fail, fix them and re-run until clean.
 4. Run `pnpm test:unit`. If any unit tests fail, read the failing test and the source code it tests, fix the issue (in the source or the test as appropriate), and re-run until all pass.
 5. Run `/coverage-run` to execute the full test suite with coverage and cache the results. If coverage drops below 90% on any targeted file, use `/coverage-increase` to add tests and bring it back above threshold.
-6. Run `pnpm test:e2e`. If any E2E tests fail, investigate and fix the issue, then re-run until passing.
+6. Run `pnpm test:e2e`. **This step is mandatory — never skip it, even if the change "looks UI-only" or "looks backend-only".** If any E2E tests fail, investigate and fix the issue, then re-run until passing.
 
 ## Rules
 
 - Fix the root cause, not the symptom. Don't delete tests or weaken assertions to make things pass.
 - If a lint or type error is in code you didn't write, fix it anyway — the goal is a green checklist.
 - After each fix, re-run only the failing check (not the whole sequence) to verify the fix before moving on.
+- E2E is non-negotiable. The summary you report MUST include the E2E result; if you didn't run it, the validation is incomplete.
 - When all 6 checks pass, report the results as a summary.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for contributing! Fill in the sections below.
+
+CI requires the `## Testing` heading to remain spelled exactly that way and
+the E2E item under it to be checked (`- [x]`). The "PR E2E attestation" job
+greps for both — see .github/workflows/ci.yml.
+-->
+
+## Background and Motivation
+
+<!-- What problem does this solve? Link issues, screenshots, or repro steps. -->
+
+## Design Decisions
+
+<!-- Non-obvious choices and the alternatives you considered. Skip if trivial. -->
+
+## Proposed Changes
+
+<!-- Group by pattern (component, layer, behavior), not just file lists. -->
+
+## Testing
+
+<!--
+Run `/validate` (or the equivalent: `pnpm lint && pnpm typecheck && pnpm check:all && pnpm test:unit:coverage && pnpm test:e2e`).
+
+E2E tests are required on every PR. Run `pnpm test:e2e` locally on your OS;
+use `./run-linux-e2e.sh` only when you specifically need to reproduce a
+Linux/CI-only failure.
+-->
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm check:all`
+- [ ] `pnpm test:unit` (coverage at or above 90% lines)
+- [ ] Ran all E2E tests locally (`pnpm test:e2e`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,3 +154,7 @@ Stories are co-located as `*.stories.tsx` next to source files. Reference images
 1. Run `/validate` (covers lint, typecheck, check:all, unit tests, coverage, E2E)
 2. Run `/feature-doc <slug>` to create/update the screenshot walkthrough
 3. Run `/code-review` on changed files
+
+### Pull request body
+
+Use the template at `.github/PULL_REQUEST_TEMPLATE.md`. The `## Testing` heading must be spelled exactly that way and contain a checked E2E item (e.g. `- [x] Ran all E2E tests locally (pnpm test:e2e)`). The CI job "PR E2E attestation" greps for this and fails the PR otherwise. E2E tests are required on every PR — `/validate` runs them. Editing the body after the PR is opened does **not** re-trigger CI; push a commit or close + reopen the PR to refresh the event payload.


### PR DESCRIPTION
## Background and Motivation

The "PR E2E attestation" CI job greps the PR body for `^## [Tt]esting` followed by a checked item containing `[Ee]2[Ee]`. This contract was unwritten — PR #119 hit it and had to be reopened to refresh the event payload after editing the body. New contributors (human or otherwise) shouldn't have to learn this from CI failures.

While codifying the contract, simplify the local-test recommendation to `pnpm test:e2e` (the standard cross-platform path); `./run-linux-e2e.sh` is for reproducing CI-environment-specific failures and shouldn't be the default.

## Design Decisions

- **Single E2E checkbox, no escape hatch.** Dropped the "E2E not applicable — CI-only change" alternative the workflow accepts. In practice almost any change can break E2E (config files, lint rules, even docs that get scanned), and the cost of running locally is ~1 minute. Always-run is simpler than always-justify.
- **Recommend `pnpm test:e2e` over `./run-linux-e2e.sh`** in the template comment. The Docker form stays available for Linux/CI repro but isn't the suggested default.
- **`/validate` step 6 is now non-skippable.** Updated wording explicitly forbids skipping E2E for "looks UI-only" or "looks backend-only" changes, and requires E2E result in the summary report.
- **CLAUDE.md gets a short pointer** at the template + the gotcha about body edits not re-triggering CI (close+reopen or push to refresh).

## Proposed Changes

**`.github/PULL_REQUEST_TEMPLATE.md`** (new)
- Sections matching the project's existing PR style: Background and Motivation, Design Decisions, Proposed Changes, Testing.
- Testing checklist mirrors `/validate` steps with one canonical E2E item that satisfies CI.

**`.claude/commands/validate.md`**
- Step 6 marked mandatory with explicit "never skip" wording.
- New rule: E2E is non-negotiable; the summary must include the E2E result.

**`CLAUDE.md`**
- New "Pull request body" subsection under the Verification Checklist pointing at the template, citing the exact `## Testing` heading requirement, and noting that body edits don't re-trigger CI.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (3346 passing — no code changes, sanity check only)
- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 72 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)