### PR TITLE
ci: pin pnpm to exact 10.34.5 so packageManager and action-setup agree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ concurrency:
 
 env:
   NODE_VERSION: '20'
-  PNPM_VERSION: '10'
+  # Exact version so it matches the `packageManager` field in package.json.
+  # pnpm/action-setup@v4 compares the two as exact strings and fails the run
+  # (ERR_PNPM_BAD_PM_VERSION) if they differ — a bare '10' would not match.
+  PNPM_VERSION: '10.34.5'
 
 jobs:
   lint:


### PR DESCRIPTION
## Background and Motivation

PR #140 adds `"packageManager": "pnpm@10.34.5"` to `package.json` so corepack
pins pnpm 10 (which honours `node-linker=hoisted`) instead of resolving pnpm 11.

But every CI job pins pnpm a *second* way — `pnpm/action-setup@v4` with
`version: ${{ env.PNPM_VERSION }}` where `PNPM_VERSION: '10'`. action-setup@v4
compares its `version` input against the `packageManager` field as an **exact
string** and throws `ERR_PNPM_BAD_PM_VERSION` when they differ. `'10'` does not
equal `'10.34.5'`, so once #140 lands, all of Lint / Typecheck / Unit tests
fail before install.

This PR lands the CI half first, on its own, so #140 goes green when rebased.

## Proposed Changes

- `.github/workflows/ci.yml`: `PNPM_VERSION: '10'` → `'10.34.5'` (exact match
  to the `packageManager` pin #140 introduces), with a comment explaining why
  the exact version matters.

This is green standalone: with no `packageManager` on `main` yet, action-setup
simply installs pnpm 10.34.5.

## Merge order

1. Merge this PR.
2. Rebase #140 on `main`; its `packageManager: pnpm@10.34.5` now matches
   `version: '10.34.5'` exactly → no conflict → merge.
3. (Optional later cleanup) drop the `version:` input entirely so
   `packageManager` is the single source of truth.

## Testing

- [ ] Ran all E2E tests locally (pnpm test:e2e) — **not run**

> This change touches **only** `.github/workflows/ci.yml`. E2E is intentionally
> not part of CI and is unaffected by a pnpm-version env change, so E2E was not
> run. The real verification here is CI itself going green on this PR.
>
> ⚠️ The `PR E2E attestation` job greps for a checked E2E box and will fail
> until one is present. Left unchecked deliberately rather than assert a test
> run that did not happen — check it (after running, or as a documented
> exception for a CI-only change) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5VxAcTTmhX8priTpJ2PVL
