### PR TITLE
feat(website): advertise Mac, Windows, and Linux support

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - '.'
   - 'website'
+allowBuilds:
+  electron: true
+  esbuild: true
+  node-pty: true
 onlyBuiltDependencies:
   - node-pty

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://broomy.org'),
   title: 'Broomy — Command center for AI coding agents',
   description:
-    'Manage multiple AI coding sessions across repositories. Open source desktop app with agent status detection, file explorer, git integration, and code review. Download for macOS.',
+    'Manage multiple AI coding sessions across repositories. Open source desktop app with agent status detection, file explorer, git integration, and code review. Download for macOS, Windows, and Linux.',
   icons: {
     icon: '/favicon.png',
     apple: '/favicon.png',

--- a/website/src/components/DownloadButton.tsx
+++ b/website/src/components/DownloadButton.tsx
@@ -7,7 +7,7 @@ export function DownloadButtons({ compact }: { compact?: boolean }) {
         href={RELEASE_URL}
         className="rounded-lg bg-text-primary px-4 py-2 text-sm font-semibold text-bg-page transition-transform hover:scale-[1.02]"
       >
-        Download for Mac
+        Download
       </a>
     )
   }
@@ -15,15 +15,10 @@ export function DownloadButtons({ compact }: { compact?: boolean }) {
   return (
     <a
       href={RELEASE_URL}
-      className="inline-flex flex-col items-center rounded-lg border border-border-hover px-8 py-4 text-lg font-semibold text-text-primary transition-all hover:scale-[1.02] hover:border-text-muted"
+      className="inline-flex items-center gap-2 rounded-lg border border-border-hover px-8 py-4 text-lg font-semibold text-text-primary transition-all hover:scale-[1.02] hover:border-text-muted"
     >
-      <span className="flex items-center gap-2">
-        <DownloadIcon />
-        Download for Mac
-      </span>
-      <span className="mt-1 text-xs font-normal text-text-muted">
-        Mac only (Windows, Linux coming soon)
-      </span>
+      <DownloadIcon />
+      Download
     </a>
   )
 }

--- a/website/src/components/GetStarted.tsx
+++ b/website/src/components/GetStarted.tsx
@@ -34,7 +34,9 @@ export default function GetStarted() {
 
         {/* Secondary: download pre-built */}
         <div className="mt-12">
-          <p className="mb-4 text-sm text-text-muted">Or download a pre-built release:</p>
+          <p className="mb-4 text-sm text-text-muted">
+            Or download a pre-built release for Mac, Windows, or Linux:
+          </p>
           <DownloadButton />
         </div>
       </div>

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -40,9 +40,7 @@ export default function Hero() {
           </a>
           <DownloadButton />
         </div>
-        <div className="mx-auto mt-5 max-w-2xl rounded-lg border border-border-hover bg-bg-elevated px-4 py-3 text-sm text-text-body">
-          Public Preview - stable enough for daily use, but you may run into issues
-        </div>
+        <p className="mt-4 text-sm text-text-muted">Available for Mac, Windows, and Linux</p>
 
         {/* Badges row */}
         <div className="mt-6 flex flex-wrap items-center justify-center gap-3">


### PR DESCRIPTION
## Background and Motivation

Broomy now ships on Linux and Windows in addition to Mac, but the marketing site still presented it as Mac-only ("Download for Mac", "Mac only (Windows, Linux coming soon)"). This updates the site copy to reflect cross-platform availability. It also removes the "Public Preview" stability banner since the app is now stable for daily use.

## Design Decisions

- The GitHub releases page already serves artifacts for all platforms, so the download links are unchanged — only the labels and surrounding copy needed updating.
- The download button now matches the "View on GitHub" button's single-line size; the platform list moved to a caption below the button row so the two CTAs line up in the Hero.

## Proposed Changes

- **DownloadButton**: removed Mac-specific labels; the primary button is now a single-line "Download" matching the GitHub button's dimensions.
- **Hero**: added an "Available for Mac, Windows, and Linux" caption; removed the "Public Preview — stable enough for daily use…" banner.
- **GetStarted**: the pre-built release blurb now lists all three platforms.
- **layout**: SEO meta description updated to list macOS, Windows, and Linux.
- **pnpm-workspace.yaml**: `allowBuilds` config (pre-existing change already on this branch, included for completeness).

## Testing

These are website-only changes (the `website/` Next.js app); the Electron app and its E2E suite are untouched. Verified the website production build:

- [x] `website` production build passes (`cd website && pnpm build`)
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm check:all`
- [ ] `pnpm test:unit` (coverage at or above 90% lines)
- [ ] Ran all E2E tests locally (`pnpm test:e2e`)
