### PR TITLE
fix(diff-viewer): revert diff colors to vs-dark defaults

### DIFF
--- a/src/renderer/panels/fileViewer/viewers/MonacoDiffViewer.test.tsx
+++ b/src/renderer/panels/fileViewer/viewers/MonacoDiffViewer.test.tsx
@@ -52,7 +52,7 @@ describe('MonacoDiffViewer', () => {
     expect(mockDiffEditor).toHaveBeenCalledWith(
       expect.objectContaining({
         language: 'typescript',
-        theme: 'broomy-dark',
+        theme: 'vs-dark',
       })
     )
   })

--- a/src/renderer/panels/fileViewer/viewers/MonacoDiffViewer.tsx
+++ b/src/renderer/panels/fileViewer/viewers/MonacoDiffViewer.tsx
@@ -14,23 +14,6 @@ import { useMonacoComments } from '../hooks/useMonacoComments'
 // Configure Monaco to use locally bundled version instead of CDN
 loader.config({ monaco: monacoEditor })
 
-// Boost diff highlight opacity over vs-dark defaults. Monaco's defaults are
-// ~20% alpha, which on the dark navy background renders side-by-side diffs as
-// near-plain-text. Inline mode is fine because its view zones use stronger
-// styling; only side-by-side needs the help.
-const BROOMY_DARK_THEME_NAME = 'broomy-dark'
-monacoEditor.editor.defineTheme(BROOMY_DARK_THEME_NAME, {
-  base: 'vs-dark',
-  inherit: true,
-  rules: [],
-  colors: {
-    'diffEditor.insertedLineBackground': '#3b8c2a55',
-    'diffEditor.removedLineBackground': '#c43c3c55',
-    'diffEditor.insertedTextBackground': '#9ccc2c80',
-    'diffEditor.removedTextBackground': '#ff000080',
-  },
-})
-
 interface MonacoDiffViewerProps {
   filePath: string
   originalContent: string
@@ -222,7 +205,7 @@ export default function MonacoDiffViewer({
           language={detectedLanguage}
           original={originalContent}
           modified={modifiedContent}
-          theme={BROOMY_DARK_THEME_NAME}
+          theme="vs-dark"
           onMount={handleDiffEditorMount}
           keepCurrentOriginalModel={false}
           keepCurrentModifiedModel={false}


### PR DESCRIPTION
## Background and Motivation

PR #127 (`fix(diff-viewer): wrap both panes and make side-by-side diffs visible`) introduced a custom `broomy-dark` Monaco theme that boosted the inserted/removed background opacity well above Monaco's `vs-dark` defaults. The brighter green/red row tints made inline review comments unreadable on top of diff lines.

## Design Decisions

Only the color override is reverted. The word-wrap fixes from #127 (`diffWordWrap: 'on'` and `useInlineViewWhenSpaceIsLimited: false`) stay in place — those are independent of the theme and still solve the original side-by-side wrap bug.

## Proposed Changes

- `MonacoDiffViewer.tsx`: drop the `BROOMY_DARK_THEME_NAME` constant and the `monacoEditor.editor.defineTheme(...)` call that set the louder diff colors. Pass `theme="vs-dark"` back to `<DiffEditor>`.
- `MonacoDiffViewer.test.tsx`: update the theme assertion from `'broomy-dark'` to `'vs-dark'` to match.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (coverage 90.22% lines)
- [x] Ran all E2E tests locally (`pnpm test:e2e`)