### PR TITLE
fix(file-viewer): keep markdown preview from snapping back to diff

### DIFF
--- a/src/renderer/panels/fileViewer/hooks/useFileViewer.test.ts
+++ b/src/renderer/panels/fileViewer/hooks/useFileViewer.test.ts
@@ -638,4 +638,52 @@ describe('useFileViewer', () => {
       expect(result.current.editorActions).toBeNull()
     })
   })
+
+  describe('viewMode persistence across re-renders', () => {
+    it('preserves user-switched viewMode when parent re-renders with new callback refs (regression)', () => {
+      // Repro: opening a markdown diff (initialViewMode='diff'), switching to
+      // preview (viewMode='latest'), then any incidental parent re-render
+      // (e.g. inline onDirtyStateChange gets a fresh ref) used to flip
+      // viewMode back to 'diff' because the init effect ran unconditionally.
+      const { result, rerender } = renderHook(
+        ({ onDirtyStateChange }) =>
+          useFileViewer({
+            filePath: '/test/file.md',
+            fileStatus: 'modified',
+            initialViewMode: 'diff',
+            onDirtyStateChange,
+          }),
+        { initialProps: { onDirtyStateChange: vi.fn() } },
+      )
+
+      expect(result.current.viewMode).toBe('diff')
+
+      act(() => {
+        result.current.setViewMode('latest')
+      })
+      expect(result.current.viewMode).toBe('latest')
+
+      // Parent re-renders with a fresh inline callback reference.
+      rerender({ onDirtyStateChange: vi.fn() })
+
+      expect(result.current.viewMode).toBe('latest')
+    })
+
+    it('still respects a new initialViewMode prop (e.g. re-opening from source control)', () => {
+      const { result, rerender } = renderHook(
+        ({ initialViewMode }) =>
+          useFileViewer({
+            filePath: '/test/file.md',
+            fileStatus: 'modified',
+            initialViewMode,
+          }),
+        { initialProps: { initialViewMode: 'latest' as 'latest' | 'diff' } },
+      )
+
+      expect(result.current.viewMode).toBe('latest')
+
+      rerender({ initialViewMode: 'diff' })
+      expect(result.current.viewMode).toBe('diff')
+    })
+  })
 })

--- a/src/renderer/panels/fileViewer/hooks/useFileViewer.ts
+++ b/src/renderer/panels/fileViewer/hooks/useFileViewer.ts
@@ -42,7 +42,9 @@ export function useFileViewer({
   const [editedContent, setEditedContent] = useState<string>('')
   const [isSaving, setIsSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
-  const [viewMode, setViewMode] = useState<ViewMode>('latest')
+  const [viewMode, setViewMode] = useState<ViewMode>(() =>
+    initialViewMode === 'diff' ? 'diff' : 'latest',
+  )
   const [pendingViewMode, setPendingViewMode] = useState<ViewMode | null>(null)
   const [diffSideBySide, setDiffSideBySide] = useState(true)
   const [editorActions, setEditorActions] = useState<EditorActions | null>(null)
@@ -100,16 +102,26 @@ export function useFileViewer({
   }, [scrollToLine, selectedViewerId, availableViewers])
 
   // Reset view mode when file changes or initialViewMode changes (e.g. clicking same file from source control)
-  // Only reset isDirty when the file itself changes, not on view mode changes
+  // Only reset isDirty when the file itself changes, not on view mode changes.
+  // The setViewMode reset must only fire when filePath/initialViewMode actually
+  // change — not on every dep churn (e.g. inline onDirtyStateChange callbacks
+  // get fresh refs on parent re-render), or it would clobber a user-switched
+  // viewMode and snap back to diff while the user is reading the preview.
   const prevFilePathRef = useRef(filePath)
+  const prevInitialViewModeRef = useRef(initialViewMode)
   useEffect(() => {
-    if (prevFilePathRef.current !== filePath) {
+    const filePathChanged = prevFilePathRef.current !== filePath
+    const initialViewModeChanged = prevInitialViewModeRef.current !== initialViewMode
+    if (filePathChanged) {
       setIsDirty(false)
       onDirtyStateChange?.(false)
       prevFilePathRef.current = filePath
     }
-    const shouldUseDiffMode = canShowDiff && (fileStatus === 'deleted' || initialViewMode === 'diff')
-    setViewMode(shouldUseDiffMode ? 'diff' : 'latest')
+    if (filePathChanged || initialViewModeChanged) {
+      const shouldUseDiffMode = canShowDiff && (fileStatus === 'deleted' || initialViewMode === 'diff')
+      setViewMode(shouldUseDiffMode ? 'diff' : 'latest')
+      prevInitialViewModeRef.current = initialViewMode
+    }
   }, [filePath, initialViewMode, canShowDiff, fileStatus, onDirtyStateChange])
 
   // Safety guard: viewMode must never be 'diff' when diffs are unavailable.


### PR DESCRIPTION
## Background and Motivation

Opening a markdown file's diff and then switching to the Preview viewer would, after a few seconds of interacting with the file, randomly snap back to the diff view. The trigger looked like scrolling but was actually any incidental parent re-render (agent activity / status updates / file-watcher events all mutate the `sessions` store, which feeds `usePanelsMap`).

## Design Decisions

The view-mode init effect in `useFileViewer` re-ran `setViewMode(...)` unconditionally on every dep change. One of those deps — `onDirtyStateChange` — is passed inline at the call site (`(dirty) => setIsFileViewerDirty(session.id, dirty)`), so it gets a fresh reference whenever the panels memo recomputes. Each fresh ref re-fired the effect, which re-applied `initialViewMode='diff'` over the user's explicit switch to `'latest'`.

Two-part fix that keeps the existing public surface:

- **Lazy-initialize `viewMode`** from `initialViewMode` so the first render has the right value without relying on the effect to "correct" it.
- **Gate the reset on actual prop changes** by tracking `filePath` *and* `initialViewMode` via refs. Other dep churn (`canShowDiff`, `fileStatus`, `onDirtyStateChange`) no longer triggers a viewMode reset. The existing `effectiveViewMode` safety guard still covers `canShowDiff` flipping to false at runtime.

Alternative considered: memoizing `onDirtyStateChange` at the call site. Rejected — the bug would re-appear any time any other unstable callback is added to the prop list, and the right fix is for the effect to express what it actually means ("re-init when file or requested mode changes").

## Proposed Changes

- `src/renderer/panels/fileViewer/hooks/useFileViewer.ts` — lazy `useState` init for `viewMode`; track previous `initialViewMode` alongside previous `filePath`; only call `setViewMode` when one of those two actually changes.
- `src/renderer/panels/fileViewer/hooks/useFileViewer.test.ts` — regression test that switches `viewMode` to `'latest'`, re-renders with a fresh `onDirtyStateChange` ref, and asserts the viewer stays in preview. Plus a paired test that a real `initialViewMode` change still propagates.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (coverage at or above 90% lines — overall 90.23%)
- [x] Ran all E2E tests locally (`pnpm test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)