### PR TITLE
fix(agent): stop session status sticking on "Working" when the agent is idle

### DIFF
--- a/src/renderer/panels/agent/hooks/ptyDataHandler.test.ts
+++ b/src/renderer/panels/agent/hooks/ptyDataHandler.test.ts
@@ -109,8 +109,20 @@ describe('createPtyDataHandler', () => {
       terminal.setScreen(['prompt>', 'thinking...'])
       handler.handleData('thinking...')
       vi.advanceTimersByTime(SAMPLE_MS)
-      expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'working' })
+      expect(state.scheduleUpdate).toHaveBeenCalledWith(expect.objectContaining({ status: 'working' }))
       expect(state.lastStatusRef.current).toBe('working')
+    })
+
+    it('reports the first-output time as workingStartedAt, not the later sample time', () => {
+      const handler = agentPastWarmup(['line 1'])
+      const firstOutput = Date.now()
+      terminal.setScreen(['line 1', 'work'])
+      handler.handleData('work')          // output arrives at firstOutput
+      vi.advanceTimersByTime(SAMPLE_MS)    // sample runs SAMPLE_MS later
+      // workingStartTime must be measured from the output, so the >=3s unread
+      // threshold isn't undercounted by the sampling/debounce delay.
+      expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'working', workingStartedAt: firstOutput })
+      expect(firstOutput).toBeLessThan(Date.now())
     })
 
     it('never flips an idle session to working on an UNCHANGED repaint — the core fix', () => {
@@ -120,7 +132,7 @@ describe('createPtyDataHandler', () => {
         handler.handleData('\x1b[?2026h idle footer \x1b[?2026l')
         vi.advanceTimersByTime(SAMPLE_MS)
       }
-      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'working' })
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'working' }))
       expect(state.lastStatusRef.current).toBe('idle')
     })
 
@@ -183,7 +195,7 @@ describe('createPtyDataHandler', () => {
       terminal.setScreen(['a', 'b'])
       handler.handleData('b')
       vi.advanceTimersByTime(SAMPLE_MS)
-      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'working' })
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'working' }))
     })
 
     it('clearTimers cancels the pending idle and sample timers', () => {
@@ -207,12 +219,12 @@ describe('createPtyDataHandler', () => {
       handler.handleData('big burst still parsing...')
       vi.advanceTimersByTime(2000)
       // Parse not done → no sample scheduled → no premature transition.
-      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'working' })
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'working' }))
       // Parse completes with a changed screen → the post-parse sample catches it.
       terminal.setScreen(['line 1', 'big burst parsed'])
       parseComplete?.()
       vi.advanceTimersByTime(SAMPLE_MS)
-      expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'working' })
+      expect(state.scheduleUpdate).toHaveBeenCalledWith(expect.objectContaining({ status: 'working' }))
     })
 
     it('a sample pending at teardown cannot revive the session', () => {
@@ -222,7 +234,7 @@ describe('createPtyDataHandler', () => {
       handler.clearTimers()              // e.g. PTY exit / unmount before it runs
       state.scheduleUpdate.mockClear()
       vi.advanceTimersByTime(SAMPLE_MS + 5000)
-      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'working' })
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'working' }))
     })
   })
 

--- a/src/renderer/panels/agent/hooks/ptyDataHandler.test.ts
+++ b/src/renderer/panels/agent/hooks/ptyDataHandler.test.ts
@@ -1,23 +1,37 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createPtyDataHandler } from './ptyDataHandler'
 
-vi.mock('../utils/terminalActivityDetector', () => ({
-  evaluateActivity: vi.fn().mockReturnValue({ status: null, scheduleIdle: false }),
-}))
+/** Throttle interval used by the handler's screen sampler (must match SAMPLE_INTERVAL_MS). */
+const SAMPLE_MS = 250
+
+interface MockTerminal {
+  write: ReturnType<typeof vi.fn>
+  scrollToBottom: ReturnType<typeof vi.fn>
+  setScreen: (lines: string[]) => void
+}
 
 function makeTerminal() {
-  return {
-    write: vi.fn(),
-    buffer: { active: { viewportY: 0, baseY: 0 } },
+  let screen: string[] = []
+  const term = {
+    // xterm's write invokes its callback after the chunk is parsed; the handler
+    // schedules screen sampling from that callback. The mock fires it synchronously.
+    write: vi.fn((_data: string, cb?: () => void) => { cb?.() }),
+    buffer: {
+      active: {
+        viewportY: 0,
+        baseY: 0,
+        getLine: (y: number) => (y < screen.length ? { translateToString: () => screen[y] } : undefined),
+      },
+    },
     cols: 80,
     rows: 24,
     resize: vi.fn(),
     scrollToBottom: vi.fn(),
-    parser: {
-      registerCsiHandler: vi.fn().mockReturnValue({ dispose: vi.fn() }),
-    },
-  } as unknown as import('@xterm/xterm').Terminal
+    parser: { registerCsiHandler: vi.fn().mockReturnValue({ dispose: vi.fn() }) },
+    setScreen: (lines: string[]) => { screen = lines },
+  }
+  return term as unknown as import('@xterm/xterm').Terminal & MockTerminal
 }
 
 function makeState() {
@@ -25,7 +39,7 @@ function makeState() {
     processPlanDetection: vi.fn(),
     lastUserInputRef: { current: 0 },
     lastInteractionRef: { current: 0 },
-    lastStatusRef: { current: 'idle' as const },
+    lastStatusRef: { current: 'idle' as 'working' | 'idle' },
     idleTimeoutRef: { current: null } as { current: ReturnType<typeof setTimeout> | null },
     scheduleUpdate: vi.fn(),
   }
@@ -67,19 +81,6 @@ describe('createPtyDataHandler', () => {
     handler.handleData('hello')
     handler.handleData(' world')
     expect(terminal.write).toHaveBeenCalledTimes(2)
-    expect(terminal.write).toHaveBeenCalledWith('hello')
-    expect(terminal.write).toHaveBeenCalledWith(' world')
-  })
-
-  it('runs activity detection for agent terminals', async () => {
-    const { evaluateActivity } = await import('../utils/terminalActivityDetector')
-    vi.mocked(evaluateActivity).mockReturnValue({ status: 'working', scheduleIdle: true })
-
-    const handler = createHandler({ isAgent: true })
-    handler.handleData('output')
-
-    expect(evaluateActivity).toHaveBeenCalled()
-    expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'working' })
   })
 
   it('does not run activity detection for non-agent terminals', () => {
@@ -88,46 +89,146 @@ describe('createPtyDataHandler', () => {
     expect(state.processPlanDetection).not.toHaveBeenCalled()
   })
 
-  it('schedules idle timeout when scheduleIdle is true and status is not working', async () => {
-    vi.useFakeTimers()
-    const { evaluateActivity } = await import('../utils/terminalActivityDetector')
-    vi.mocked(evaluateActivity).mockReturnValue({ status: null, scheduleIdle: true })
+  describe('activity detection (rendered-change + capped stability lease)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(1_000_000)
+    })
+    afterEach(() => { vi.useRealTimers() })
 
-    const handler = createHandler({ isAgent: true })
-    handler.handleData('output')
+    /** Create an agent handler past its warmup, with a known baseline screen. */
+    function agentPastWarmup(baseline: string[]) {
+      terminal.setScreen(baseline)
+      const handler = createHandler({ isAgent: true })
+      vi.advanceTimersByTime(6000) // past the 5s warmup
+      return handler
+    }
 
-    // Idle timeout not yet fired
-    expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'idle' })
+    it('flags working when the rendered screen changes after warmup', () => {
+      const handler = agentPastWarmup(['prompt>'])
+      terminal.setScreen(['prompt>', 'thinking...'])
+      handler.handleData('thinking...')
+      vi.advanceTimersByTime(SAMPLE_MS)
+      expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'working' })
+      expect(state.lastStatusRef.current).toBe('working')
+    })
 
