### PR TITLE
fix(keyboard): let Monaco handle Cmd+/ for toggle-comment

### DIFF
--- a/src/renderer/shared/hooks/useLayoutKeyboard.test.ts
+++ b/src/renderer/shared/hooks/useLayoutKeyboard.test.ts
@@ -499,6 +499,29 @@ describe('useLayoutKeyboard', () => {
       expect(onShowShortcuts).toHaveBeenCalled()
     })
 
+    it('Cmd+/ does not call onShowShortcuts when focus is in monaco-editor', () => {
+      const editor = document.createElement('div')
+      editor.classList.add('monaco-editor')
+      const textarea = document.createElement('div')
+      textarea.tabIndex = 0
+      editor.appendChild(textarea)
+      document.body.appendChild(editor)
+      textarea.focus()
+
+      renderHook(() => useLayoutKeyboard(defaultProps))
+
+      let defaultPrevented = false
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: '/', metaKey: true, bubbles: true, cancelable: true })
+        window.dispatchEvent(event)
+        defaultPrevented = event.defaultPrevented
+      })
+
+      expect(onShowShortcuts).not.toHaveBeenCalled()
+      expect(defaultPrevented).toBe(false)
+      document.body.removeChild(editor)
+    })
+
     it('Alt+Down calls onNextSession', () => {
       renderHook(() => useLayoutKeyboard(defaultProps))
       act(() => {

--- a/src/renderer/shared/hooks/useLayoutKeyboard.ts
+++ b/src/renderer/shared/hooks/useLayoutKeyboard.ts
@@ -53,6 +53,11 @@ function isInsideModalDialog(): boolean {
   return !!document.activeElement?.closest('[role="dialog"][aria-modal="true"]')
 }
 
+/** Check if focus is inside a Monaco editor, which has its own keybindings (e.g. Cmd+/ for toggle comment). */
+function isInsideMonaco(): boolean {
+  return !!document.activeElement?.closest('.monaco-editor')
+}
+
 /** Check if focus is in a context that should pass through arrow keys. */
 function isArrowPassthrough(el: Element): boolean {
   if (el.closest('.xterm')) return true
@@ -293,6 +298,9 @@ export function useLayoutKeyboard({
       const key = shortcutKey(e)
       const appAction = appWideShortcuts.get(key)
       if (appAction) {
+        // Cmd+/ is Monaco's toggle-line-comment binding. When focus is in a
+        // Monaco editor, let Monaco handle it instead of opening the shortcuts modal.
+        if (key === 'mod:/' && isInsideMonaco()) return
         e.preventDefault()
         e.stopImmediatePropagation()
         appAction()


### PR DESCRIPTION
## Background and Motivation

Pressing `Cmd+/` while editing in a Monaco file viewer opened the keyboard-shortcuts modal instead of toggling line comments. Monaco's built-in `editor.action.commentLine` binding never received the keystroke because the global app handler intercepted it first.

## Design Decisions

The global `Cmd+/` shortcut still opens the shortcuts modal everywhere else. Monaco was singled out (rather than excluding all text inputs) because it's the only context with a meaningful `Cmd+/` binding of its own; xterm doesn't, and other text inputs don't expect it either. Implemented by checking `document.activeElement?.closest('.monaco-editor')` inside the keydown handler before calling `preventDefault()`, mirroring the existing `isInsideModalDialog` / `isArrowPassthrough` patterns in the same file.

## Proposed Changes

- `useLayoutKeyboard.ts`: added `isInsideMonaco()` helper and an early-return in the app-wide shortcut path that lets `mod:/` fall through to Monaco when focus is inside the editor.
- `useLayoutKeyboard.test.ts`: added a test asserting `Cmd+/` in a `.monaco-editor` does not call `onShowShortcuts` and does not `preventDefault` the event.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (coverage at or above 90% lines)
- [x] Ran all E2E tests locally (`pnpm test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)