### PR TITLE
fix(terminal): set CLAUDE_CODE_NO_FLICKER=1 to dodge xterm duplicate-content bug

### DIFF
--- a/src/main/handlers/pty.test.ts
+++ b/src/main/handlers/pty.test.ts
@@ -493,6 +493,43 @@ describe('pty handlers', () => {
       expect(spawnEnv.CLAUDE_CONFIG_DIR).toContain('.claude-custom')
     })
 
+    it('defaults CLAUDE_CODE_NO_FLICKER=1 to opt Claude into alt-screen', async () => {
+      const { register } = await import('./pty')
+      const ctx = createCtx()
+      register(mockIpcMain as never, ctx)
+
+      const mockProcess = createMockPtyProcess()
+      mockPtySpawn.mockReturnValue(mockProcess)
+      mockBrowserWindowFromWebContents.mockReturnValue(mockSenderWindow)
+
+      await handlers['pty:create'](mockEvent, {
+        id: 'env-no-flicker-default',
+        cwd: '/tmp',
+      })
+
+      const spawnEnv = mockPtySpawn.mock.calls[0][2].env
+      expect(spawnEnv.CLAUDE_CODE_NO_FLICKER).toBe('1')
+    })
+
+    it('lets per-session env override CLAUDE_CODE_NO_FLICKER', async () => {
+      const { register } = await import('./pty')
+      const ctx = createCtx()
+      register(mockIpcMain as never, ctx)
+
+      const mockProcess = createMockPtyProcess()
+      mockPtySpawn.mockReturnValue(mockProcess)
+      mockBrowserWindowFromWebContents.mockReturnValue(mockSenderWindow)
+
+      await handlers['pty:create'](mockEvent, {
+        id: 'env-no-flicker-override',
+        cwd: '/tmp',
+        env: { CLAUDE_CODE_NO_FLICKER: '0' },
+      })
+
+      const spawnEnv = mockPtySpawn.mock.calls[0][2].env
+      expect(spawnEnv.CLAUDE_CODE_NO_FLICKER).toBe('0')
+    })
+
     it('does not set owner window when sender window not found', async () => {
       const { register } = await import('./pty')
       const ctx = createCtx()

--- a/src/main/handlers/pty.ts
+++ b/src/main/handlers/pty.ts
@@ -236,9 +236,11 @@ function createDevcontainerPty(
       })
     }
 
-    // Start docker exec PTY using devcontainer's remote user
+    // Start docker exec PTY using devcontainer's remote user.
+    // Default CLAUDE_CODE_NO_FLICKER=1 first so per-session env can override
+    // it (see standard PTY path for rationale).
     const containerHome = remoteUser === 'root' ? '/root' : `/home/${remoteUser}`
-    const dockerEnv: Record<string, string> = {}
+    const dockerEnv: Record<string, string> = { CLAUDE_CODE_NO_FLICKER: '1' }
     if (options.env) {
       for (const [key, value] of Object.entries(options.env)) {
         if (value.startsWith('~/')) {
@@ -368,7 +370,17 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
     // Build environment — extend PATH with common bin dirs so agents in
     // ~/.local/bin, /opt/homebrew/bin, etc. are reachable even if the
     // login shell profile doesn't add them or resolveShellEnv() failed.
-    const baseEnv = { ...process.env, PATH: enhancedPath(process.env.PATH) } as Record<string, string>
+    //
+    // CLAUDE_CODE_NO_FLICKER=1 opts Claude Code into alt-screen rendering,
+    // which avoids the duplicate-content / scroll-yank bugs that arise when
+    // its synchronized full-screen redraws are written to the main buffer.
+    // See xtermjs/xterm.js#5784 and #5801. Per-session env (agentEnv) is
+    // merged after this, so users can override with CLAUDE_CODE_NO_FLICKER=0.
+    const baseEnv = {
+      ...process.env,
+      PATH: enhancedPath(process.env.PATH),
+      CLAUDE_CODE_NO_FLICKER: '1',
+    } as Record<string, string>
     delete baseEnv.CLAUDE_CONFIG_DIR
 
     const expandHome = (value: string) => {


### PR DESCRIPTION
## Background and Motivation

Users running Claude Code inside Broomy have been reporting that conversation content (e.g. \"Q6 — Misconception trap\", multi-paragraph explanation blocks) appears **duplicated** in xterm's scrollback as the session progresses. Captured PTY byte streams show the same byte-level pattern: Claude does a synchronized full-screen redraw on the **main buffer** using `ESC[?2026h … ESC[2K ESC[1B (×N) ESC[H … ESC[?2026l`, and the bytes themselves contain the duplicated text — xterm.js is rendering exactly what it's told.

Upstream xterm.js has explicitly declined to patch around this. From their maintainer on [xtermjs/xterm.js#5784](https://github.com/xtermjs/xterm.js/issues/5784) and [#5801](https://github.com/xtermjs/xterm.js/issues/5801):

> *AI cli tools using terminal functions wrong... The real fix would be for those tools to stop using ED at all, if they want the scrollback to be intact, or to switch to altbuffer without scrollback. I think we should not patch around misusage of terminal functions.*

Anthropic shipped `CLAUDE_CODE_NO_FLICKER=1` in claude-code v2.1.89 to opt Claude into the alt-screen buffer, which sidesteps the bug. Setting it in Broomy's PTY env is a one-line mitigation that costs us xterm-level scrollback while Claude is running (Claude's own UI still scrolls), in exchange for clean rendering.

## Design Decisions

- **Default the env var in baseEnv, before agentEnv** so per-session env can override it with `CLAUDE_CODE_NO_FLICKER=0` if someone explicitly wants the old behavior (e.g. heavy xterm-scrollback workflows).
- **Apply to both PTY paths** (standard + devcontainer Docker exec). The devcontainer path passes env into the container via docker exec args, so the var has to land in `dockerEnv` not just baseEnv.

## Proposed Changes

`src/main/handlers/pty.ts` — default `CLAUDE_CODE_NO_FLICKER=1` in both standard and devcontainer PTY spawn paths.

`src/main/handlers/pty.test.ts` — two new unit tests: one confirming the default, one confirming per-session env overrides it.

Diagnostic harness work (fixture extension, byte-level bisect tooling, `@xterm/headless` version alignment) is **deliberately not included here** — it lives on `fix/xterm-bug-harness` for a follow-up PR.

## Testing

- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [ ] \`pnpm check:all\`
- [x] \`pnpm test:unit\` (relevant: `pty.test.ts` 34/34 passing, including the two new env-var tests)
- [ ] Ran all E2E tests locally (\`pnpm test:e2e\`)

Manual verification: rebuilt with the env var set, ran a long Claude conversation, confirmed no duplicate content appeared in scrollback. Setting `CLAUDE_CODE_NO_FLICKER=0` in agent env brings the old broken behavior back, confirming the override path works.

⚠️ E2E + check:all not yet run from this branch — the CI \"PR E2E attestation\" job will block merge until those boxes are checked. Recommend running \`/validate\` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)