-    // Existing idle timeout should have been cleared and a new one scheduled
-    vi.advanceTimersByTime(1000)
-    expect(state.lastStatusRef.current).toBe('idle')
-    expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'idle' })
+    it('never flips an idle session to working on an UNCHANGED repaint — the core fix', () => {
+      const handler = agentPastWarmup(['idle footer'])
+      // Agent repaints the exact same screen (sync-wrapped), many times.
+      for (let i = 0; i < 5; i++) {
+        handler.handleData('\x1b[?2026h idle footer \x1b[?2026l')
+        vi.advanceTimersByTime(SAMPLE_MS)
+      }
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'working' })
+      expect(state.lastStatusRef.current).toBe('idle')
+    })
 
-    vi.useRealTimers()
-  })
+    it('idles after the stability cap when an idle TUI keeps repainting the same screen', () => {
+      const handler = agentPastWarmup(['line 1'])
+      // Real work makes the screen change → working.
+      terminal.setScreen(['line 1', 'working...'])
+      handler.handleData('working...')
+      vi.advanceTimersByTime(SAMPLE_MS)
+      expect(state.lastStatusRef.current).toBe('working')
 
-  it('clears previous idle timeout when scheduleIdle and status is not working', async () => {
-    vi.useFakeTimers()
-    const { evaluateActivity } = await import('../utils/terminalActivityDetector')
-    vi.mocked(evaluateActivity).mockReturnValue({ status: null, scheduleIdle: true })
+      // Then the agent goes idle but repaints the SAME screen every 500ms.
+      state.scheduleUpdate.mockClear()
+      for (let i = 0; i < 12; i++) {
+        vi.advanceTimersByTime(500)
+        handler.handleData('\x1b[?2026h working... \x1b[?2026l') // screen unchanged
+        vi.advanceTimersByTime(SAMPLE_MS)
+      }
+      // Within maxStableOutputMs (3s) of the last real change it must have idled,
+      // despite output never stopping.
+      expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'idle' })
+      expect(state.lastStatusRef.current).toBe('idle')
+    })
 
-    const handler = createHandler({ isAgent: true })
-    // Set up an existing idle timeout
-    state.idleTimeoutRef.current = setTimeout(() => {}, 5000)
-    handler.handleData('output')
+    it('stays working while the screen keeps changing, even past the stability cap', () => {
+      const handler = agentPastWarmup(['line 1'])
+      terminal.setScreen(['line 1', 'stream 0'])
+      handler.handleData('stream 0')
+      vi.advanceTimersByTime(SAMPLE_MS)
+      expect(state.lastStatusRef.current).toBe('working')
 
-    // The old timeout should have been replaced
-    vi.advanceTimersByTime(1000)
-    expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'idle' })
+      state.scheduleUpdate.mockClear()
+      for (let i = 1; i < 12; i++) {
+        vi.advanceTimersByTime(500)
+        terminal.setScreen(['line 1', `stream ${i}`]) // screen changes each time
+        handler.handleData(`stream ${i}`)
+        vi.advanceTimersByTime(SAMPLE_MS)
+      }
+      expect(state.lastStatusRef.current).toBe('working')
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'idle' })
+    })
 
-    vi.useRealTimers()
+    it('idles after idleTimeoutMs of true silence', () => {
+      const handler = agentPastWarmup(['line 1'])
+      terminal.setScreen(['line 1', 'done'])
+      handler.handleData('done')
+      vi.advanceTimersByTime(SAMPLE_MS)
+      expect(state.lastStatusRef.current).toBe('working')
+
+      state.scheduleUpdate.mockClear()
+      vi.advanceTimersByTime(1000) // no further output → silence timeout
+      expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'idle' })
+      expect(state.lastStatusRef.current).toBe('idle')
+    })
+
+    it('ignores a screen change during the warmup window', () => {
+      terminal.setScreen(['a'])
+      const handler = createHandler({ isAgent: true })
+      vi.advanceTimersByTime(1000) // still within 5s warmup
+      terminal.setScreen(['a', 'b'])
+      handler.handleData('b')
+      vi.advanceTimersByTime(SAMPLE_MS)
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'working' })
+    })
+
+    it('clearTimers cancels the pending idle and sample timers', () => {
+      const handler = agentPastWarmup(['line 1'])
+      terminal.setScreen(['line 1', 'x'])
+      handler.handleData('x') // arms a sample; will arm idle once working
+      vi.advanceTimersByTime(SAMPLE_MS)
+      handler.handleData('\x1b[?2026h x \x1b[?2026l') // another sample pending
+
+      handler.clearTimers()
+      state.scheduleUpdate.mockClear()
+      vi.advanceTimersByTime(10000)
+      expect(state.scheduleUpdate).not.toHaveBeenCalled()
+    })
+
+    it('samples only after the write callback fires — a change parsed late is still caught', () => {
+      const handler = agentPastWarmup(['line 1'])
+      // Simulate a slow/large parse: capture the write callback instead of firing it now.
+      let parseComplete: (() => void) | undefined
+      vi.mocked(terminal.write).mockImplementation((_d: string, cb?: () => void) => { parseComplete = cb })
+      handler.handleData('big burst still parsing...')
+      vi.advanceTimersByTime(2000)
+      // Parse not done → no sample scheduled → no premature transition.
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'working' })
+      // Parse completes with a changed screen → the post-parse sample catches it.
+      terminal.setScreen(['line 1', 'big burst parsed'])
+      parseComplete?.()
+      vi.advanceTimersByTime(SAMPLE_MS)
+      expect(state.scheduleUpdate).toHaveBeenCalledWith({ status: 'working' })
+    })
+
+    it('a sample pending at teardown cannot revive the session', () => {
+      const handler = agentPastWarmup(['line 1'])
+      terminal.setScreen(['line 1', 'late output'])
+      handler.handleData('late output') // schedules a sample
+      handler.clearTimers()              // e.g. PTY exit / unmount before it runs
+      state.scheduleUpdate.mockClear()
+      vi.advanceTimersByTime(SAMPLE_MS + 5000)
+      expect(state.scheduleUpdate).not.toHaveBeenCalledWith({ status: 'working' })
+    })
   })
 
   describe('repaint transaction detection', () => {
     it('registers CSI handlers for agent terminals', () => {
       createHandler({ isAgent: true })
-      // Should register 3 CSI handlers: sync set, clear scrollback, sync reset
       expect(terminal.parser.registerCsiHandler).toHaveBeenCalledTimes(3)
     })
 
@@ -138,8 +239,6 @@ describe('createPtyDataHandler', () => {
 
     it('scrolls to bottom after a repaint transaction (CSI 3 J inside DEC mode 2026)', () => {
       vi.useFakeTimers()
-
-      // Capture the CSI handler callbacks
       const handlers: { prefix?: string; final: string; cb: (params: (number | number[])[]) => void }[] = []
       vi.mocked(terminal.parser.registerCsiHandler).mockImplementation(
         (id: { prefix?: string; final: string }, cb: (params: (number | number[])[]) => boolean | Promise<boolean>) => {
@@ -147,30 +246,21 @@ describe('createPtyDataHandler', () => {
           return { dispose: vi.fn() }
         },
       )
-
       createHandler({ isAgent: true })
-
-      // Find handlers by their signature
       const syncSetHandler = handlers.find(h => h.prefix === '?' && h.final === 'h')!
       const clearScrollbackHandler = handlers.find(h => h.final === 'J' && !h.prefix)!
       const syncResetHandler = handlers.find(h => h.prefix === '?' && h.final === 'l')!
-
-      // Simulate: DEC mode 2026 set → CSI 3 J → DEC mode 2026 reset
       syncSetHandler.cb([2026])
       clearScrollbackHandler.cb([3])
       syncResetHandler.cb([2026])
-
-      // scrollToBottom should be called after 20ms delay
       expect(terminal.scrollToBottom).not.toHaveBeenCalled()
       vi.advanceTimersByTime(20)
       expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1)
-
       vi.useRealTimers()
     })
 
     it('does not scroll to bottom if CSI 3 J is not inside a sync transaction', () => {
       vi.useFakeTimers()
-
       const handlers: { prefix?: string; final: string; cb: (params: (number | number[])[]) => void }[] = []
       vi.mocked(terminal.parser.registerCsiHandler).mockImplementation(
         (id: { prefix?: string; final: string }, cb: (params: (number | number[])[]) => boolean | Promise<boolean>) => {
@@ -178,70 +268,27 @@ describe('createPtyDataHandler', () => {
           return { dispose: vi.fn() }
         },
       )
-
       createHandler({ isAgent: true })
-
       const clearScrollbackHandler = handlers.find(h => h.final === 'J' && !h.prefix)!
       const syncResetHandler = handlers.find(h => h.prefix === '?' && h.final === 'l')!
-
-      // CSI 3 J without prior DEC mode 2026 set
       clearScrollbackHandler.cb([3])
-      syncResetHandler.cb([2026])
-
-      vi.advanceTimersByTime(20)
-      expect(terminal.scrollToBottom).not.toHaveBeenCalled()
-
-      vi.useRealTimers()
-    })
-
-    it('does not scroll if repaint transaction exceeds timeout', () => {
-      vi.useFakeTimers()
-
-      const handlers: { prefix?: string; final: string; cb: (params: (number | number[])[]) => void }[] = []
-      vi.mocked(terminal.parser.registerCsiHandler).mockImplementation(
-        (id: { prefix?: string; final: string }, cb: (params: (number | number[])[]) => boolean | Promise<boolean>) => {
-          handlers.push({ ...id, cb: cb as (params: (number | number[])[]) => void })
-          return { dispose: vi.fn() }
-        },
-      )
-
-      createHandler({ isAgent: true })
-
-      const syncSetHandler = handlers.find(h => h.prefix === '?' && h.final === 'h')!
-      const clearScrollbackHandler = handlers.find(h => h.final === 'J' && !h.prefix)!
-      const syncResetHandler = handlers.find(h => h.prefix === '?' && h.final === 'l')!
-
-      // Start transaction
-      syncSetHandler.cb([2026])
-      clearScrollbackHandler.cb([3])
-
-      // Wait longer than MAX_REPAINT_TRANSACTION_MS (2000ms)
-      vi.advanceTimersByTime(2100)
-
-      // End transaction — too late
       syncResetHandler.cb([2026])
       vi.advanceTimersByTime(20)
       expect(terminal.scrollToBottom).not.toHaveBeenCalled()
-
       vi.useRealTimers()
     })
 
     it('disposes CSI handlers on clearTimers', () => {
       const disposeFns = [vi.fn(), vi.fn(), vi.fn()]
       let callIdx = 0
-      vi.mocked(terminal.parser.registerCsiHandler).mockImplementation(() => {
-        return { dispose: disposeFns[callIdx++] }
-      })
-
+      vi.mocked(terminal.parser.registerCsiHandler).mockImplementation(() => ({ dispose: disposeFns[callIdx++] }))
       const handler = createHandler({ isAgent: true })
       handler.clearTimers()
-
       disposeFns.forEach(fn => expect(fn).toHaveBeenCalled())
     })
 
     it('ignores non-2026 DEC mode params', () => {
       vi.useFakeTimers()
-
       const handlers: { prefix?: string; final: string; cb: (params: (number | number[])[]) => void }[] = []
       vi.mocked(terminal.parser.registerCsiHandler).mockImplementation(
         (id: { prefix?: string; final: string }, cb: (params: (number | number[])[]) => boolean | Promise<boolean>) => {
@@ -249,49 +296,15 @@ describe('createPtyDataHandler', () => {
           return { dispose: vi.fn() }
         },
       )
-
       createHandler({ isAgent: true })
-
       const syncSetHandler = handlers.find(h => h.prefix === '?' && h.final === 'h')!
       const clearScrollbackHandler = handlers.find(h => h.final === 'J' && !h.prefix)!
       const syncResetHandler = handlers.find(h => h.prefix === '?' && h.final === 'l')!
-
-      // Use a different DEC mode (not 2026)
       syncSetHandler.cb([1049])
       clearScrollbackHandler.cb([3])
       syncResetHandler.cb([1049])
-
       vi.advanceTimersByTime(20)
       expect(terminal.scrollToBottom).not.toHaveBeenCalled()
-
-      vi.useRealTimers()
-    })
-
-    it('ignores non-3 erase params (e.g. CSI 2 J)', () => {
-      vi.useFakeTimers()
-
-      const handlers: { prefix?: string; final: string; cb: (params: (number | number[])[]) => void }[] = []
-      vi.mocked(terminal.parser.registerCsiHandler).mockImplementation(
-        (id: { prefix?: string; final: string }, cb: (params: (number | number[])[]) => boolean | Promise<boolean>) => {
-          handlers.push({ ...id, cb: cb as (params: (number | number[])[]) => void })
-          return { dispose: vi.fn() }
-        },
-      )
-
-      createHandler({ isAgent: true })
-
-      const syncSetHandler = handlers.find(h => h.prefix === '?' && h.final === 'h')!
-      const clearScrollbackHandler = handlers.find(h => h.final === 'J' && !h.prefix)!
-      const syncResetHandler = handlers.find(h => h.prefix === '?' && h.final === 'l')!
-
-      // CSI 2 J (clear screen, not scrollback)
-      syncSetHandler.cb([2026])
-      clearScrollbackHandler.cb([2])
-      syncResetHandler.cb([2026])
-
-      vi.advanceTimersByTime(20)
-      expect(terminal.scrollToBottom).not.toHaveBeenCalled()
-
       vi.useRealTimers()
     })
   })

--- a/src/renderer/panels/agent/hooks/ptyDataHandler.ts
+++ b/src/renderer/panels/agent/hooks/ptyDataHandler.ts
@@ -20,7 +20,7 @@ interface TerminalStateForPtyData {
   lastInteractionRef: React.MutableRefObject<number>
   lastStatusRef: React.MutableRefObject<'working' | 'idle'>
   idleTimeoutRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>
-  scheduleUpdate: (update: { status?: 'working' | 'idle' | 'error'; lastMessage?: string }) => void
+  scheduleUpdate: (update: { status?: 'working' | 'idle' | 'error'; lastMessage?: string; workingStartedAt?: number }) => void
 }
 
 interface CreatePtyDataHandlerArgs {
@@ -160,6 +160,11 @@ export function createPtyDataHandler(args: CreatePtyDataHandlerArgs): PtyDataHan
   // Set once the PTY has exited or the terminal is torn down: stops all further
   // activity detection so a late sample can't revive a finished session.
   let closed = false
+  // Timestamp of the first output since the last sample ran. When a sample first
+  // proves the screen changed (idle→working), this is the *true* start of the
+  // working period — so workingStartTime isn't undercounted by the sample+debounce
+  // delay, and the >=3s "unread / check-me" threshold is measured accurately.
+  let firstOutputSinceSample: number | null = null
 
   // (Re)arm the working→idle timer for a working session. The deadline is the
   // earlier of true-silence and the stable-output cap, so a periodically
@@ -181,6 +186,10 @@ export function createPtyDataHandler(args: CreatePtyDataHandlerArgs): PtyDataHan
     sampleTimer = null
     if (closed) return
     const now = Date.now()
+    // Earliest output represented by this sample — the true work start if the
+    // screen turns out to have changed. Reset the window for the next sample.
+    const workStart = firstOutputSinceSample ?? now
+    firstOutputSinceSample = null
     const fingerprint = fingerprintScreen(terminal)
     const changed = fingerprint !== lastFingerprint
     lastFingerprint = fingerprint
@@ -192,7 +201,7 @@ export function createPtyDataHandler(args: CreatePtyDataHandlerArgs): PtyDataHan
     }, config)
     if (status === 'working' && state.lastStatusRef.current !== 'working') {
       state.lastStatusRef.current = 'working'
-      state.scheduleUpdate({ status: 'working' })
+      state.scheduleUpdate({ status: 'working', workingStartedAt: workStart })
     }
     armIdle(now)
   }
@@ -207,6 +216,7 @@ export function createPtyDataHandler(args: CreatePtyDataHandlerArgs): PtyDataHan
     state.processPlanDetection(data)
     const now = Date.now()
     lastRawOutputAt = now
+    if (firstOutputSinceSample === null) firstOutputSinceSample = now
     // Refresh the silence/stability deadline now (cheap); the throttled sample
     // (scheduled from the write callback below) decides whether this output
     // actually changed the screen.

--- a/src/renderer/panels/agent/hooks/ptyDataHandler.ts
+++ b/src/renderer/panels/agent/hooks/ptyDataHandler.ts
@@ -12,7 +12,7 @@
  * transaction boundary and scroll to bottom after the repaint completes.
  */
 import { Terminal as XTerm } from '@xterm/xterm'
-import { evaluateActivity } from '../utils/terminalActivityDetector'
+import { evaluateActivity, computeIdleDeadline, DEFAULT_CONFIG, type ActivityDetectorConfig } from '../utils/terminalActivityDetector'
 
 interface TerminalStateForPtyData {
   processPlanDetection: (data: string) => void
@@ -40,6 +40,33 @@ interface PtyDataHandlerController {
 // Maximum time (ms) between CSI 3 J and DEC mode 2026 reset to still count
 // as a repaint transaction. Matches Wave Terminal's constant.
 const MAX_REPAINT_TRANSACTION_MS = 2000
+
+// How often (ms) to sample the rendered screen for change detection. Throttling
+// coalesces output bursts; the delay also means any synchronized repaint
+// transaction has fully settled by the time we read the buffer, so we never
+// fingerprint the intermediate cleared state of a CSI 3 J repaint.
+const SAMPLE_INTERVAL_MS = 250
+
+/**
+ * Cheap djb2 fingerprint of the *live* (bottom) screen rows — what the agent is
+ * currently drawing, read from `baseY` so it is independent of the user's scroll
+ * position. Trailing whitespace is trimmed so cursor-only/padding repaints don't
+ * register as changes.
+ */
+function fingerprintScreen(terminal: XTerm): number {
+  const buffer = terminal.buffer.active
+  const base = buffer.baseY
+  const rows = terminal.rows
+  let hash = 5381
+  for (let i = 0; i < rows; i++) {
+    const text = buffer.getLine(base + i)?.translateToString(true) ?? ''
+    for (let j = 0; j < text.length; j++) {
+      hash = (Math.imul(hash, 33) + text.charCodeAt(j)) | 0
+    }
+    hash = (Math.imul(hash, 33) + 10) | 0 // row boundary
+  }
+  return hash >>> 0
+}
 
 /**
  * Registers CSI handlers on the terminal to detect Claude Code's
@@ -118,42 +145,91 @@ function setupRepaintDetection(terminal: XTerm, wasRecentlyAtBottom?: () => bool
 
 export function createPtyDataHandler(args: CreatePtyDataHandlerArgs): PtyDataHandlerController {
   const { terminal, isAgent, state, effectStartTime, wasRecentlyAtBottom } = args
+  const config: ActivityDetectorConfig = DEFAULT_CONFIG
 
   // Set up repaint transaction detection for agent terminals
   const repaintDetection = isAgent ? setupRepaintDetection(terminal, wasRecentlyAtBottom) : null
 
-  const processActivityDetection = (data: string) => {
-    if (!isAgent) return
+  // Activity-detection state (per PTY): raw output timing, the last time the
+  // rendered screen actually changed, the last screen fingerprint, and the
+  // throttled sample timer. The idle timer itself lives in state.idleTimeoutRef.
+  let lastRawOutputAt = effectStartTime
+  let lastRenderedChangeAt = effectStartTime
+  let lastFingerprint = isAgent ? fingerprintScreen(terminal) : 0
+  let sampleTimer: ReturnType<typeof setTimeout> | null = null
+  // Set once the PTY has exited or the terminal is torn down: stops all further
+  // activity detection so a late sample can't revive a finished session.
+  let closed = false
 
-    state.processPlanDetection(data)
+  // (Re)arm the working→idle timer for a working session. The deadline is the
+  // earlier of true-silence and the stable-output cap, so a periodically
+  // repainting idle TUI can no longer postpone idle forever.
+  const armIdle = (now: number) => {
+    if (state.lastStatusRef.current !== 'working') return
+    const deadline = computeIdleDeadline({ lastRawOutputAt, lastRenderedChangeAt }, config)
+    if (state.idleTimeoutRef.current) clearTimeout(state.idleTimeoutRef.current)
+    state.idleTimeoutRef.current = setTimeout(() => {
+      state.idleTimeoutRef.current = null
+      state.lastStatusRef.current = 'idle'
+      state.scheduleUpdate({ status: 'idle' })
+    }, Math.max(0, deadline - now))
+  }
+
+  // Sample the rendered screen (throttled). A change is real activity → working;
+  // an unchanged repaint is not, so it can never revive an idle session.
+  const runSample = () => {
+    sampleTimer = null
+    if (closed) return
     const now = Date.now()
-    const result = evaluateActivity(data.length, now, {
+    const fingerprint = fingerprintScreen(terminal)
+    const changed = fingerprint !== lastFingerprint
+    lastFingerprint = fingerprint
+    if (changed) lastRenderedChangeAt = now
+    const { status } = evaluateActivity(changed, now, {
       lastUserInput: state.lastUserInputRef.current,
       lastInteraction: state.lastInteractionRef.current,
-      lastStatus: state.lastStatusRef.current,
       startTime: effectStartTime,
-    })
-    if (result.status === 'working') {
-      if (state.idleTimeoutRef.current) clearTimeout(state.idleTimeoutRef.current)
+    }, config)
+    if (status === 'working' && state.lastStatusRef.current !== 'working') {
       state.lastStatusRef.current = 'working'
       state.scheduleUpdate({ status: 'working' })
     }
-    if (result.scheduleIdle) {
-      if (result.status !== 'working' && state.idleTimeoutRef.current) clearTimeout(state.idleTimeoutRef.current)
-      state.idleTimeoutRef.current = setTimeout(() => {
-        state.lastStatusRef.current = 'idle'
-        state.scheduleUpdate({ status: 'idle' })
-      }, 1000)
-    }
+    armIdle(now)
+  }
+
+  const scheduleSample = () => {
+    if (sampleTimer) return
+    sampleTimer = setTimeout(runSample, SAMPLE_INTERVAL_MS)
+  }
+
+  const processActivityDetection = (data: string) => {
+    if (!isAgent || closed) return
+    state.processPlanDetection(data)
+    const now = Date.now()
+    lastRawOutputAt = now
+    // Refresh the silence/stability deadline now (cheap); the throttled sample
+    // (scheduled from the write callback below) decides whether this output
+    // actually changed the screen.
+    armIdle(now)
   }
 
   const handleData = (data: string) => {
     processActivityDetection(data)
-    terminal.write(data)
+    // Sample the screen only AFTER xterm has parsed this chunk — the write
+    // callback fires post-parse — so a change is never missed (or an
+    // intermediate/cleared state fingerprinted) under a slow or large parse.
+    if (isAgent && !closed) {
+      terminal.write(data, scheduleSample)
+    } else {
+      terminal.write(data)
+    }
   }
 
   const clearTimers = () => {
+    closed = true
     repaintDetection?.cleanup()
+    if (sampleTimer) { clearTimeout(sampleTimer); sampleTimer = null }
+    if (state.idleTimeoutRef.current) { clearTimeout(state.idleTimeoutRef.current); state.idleTimeoutRef.current = null }
   }
 
   return { handleData, clearTimers }

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.test.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.test.ts
@@ -43,7 +43,7 @@ vi.mock('@xterm/xterm', () => {
       resize = mockTerminalResize
       cols = 80
       rows = 24
-      buffer = { active: { viewportY: 0, baseY: 0 } }
+      buffer = { active: { viewportY: 0, baseY: 0, getLine: () => undefined } }
       parser = { registerCsiHandler: mockRegisterCsiHandler }
     },
   }
@@ -86,9 +86,13 @@ vi.mock('../../../shared/utils/terminalBufferRegistry', () => ({
   },
 }))
 
-vi.mock('../utils/terminalActivityDetector', () => ({
-  evaluateActivity: vi.fn().mockReturnValue({ status: null, scheduleIdle: false }),
-}))
+vi.mock('../utils/terminalActivityDetector', async (importActual) => {
+  const actual = await importActual<typeof import('../utils/terminalActivityDetector')>()
+  return {
+    ...actual, // keep computeIdleDeadline + DEFAULT_CONFIG real
+    evaluateActivity: vi.fn().mockReturnValue({ status: null }),
+  }
+})
 
 // Mock ResizeObserver - track instances for assertions
 const mockResizeObserverInstances: { observe: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }[] = []
@@ -497,7 +501,7 @@ describe('useTerminalSetup', () => {
   describe('agent idle on unmount', () => {
     it('sets agent to idle on unmount when agent was still working', async () => {
       const { evaluateActivity } = await import('../utils/terminalActivityDetector')
-      vi.mocked(evaluateActivity).mockReturnValue({ status: 'working', scheduleIdle: true })
+      vi.mocked(evaluateActivity).mockReturnValue({ status: 'working' })
 
       const config = makeConfig({ isAgentTerminal: true, command: 'claude-code' })
       const containerRef = makeContainerRef()
@@ -695,7 +699,7 @@ describe('useTerminalSetup', () => {
 
     it('processes agent activity detection on PTY data for agent terminals', async () => {
       const { evaluateActivity } = await import('../utils/terminalActivityDetector')
-      vi.mocked(evaluateActivity).mockReturnValue({ status: 'working', scheduleIdle: true })
+      vi.mocked(evaluateActivity).mockReturnValue({ status: 'working' })
 
       let onDataCb: ((data: string) => void) | null = null
       vi.mocked(window.pty.onData).mockImplementation((_id, cb) => {
@@ -711,6 +715,9 @@ describe('useTerminalSetup', () => {
 
       if (onDataCb) {
         act(() => { onDataCb!('some data') })
+        // Activity detection now samples the rendered screen on a throttle, so
+        // it runs shortly after output rather than synchronously per chunk.
+        await act(async () => { await new Promise(r => setTimeout(r, 300)) })
         expect(evaluateActivity).toHaveBeenCalled()
       }
     })

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.ts
@@ -340,7 +340,7 @@ function useTerminalState(config: TerminalConfig) {
   const handleKeyEvent = useTerminalKeyboard(ptyIdRef)
   const processPlanDetection = usePlanDetection(sessionIdRef, setPlanFileRef)
 
-  const pendingUpdateRef = useRef<{ status?: 'working' | 'idle' | 'error'; lastMessage?: string } | null>(null)
+  const pendingUpdateRef = useRef<{ status?: 'working' | 'idle' | 'error'; lastMessage?: string; workingStartedAt?: number } | null>(null)
 
   const flushUpdate = useCallback(() => {
     if (pendingUpdateRef.current && sessionIdRef.current) {
@@ -349,7 +349,16 @@ function useTerminalState(config: TerminalConfig) {
     }
   }, [])
 
-  const scheduleUpdate = useCallback((update: { status?: 'working' | 'idle' | 'error'; lastMessage?: string }) => {
+  const scheduleUpdate = useCallback((update: { status?: 'working' | 'idle' | 'error'; lastMessage?: string; workingStartedAt?: number }) => {
+    // Preserve status EDGES: if this update flips the status away from one that's
+    // still pending, flush that first so the store observes BOTH transitions.
+    // Merging working+idle into one pending object would drop the working→idle
+    // edge (e.g. idle arriving within the debounce, or a fast process exit),
+    // suppressing the "check me" unread LED and the broomy:agent-finished event.
+    const pending = pendingUpdateRef.current
+    if (update.status !== undefined && pending?.status !== undefined && pending.status !== update.status) {
+      flushUpdate()
+    }
     pendingUpdateRef.current = { ...pendingUpdateRef.current, ...update }
     if (updateTimeoutRef.current) clearTimeout(updateTimeoutRef.current)
     const delay = update.status === 'working' ? 150 : 300

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.ts
@@ -526,6 +526,9 @@ export function useTerminalSetup(
         s.lastStatusRef.current = 'idle'
         s.scheduleUpdate({ status: 'idle' })
       }
+      // Stop activity detection so a screen sample still pending from output
+      // just before exit can't revive the finished session back to "working".
+      dataHandler.clearTimers()
     })
 
     s.cleanupRef.current = () => { isStale = true; dataHandler.clearTimers(); removeDataListener(); removeExitListener() }

--- a/src/renderer/panels/agent/utils/terminalActivityDetector.test.ts
+++ b/src/renderer/panels/agent/utils/terminalActivityDetector.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   evaluateActivity,
+  computeIdleDeadline,
   type ActivityDetectorState,
   type ActivityDetectorConfig,
 } from './terminalActivityDetector'
@@ -9,7 +10,6 @@ function makeState(overrides: Partial<ActivityDetectorState> = {}): ActivityDete
   return {
     lastUserInput: 0,
     lastInteraction: 0,
-    lastStatus: 'idle',
     startTime: 0,
     ...overrides,
   }
@@ -17,145 +17,88 @@ function makeState(overrides: Partial<ActivityDetectorState> = {}): ActivityDete
 
 describe('evaluateActivity', () => {
   describe('warmup period', () => {
-    it('ignores data during warmup', () => {
+    it('ignores a screen change during warmup', () => {
       const state = makeState({ startTime: 1000 })
       // now=4999, startTime=1000 → 3999ms < 5000ms warmup
-      const result = evaluateActivity(100, 4999, state)
-      expect(result.status).toBeNull()
-      expect(result.scheduleIdle).toBe(false)
+      expect(evaluateActivity(true, 4999, state).status).toBeNull()
     })
 
-    it('detects activity after warmup', () => {
+    it('detects a screen change after warmup', () => {
       const state = makeState({ startTime: 0 })
-      // now=5001 → past warmup
-      const result = evaluateActivity(100, 5001, state)
-      expect(result.status).toBe('working')
-      expect(result.scheduleIdle).toBe(true)
+      expect(evaluateActivity(true, 5001, state).status).toBe('working')
     })
 
-    it('ignores data at exact warmup boundary', () => {
+    it('ignores a change at the exact warmup boundary', () => {
       const state = makeState({ startTime: 0 })
-      // now=4999 → still within warmup
-      const result = evaluateActivity(100, 4999, state)
-      expect(result.status).toBeNull()
+      expect(evaluateActivity(true, 4999, state).status).toBeNull()
     })
   })
 
-  describe('empty data', () => {
-    it('returns null for zero-length data', () => {
+  describe('unchanged screen', () => {
+    it('never counts an unchanged repaint as activity — the core fix', () => {
       const state = makeState({ startTime: 0 })
-      const result = evaluateActivity(0, 10000, state)
-      expect(result.status).toBeNull()
-      expect(result.scheduleIdle).toBe(false)
-    })
-
-    it('returns null for negative data length', () => {
-      const state = makeState({ startTime: 0 })
-      const result = evaluateActivity(-1, 10000, state)
-      expect(result.status).toBeNull()
+      // Well past warmup, no input suppression, but the screen did not change.
+      expect(evaluateActivity(false, 100000, state).status).toBeNull()
     })
   })
 
   describe('user input suppression', () => {
-    it('suppresses when user typed recently', () => {
-      const state = makeState({
-        startTime: 0,
-        lastUserInput: 9900,    // 100ms ago
-        lastInteraction: 0,
-      })
-      const result = evaluateActivity(100, 10000, state)
-      // Within 200ms input suppression — paused
-      expect(result.status).toBeNull()
-      expect(result.scheduleIdle).toBe(true)
+    it('suppresses a change when the user typed recently', () => {
+      const state = makeState({ startTime: 0, lastUserInput: 9900 }) // 100ms ago
+      expect(evaluateActivity(true, 10000, state).status).toBeNull()
     })
 
-    it('suppresses when window interaction happened recently', () => {
-      const state = makeState({
-        startTime: 0,
-        lastUserInput: 0,
-        lastInteraction: 9900,  // 100ms ago
-      })
-      const result = evaluateActivity(100, 10000, state)
-      expect(result.status).toBeNull()
-      expect(result.scheduleIdle).toBe(true)
+    it('suppresses a change when window interaction happened recently', () => {
+      const state = makeState({ startTime: 0, lastInteraction: 9900 }) // 100ms ago
+      expect(evaluateActivity(true, 10000, state).status).toBeNull()
     })
 
     it('does not suppress when input was long ago', () => {
-      const state = makeState({
-        startTime: 0,
-        lastUserInput: 9700,    // 300ms ago (> 200ms threshold)
-        lastInteraction: 9700,
-      })
-      const result = evaluateActivity(100, 10000, state)
-      expect(result.status).toBe('working')
+      const state = makeState({ startTime: 0, lastUserInput: 9700, lastInteraction: 9700 }) // 300ms ago
+      expect(evaluateActivity(true, 10000, state).status).toBe('working')
     })
   })
 
   describe('working transition', () => {
-    it('returns working when data arrives outside suppression window', () => {
-      const state = makeState({
-        startTime: 0,
-        lastUserInput: 0,
-        lastInteraction: 0,
-        lastStatus: 'idle',
-      })
-      const result = evaluateActivity(50, 10000, state)
-      expect(result.status).toBe('working')
-      expect(result.scheduleIdle).toBe(true)
-    })
-
-    it('returns working even if already working', () => {
-      const state = makeState({
-        startTime: 0,
-        lastUserInput: 0,
-        lastInteraction: 0,
-        lastStatus: 'working',
-      })
-      const result = evaluateActivity(50, 10000, state)
-      expect(result.status).toBe('working')
-      expect(result.scheduleIdle).toBe(true)
+    it('returns working when a change arrives outside the suppression window', () => {
+      const state = makeState({ startTime: 0 })
+      expect(evaluateActivity(true, 10000, state).status).toBe('working')
     })
   })
 
   describe('custom config', () => {
     it('respects custom warmup period', () => {
-      const config: ActivityDetectorConfig = {
-        warmupMs: 1000,
-        inputSuppressionMs: 200,
-        idleTimeoutMs: 1000,
-      }
+      const config: ActivityDetectorConfig = { warmupMs: 1000, inputSuppressionMs: 200, idleTimeoutMs: 1000, maxStableOutputMs: 3000 }
       const state = makeState({ startTime: 0 })
-      // 999ms < 1000ms custom warmup
-      expect(evaluateActivity(100, 999, state, config).status).toBeNull()
-      // 1001ms > 1000ms custom warmup
-      expect(evaluateActivity(100, 1001, state, config).status).toBe('working')
+      expect(evaluateActivity(true, 999, state, config).status).toBeNull()
+      expect(evaluateActivity(true, 1001, state, config).status).toBe('working')
     })
 
     it('respects custom input suppression', () => {
-      const config: ActivityDetectorConfig = {
-        warmupMs: 0,
-        inputSuppressionMs: 500,
-        idleTimeoutMs: 1000,
-      }
-      const state = makeState({
-        startTime: 0,
-        lastUserInput: 9600,  // 400ms ago (< 500ms custom threshold)
-      })
-      const result = evaluateActivity(100, 10000, state, config)
-      expect(result.status).toBeNull()  // suppressed
-      expect(result.scheduleIdle).toBe(true)
+      const config: ActivityDetectorConfig = { warmupMs: 0, inputSuppressionMs: 500, idleTimeoutMs: 1000, maxStableOutputMs: 3000 }
+      const state = makeState({ startTime: 0, lastUserInput: 9600 }) // 400ms ago (< 500ms)
+      expect(evaluateActivity(true, 10000, state, config).status).toBeNull()
     })
   })
+})
 
-  describe('rapid data bursts', () => {
-    it('consistently returns working for sequential data chunks', () => {
-      const state = makeState({ startTime: 0 })
-      // Simulate rapid data arrival
-      for (let t = 6000; t < 6100; t += 10) {
-        const result = evaluateActivity(50, t, state)
-        expect(result.status).toBe('working')
-        expect(result.scheduleIdle).toBe(true)
-      }
-    })
+describe('computeIdleDeadline', () => {
+  const config: ActivityDetectorConfig = { warmupMs: 5000, inputSuppressionMs: 200, idleTimeoutMs: 1000, maxStableOutputMs: 3000 }
+
+  it('uses the silence timeout while the screen keeps changing (recent render change)', () => {
+    // Raw output and rendered change both at t=10000 → silence term (11000) < cap (13000).
+    expect(computeIdleDeadline({ lastRawOutputAt: 10000, lastRenderedChangeAt: 10000 }, config)).toBe(11000)
+  })
+
+  it('uses the stability cap when output continues but the screen is stale', () => {
+    // Repaints keep arriving (raw output at 12000) but the screen last changed at 10000.
+    // cap (10000+3000=13000) < silence (12000+1000=13000)? equal here; make raw more recent:
+    expect(computeIdleDeadline({ lastRawOutputAt: 12500, lastRenderedChangeAt: 10000 }, config)).toBe(13000)
+  })
+
+  it('the cap defeats an infinite repaint loop — deadline stops advancing with raw output', () => {
+    const stale = 10000
+    // No matter how much later raw output keeps arriving, the deadline is pinned to stale+cap.
+    expect(computeIdleDeadline({ lastRawOutputAt: 999999, lastRenderedChangeAt: stale }, config)).toBe(stale + 3000)
   })
 })

--- a/src/renderer/panels/agent/utils/terminalActivityDetector.ts
+++ b/src/renderer/panels/agent/utils/terminalActivityDetector.ts
@@ -1,80 +1,98 @@
 /**
- * Terminal activity detection logic for determining agent working/idle status.
+ * Terminal activity detection: decides when an agent is "working" vs "idle"
+ * from terminal output, using timing + rendered-screen-change heuristics.
  *
- * Uses timing heuristics rather than parsing terminal output content. The detector
- * has three phases: a warmup period (ignores the first N ms after creation), an
- * input suppression window (pauses detection briefly after user input or window
- * interaction to avoid false positives), and steady-state detection where any
- * terminal data means "working" and silence means "idle". The evaluateActivity
- * function is pure -- it takes state and config, returns a result with no side effects.
+ * The classic failure mode is an idle agent TUI that repaints its footer/prompt
+ * sub-second: treating *any* output as "working" (and re-arming a silence
+ * timeout on every byte) pins the session to "working" forever. So activity is
+ * gated on the *rendered screen actually changing*, and a "stability lease"
+ * caps how long unchanged repaint output may postpone idle.
+ *
+ * `evaluateActivity` and `computeIdleDeadline` are pure; the caller
+ * (ptyDataHandler) owns the screen fingerprinting and the timers.
+ *
+ * Contract & known limitation: "working" means the visible terminal *text*
+ * changed recently. The fingerprint intentionally ignores cursor position and
+ * cell attributes, so an agent that genuinely works for longer than
+ * `maxStableOutputMs` while displaying byte-identical text (e.g. a static
+ * "Thinking…" screen, or an animation expressed only through colours) will be
+ * marked idle. This is a deliberate bias toward the far more common failure —
+ * an idle TUI repainting forever — and cannot be resolved from the PTY stream
+ * alone; a precise signal needs agent-native lifecycle events.
  */
 
 export type ActivityStatus = 'working' | 'idle'
 
 export interface ActivityDetectorConfig {
-  /** Ignore activity detection for this many ms after terminal creation */
+  /** Ignore activity for this many ms after terminal creation. */
   warmupMs: number
-  /** Suppress detection for this many ms after user input */
+  /** Suppress activity for this many ms after user input (avoids counting echo). */
   inputSuppressionMs: number
-  /** After this many ms of no output, transition to idle */
+  /** Idle after this many ms of no terminal output at all (true silence). */
   idleTimeoutMs: number
+  /** Idle after this many ms of output that does NOT change the rendered screen. */
+  maxStableOutputMs: number
 }
 
 export const DEFAULT_CONFIG: ActivityDetectorConfig = {
   warmupMs: 5000,
   inputSuppressionMs: 200,
   idleTimeoutMs: 1000,
+  maxStableOutputMs: 3000,
 }
 
 export interface ActivityDetectorState {
   lastUserInput: number
   lastInteraction: number
-  lastStatus: ActivityStatus
   startTime: number
 }
 
 export interface ActivityResult {
-  /** null means no status change should be emitted */
-  status: ActivityStatus | null
-  /** Whether to schedule an idle timeout */
-  scheduleIdle: boolean
+  /** 'working' if this observation is real activity; null for no transition. */
+  status: 'working' | null
+}
+
+export interface IdleDeadlineInput {
+  /** Timestamp of the most recent terminal output (any bytes). */
+  lastRawOutputAt: number
+  /** Timestamp of the most recent output that changed the rendered screen. */
+  lastRenderedChangeAt: number
 }
 
 /**
- * Evaluate terminal data and determine the status transition.
+ * Decide whether an observed output sample counts as real activity.
  *
- * @param dataLength Length of incoming terminal data
- * @param now Current timestamp (ms)
- * @param state Current detector state
- * @param config Detector configuration
- * @returns What action to take
+ * Only a *change* to the rendered screen counts — an unchanged repaint does not,
+ * so an idle TUI's periodic redraws can never flip the session to "working".
+ * Output during warmup or the post-input suppression window is ignored.
  */
 export function evaluateActivity(
-  dataLength: number,
+  changed: boolean,
   now: number,
   state: ActivityDetectorState,
   config: ActivityDetectorConfig = DEFAULT_CONFIG,
 ): ActivityResult {
-  // No data or empty data — no change
-  if (dataLength <= 0) {
-    return { status: null, scheduleIdle: false }
-  }
+  if (now - state.startTime < config.warmupMs) return { status: null }
+  if (!changed) return { status: null }
+  const isPaused = now - state.lastUserInput < config.inputSuppressionMs ||
+                   now - state.lastInteraction < config.inputSuppressionMs
+  return { status: isPaused ? null : 'working' }
+}
 
-  // Within warmup period — ignore
-  if (now - state.startTime < config.warmupMs) {
-    return { status: null, scheduleIdle: false }
-  }
-
-  const timeSinceInput = now - state.lastUserInput
-  const timeSinceInteraction = now - state.lastInteraction
-  const isPaused = timeSinceInput < config.inputSuppressionMs ||
-                   timeSinceInteraction < config.inputSuppressionMs
-
-  if (isPaused) {
-    // Data arrived but we're in a pause window — schedule idle check
-    return { status: null, scheduleIdle: true }
-  }
-
-  // Not paused — agent is working
-  return { status: 'working', scheduleIdle: true }
+/**
+ * The absolute timestamp at which a currently-working session should go idle:
+ * the earlier of
+ *   (a) `idleTimeoutMs` after the last output of any kind — true silence, and
+ *   (b) `maxStableOutputMs` after the last output that actually changed the
+ *       screen — the stability-lease cap that defeats idle repaint loops.
+ * The caller schedules a timer for `max(0, deadline - now)`.
+ */
+export function computeIdleDeadline(
+  input: IdleDeadlineInput,
+  config: ActivityDetectorConfig = DEFAULT_CONFIG,
+): number {
+  return Math.min(
+    input.lastRawOutputAt + config.idleTimeoutMs,
+    input.lastRenderedChangeAt + config.maxStableOutputMs,
+  )
 }

--- a/src/renderer/store/sessions.test.ts
+++ b/src/renderer/store/sessions.test.ts
@@ -535,6 +535,20 @@ describe('useSessionStore', () => {
       expect(useSessionStore.getState().sessions[0].isUnread).toBe(true)
     })
 
+    it('honors workingStartedAt (source timestamp) for the unread threshold', () => {
+      const s1 = createTestSession({ id: 's1' })
+      useSessionStore.setState({ sessions: [s1], isLoading: false })
+
+      const now = Date.now()
+      // The detector reports the working period began 4s ago, even though the
+      // store is only told now — so no timer advance is needed to cross 3s.
+      useSessionStore.getState().updateAgentMonitor('s1', { status: 'working', workingStartedAt: now - 4000 })
+      expect(useSessionStore.getState().sessions[0].workingStartTime).toBe(now - 4000)
+
+      useSessionStore.getState().updateAgentMonitor('s1', { status: 'idle' })
+      expect(useSessionStore.getState().sessions[0].isUnread).toBe(true)
+    })
+
     it('dispatches broomy:agent-finished event when agent finishes work', () => {
       const s1 = createTestSession({ id: 's1' })
       useSessionStore.setState({ sessions: [s1], isLoading: false })

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -160,7 +160,7 @@ interface SessionStore {
   updateLayoutSize: (id: string, key: keyof LayoutSizes, value: number) => void
   setExplorerFilter: (id: string, filter: ExplorerFilter) => void
   // Agent monitoring actions
-  updateAgentMonitor: (id: string, update: { status?: SessionStatus; lastMessage?: string }) => void
+  updateAgentMonitor: (id: string, update: { status?: SessionStatus; lastMessage?: string; workingStartedAt?: number }) => void
   markSessionRead: (id: string) => void
   // Terminal tab actions
   addTerminalTab: (sessionId: string, name?: string, isolated?: boolean) => string
@@ -281,7 +281,7 @@ export const useSessionStore = create<SessionStore>((set, get) => {
     debouncedSave()
   },
 
-  updateAgentMonitor: (id: string, update: { status?: SessionStatus; lastMessage?: string }) => {
+  updateAgentMonitor: (id: string, update: { status?: SessionStatus; lastMessage?: string; workingStartedAt?: number }) => {
     const { sessions } = get()
     const session = sessions.find(s => s.id === id)
     if (!session) return
@@ -298,9 +298,11 @@ export const useSessionStore = create<SessionStore>((set, get) => {
         changes.lastMessage = update.lastMessage
         changes.lastMessageTime = Date.now()
       }
-      // Track when working period starts
+      // Track when the working period starts. Prefer the caller's source
+      // timestamp (the first output of the working burst) over receipt time, so
+      // the >=3s unread threshold isn't undercounted by detection/debounce delay.
       if (update.status === 'working' && s.status !== 'working') {
-        changes.workingStartTime = Date.now()
+        changes.workingStartTime = update.workingStartedAt ?? Date.now()
       }
       // Mark as unread when transitioning from working to idle,
       // but only if the agent was working for at least 3 seconds.


### PR DESCRIPTION
## Background and Motivation

A session's sidebar card stays on **Working** with a runaway elapsed timer (`Working 38m 24s`) even after the agent has finished and is idle at its prompt — and on relaunch every restored session latches it together (identical timers). Closes #143.

Agent status is inferred from PTY output: any output flips a session to "working" and re-arms a 1s idle timer, so idle only fires after a full second of *total* silence. An idle agent TUI that repaints its footer/status line sub-second (a live status line, or an Ink-based CLI's periodic redraws / cursor-position queries) re-arms "working" forever; `workingStartTime` is set once and never cleared → the runaway timer. On relaunch, every restored terminal mounts at once and latches "working" in the same wall-clock second after the 5s warmup.

## Design Decisions

- **Gate "working" on the rendered screen actually changing, not raw output.** A byte-volume threshold can't cleanly separate an idle repaint from slow real streaming, and a false-*idle* is worse than the bug — it stops the spinner and prematurely marks the session unread + fires `broomy:agent-finished`. So an unchanged repaint is never activity and can never revive an idle session.
- **Capped stability lease.** `computeIdleDeadline = min(lastRawOutput + idleTimeoutMs, lastRenderedChange + maxStableOutputMs)`. With `maxStableOutputMs = 3s`, a repaint loop idles ~3s after the last real screen change, while a genuinely streaming agent (screen changing) keeps working via the ordinary 1s silence timeout.
- **Sample the live bottom rows** — read from `baseY`, so it's independent of the user's scroll position — on a **250ms throttle**, triggered from **xterm's write callback** so a change is fingerprinted only *after* the chunk is parsed, never an intermediate cleared state of a `CSI 3 J` repaint.
- **Deliberate bias toward false-"working".** An agent that works while displaying byte-identical text for longer than the cap is marked idle (see the limitation below). A precise signal needs agent-native lifecycle events; this is a PTY-only heuristic.

## Proposed Changes

- `terminalActivityDetector.ts`: pure `evaluateActivity(changed, now, state, config)` (a rendered-screen change is activity; warmup + input-suppression still gate it) and a pure `computeIdleDeadline(...)`; config gains `maxStableOutputMs`.
- `ptyDataHandler.ts`: `fingerprintScreen` (djb2 over the live bottom rows, trailing-whitespace-trimmed), throttled sampling from the write callback, a deadline-based idle timer now owned by the handler, and a `closed` guard so a queued sample can't run after teardown.
- `useTerminalSetup.ts`: stop activity detection on PTY exit so a sample pending from output just before exit can't revive the finished session.

## Known limitations

An agent that genuinely works for longer than `maxStableOutputMs` while showing byte-identical text (a static "Thinking…" screen, or an animation expressed only through cell colours/attributes, which the fingerprint ignores) will be marked idle. That's the accepted tradeoff versus the far more common idle-repaint-forever bug this fixes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (coverage at or above 90% lines) — 3451 passed; the two changed detector/handler files are 100% lines
- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 72 passed
