### PR TITLE
feat(terminal): ⌘/⌃-click a URL in the terminal to open it (#149)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-serialize": "^0.13.0",
+    "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "electron-updater": "^6.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@xterm/addon-serialize':
         specifier: ^0.13.0
         version: 0.13.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-web-links':
+        specifier: ^0.11.0
+        version: 0.11.0(@xterm/xterm@5.5.0)
       '@xterm/addon-webgl':
         specifier: ^0.18.0
         version: 0.18.0(@xterm/xterm@5.5.0)
@@ -761,56 +764,66 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
@@ -897,24 +910,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -1001,66 +1018,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1206,24 +1236,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1533,6 +1567,11 @@ packages:
 
   '@xterm/addon-serialize@0.13.0':
     resolution: {integrity: sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-web-links@0.11.0':
+    resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
 
@@ -2771,24 +2810,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -5422,6 +5465,10 @@ snapshots:
       '@xterm/xterm': 5.5.0
 
   '@xterm/addon-serialize@0.13.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
 

--- a/scripts/fake-claude.ps1
+++ b/scripts/fake-claude.ps1
@@ -35,6 +35,7 @@ Write-Host "`r* Generating response...  "
 
 Write-Host ""
 Write-Host "Done! This is a simulated Claude response."
+Write-Host "View the PR at https://github.com/Broomy-AI/broomy/pull/149"
 Write-Host ""
 
 Write-Host "FAKE_CLAUDE_IDLE"

--- a/scripts/fake-claude.sh
+++ b/scripts/fake-claude.sh
@@ -45,6 +45,7 @@ simulate_spinner 1 "Generating response..."
 
 echo ""
 echo "Done! This is a simulated Claude response."
+echo "View the PR at https://github.com/Broomy-AI/broomy/pull/149"
 echo ""
 
 # Now go idle (stop outputting)

--- a/src/main/externalUrl.test.ts
+++ b/src/main/externalUrl.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { toHttpUrl } from './externalUrl'
+
+describe('toHttpUrl', () => {
+  it('passes through an http(s) URL that is already normalized', () => {
+    expect(toHttpUrl('https://github.com/Broomy-AI/broomy/pull/149')).toBe(
+      'https://github.com/Broomy-AI/broomy/pull/149',
+    )
+  })
+
+  it('returns the WHATWG-normalized href, not the raw string', () => {
+    // A bare host gains a trailing slash, so the OS gets exactly what was validated.
+    expect(toHttpUrl('http://localhost:5173')).toBe('http://localhost:5173/')
+    // Backslashes normalize to forward slashes — the OS must not re-parse the raw form.
+    expect(toHttpUrl('https://example.com\\@evil.com')).not.toContain('\\')
+  })
+
+  it('is case-insensitive on the scheme', () => {
+    expect(toHttpUrl('HTTPS://Example.com')).toBe('https://example.com/')
+  })
+
+  it('refuses non-http(s) schemes', () => {
+    for (const url of ['file:///etc/passwd', 'javascript:alert(1)', 'mailto:a@b.com', 'app://x', 'ftp://example.com']) {
+      expect(toHttpUrl(url)).toBeNull()
+    }
+  })
+
+  it('refuses a scheme smuggled past the prefix check', () => {
+    // `http:\\host` and leading whitespace fail the literal prefix test before URL parsing.
+    expect(toHttpUrl('http:\\\\example.com')).toBeNull()
+    expect(toHttpUrl('  https://example.com')).toBeNull()
+    expect(toHttpUrl('https:')).toBeNull()
+  })
+
+  it('refuses embedded credentials (host-spoofing guard)', () => {
+    // Reads as github.com to a human skimming terminal output; the real host is evil.example.
+    expect(toHttpUrl('https://github.com@evil.example/pull/149')).toBeNull()
+    expect(toHttpUrl('https://user:pass@evil.example')).toBeNull()
+  })
+
+  it('refuses malformed and non-string input', () => {
+    expect(toHttpUrl('not a url')).toBeNull()
+    expect(toHttpUrl('')).toBeNull()
+    expect(toHttpUrl('https://')).toBeNull()
+    expect(toHttpUrl(undefined)).toBeNull()
+    expect(toHttpUrl(null)).toBeNull()
+    expect(toHttpUrl(42)).toBeNull()
+  })
+})

--- a/src/main/externalUrl.ts
+++ b/src/main/externalUrl.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure validator for every URL the privileged side hands to the OS via `shell.openExternal`.
+ *
+ * Kept out of index.ts (importing that module boots the app) so the decision stays
+ * unit-testable, and shared by every path that can reach `shell.openExternal` with a URL
+ * the app did not construct itself:
+ *   - the `shell:openExternal` IPC handler (renderer callers, incl. untrusted terminal output),
+ *   - `setWindowOpenHandler` (a `window.open()` from anything running in the renderer).
+ *
+ * External URLs cross an untrusted boundary — agent terminal output, repo content, review
+ * markdown — so only http(s) reaches the OS. Everything else (file:, mailto:, custom app
+ * protocols, malformed input) is refused. Every in-app caller already passes http(s), so this
+ * narrows the attack surface without changing behaviour.
+ *
+ * Requires a literal `http(s)://` prefix (rejecting `http:\\host`, whitespace-prefixed, and
+ * scheme-only inputs) and returns the WHATWG-normalized form, so the OS receives exactly the
+ * URL that was validated rather than a variant its own parser might read differently.
+ * Embedded credentials are refused: `https://github.com@evil.example` reads as a trusted host
+ * to a human skimming terminal output, which is precisely the spoof this boundary should stop.
+ */
+export function toHttpUrl(url: unknown): string | null {
+  if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) return null
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    if (parsed.username || parsed.password) return null
+    return parsed.href
+  } catch {
+    return null
+  }
+}

--- a/src/main/handlers/shell.test.ts
+++ b/src/main/handlers/shell.test.ts
@@ -178,8 +178,54 @@ describe('shell handlers', () => {
       register(mockIpcMain as never, ctx)
 
       mockShellOpenExternal.mockResolvedValue(undefined)
-      await handlers['shell:openExternal'](mockEvent, 'https://example.com')
-      expect(mockShellOpenExternal).toHaveBeenCalledWith('https://example.com')
+      // A URL with a path is passed through unchanged (normalized href === input).
+      await handlers['shell:openExternal'](mockEvent, 'https://github.com/Broomy-AI/broomy/pull/149')
+      expect(mockShellOpenExternal).toHaveBeenCalledWith('https://github.com/Broomy-AI/broomy/pull/149')
+    })
+
+    it('allows http as well as https', async () => {
+      const { register } = await import('./shell')
+      const ctx = createCtx()
+      register(mockIpcMain as never, ctx)
+
+      mockShellOpenExternal.mockResolvedValue(undefined)
+      // WHATWG normalizes a bare host to a trailing slash — the OS gets exactly what we validated.
+      await handlers['shell:openExternal'](mockEvent, 'http://localhost:5173')
+      expect(mockShellOpenExternal).toHaveBeenCalledWith('http://localhost:5173/')
+    })
+
+    it('dispatches the normalized href, not the raw string (parser-differential guard)', async () => {
+      const { register } = await import('./shell')
+      const ctx = createCtx()
+      register(mockIpcMain as never, ctx)
+
+      mockShellOpenExternal.mockResolvedValue(undefined)
+      // Backslashes are normalized to forward slashes by WHATWG; the OS must not re-parse the raw form.
+      await handlers['shell:openExternal'](mockEvent, 'https://example.com\\@evil.com')
+      expect(mockShellOpenExternal).toHaveBeenCalledTimes(1)
+      expect(mockShellOpenExternal.mock.calls[0][0]).not.toContain('\\')
+    })
+
+    it('refuses non-http(s) schemes (file:, javascript:, mailto:, custom)', async () => {
+      const { register } = await import('./shell')
+      const ctx = createCtx()
+      register(mockIpcMain as never, ctx)
+
+      for (const url of ['file:///etc/passwd', 'javascript:alert(1)', 'mailto:a@b.com', 'app://x']) {
+        await handlers['shell:openExternal'](mockEvent, url)
+      }
+      expect(mockShellOpenExternal).not.toHaveBeenCalled()
+    })
+
+    it('refuses malformed / non-string input', async () => {
+      const { register } = await import('./shell')
+      const ctx = createCtx()
+      register(mockIpcMain as never, ctx)
+
+      await handlers['shell:openExternal'](mockEvent, 'not a url')
+      await handlers['shell:openExternal'](mockEvent, '')
+      await handlers['shell:openExternal'](mockEvent, undefined as never)
+      expect(mockShellOpenExternal).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/handlers/shell.test.ts
+++ b/src/main/handlers/shell.test.ts
@@ -183,47 +183,28 @@ describe('shell handlers', () => {
       expect(mockShellOpenExternal).toHaveBeenCalledWith('https://github.com/Broomy-AI/broomy/pull/149')
     })
 
-    it('allows http as well as https', async () => {
-      const { register } = await import('./shell')
-      const ctx = createCtx()
-      register(mockIpcMain as never, ctx)
-
-      mockShellOpenExternal.mockResolvedValue(undefined)
-      // WHATWG normalizes a bare host to a trailing slash — the OS gets exactly what we validated.
-      await handlers['shell:openExternal'](mockEvent, 'http://localhost:5173')
-      expect(mockShellOpenExternal).toHaveBeenCalledWith('http://localhost:5173/')
-    })
-
+    // The validation table itself lives in externalUrl.test.ts (toHttpUrl) — these two cover
+    // only the handler's contract: it dispatches the *normalized* URL, and refuses what the
+    // guard rejects rather than passing it through.
     it('dispatches the normalized href, not the raw string (parser-differential guard)', async () => {
       const { register } = await import('./shell')
       const ctx = createCtx()
       register(mockIpcMain as never, ctx)
 
       mockShellOpenExternal.mockResolvedValue(undefined)
-      // Backslashes are normalized to forward slashes by WHATWG; the OS must not re-parse the raw form.
-      await handlers['shell:openExternal'](mockEvent, 'https://example.com\\@evil.com')
-      expect(mockShellOpenExternal).toHaveBeenCalledTimes(1)
-      expect(mockShellOpenExternal.mock.calls[0][0]).not.toContain('\\')
+      // WHATWG normalizes a bare host to a trailing slash; the OS must never re-parse the raw form.
+      await handlers['shell:openExternal'](mockEvent, 'http://localhost:5173')
+      expect(mockShellOpenExternal).toHaveBeenCalledExactlyOnceWith('http://localhost:5173/')
     })
 
-    it('refuses non-http(s) schemes (file:, javascript:, mailto:, custom)', async () => {
+    it('refuses anything the http(s) guard rejects', async () => {
       const { register } = await import('./shell')
       const ctx = createCtx()
       register(mockIpcMain as never, ctx)
 
-      for (const url of ['file:///etc/passwd', 'javascript:alert(1)', 'mailto:a@b.com', 'app://x']) {
+      for (const url of ['file:///etc/passwd', 'javascript:alert(1)', 'mailto:a@b.com', 'https://github.com@evil.example', 'not a url', '']) {
         await handlers['shell:openExternal'](mockEvent, url)
       }
-      expect(mockShellOpenExternal).not.toHaveBeenCalled()
-    })
-
-    it('refuses malformed / non-string input', async () => {
-      const { register } = await import('./shell')
-      const ctx = createCtx()
-      register(mockIpcMain as never, ctx)
-
-      await handlers['shell:openExternal'](mockEvent, 'not a url')
-      await handlers['shell:openExternal'](mockEvent, '')
       await handlers['shell:openExternal'](mockEvent, undefined as never)
       expect(mockShellOpenExternal).not.toHaveBeenCalled()
     })

--- a/src/main/handlers/shell.ts
+++ b/src/main/handlers/shell.ts
@@ -9,6 +9,27 @@ import { zoomMenuItems } from './settings'
 
 const isDev = process.env.ELECTRON_RENDERER_URL !== undefined
 
+/**
+ * External URLs cross an untrusted boundary — agent terminal output, repo content, review
+ * markdown — so the privileged side only ever hands http(s) URLs to the OS. Everything else
+ * (file:, mailto:, custom app protocols, malformed input) is refused. Every in-app caller
+ * already passes http(s), so this narrows the attack surface without changing behaviour.
+ *
+ * Requires a literal `http(s)://` prefix (rejecting `http:\\host`, whitespace-prefixed, and
+ * scheme-only inputs) and returns the WHATWG-normalized form, so the OS receives exactly the
+ * URL that was validated rather than a variant its own parser might read differently.
+ */
+function toHttpUrl(url: unknown): string | null {
+  if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) return null
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    return parsed.href
+  } catch {
+    return null
+  }
+}
+
 export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
   ipcMain.handle('shell:exec', async (_event, command: string, cwd: string) => {
     if (ctx.isE2ETest && !ctx.e2eRealRepos) {
@@ -32,7 +53,13 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
     if (ctx.isE2ETest) {
       return
     }
-    await shell.openExternal(url)
+    // Refuse anything that isn't http(s): agent output / repo content is untrusted, and
+    // every in-app caller already passes http(s). Silent, like the other guarded handlers.
+    const safeUrl = toHttpUrl(url)
+    if (!safeUrl) {
+      return
+    }
+    await shell.openExternal(safeUrl)
   })
 
   ipcMain.handle('shells:list', (_event) => {

--- a/src/main/handlers/shell.ts
+++ b/src/main/handlers/shell.ts
@@ -6,29 +6,9 @@ import { exec } from 'child_process'
 import { getExecShell, normalizePath, getAvailableShells, getDefaultShell } from '../platform'
 import { HandlerContext, expandHomePath } from './types'
 import { zoomMenuItems } from './settings'
+import { toHttpUrl } from '../externalUrl'
 
 const isDev = process.env.ELECTRON_RENDERER_URL !== undefined
-
-/**
- * External URLs cross an untrusted boundary — agent terminal output, repo content, review
- * markdown — so the privileged side only ever hands http(s) URLs to the OS. Everything else
- * (file:, mailto:, custom app protocols, malformed input) is refused. Every in-app caller
- * already passes http(s), so this narrows the attack surface without changing behaviour.
- *
- * Requires a literal `http(s)://` prefix (rejecting `http:\\host`, whitespace-prefixed, and
- * scheme-only inputs) and returns the WHATWG-normalized form, so the OS receives exactly the
- * URL that was validated rather than a variant its own parser might read differently.
- */
-function toHttpUrl(url: unknown): string | null {
-  if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) return null
-  try {
-    const parsed = new URL(url)
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
-    return parsed.href
-  } catch {
-    return null
-  }
-}
 
 export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
   ipcMain.handle('shell:exec', async (_event, command: string, cwd: string) => {
@@ -54,9 +34,11 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
       return
     }
     // Refuse anything that isn't http(s): agent output / repo content is untrusted, and
-    // every in-app caller already passes http(s). Silent, like the other guarded handlers.
+    // every in-app caller already passes http(s). Silent in production, like the other
+    // guarded handlers, but noisy in dev so a mis-formed caller isn't a button that does nothing.
     const safeUrl = toHttpUrl(url)
     if (!safeUrl) {
+      if (isDev) console.warn('[shell] refused to open non-http(s) URL:', url)
       return
     }
     await shell.openExternal(safeUrl)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,7 @@ import { resolveShellEnv } from './shellEnv'
 import { writeCrashLog, appendErrorLog } from './crashLog'
 import { disposePtyListenersForWindow, disposeAllPtyListeners } from './handlers/pty'
 import { navigationAction } from './navigation'
+import { toHttpUrl } from './externalUrl'
 import { treeKill } from './treeKill'
 import { sweepOrphanedPtys, clearOwnMarkers } from './ptyMarkers'
 
@@ -254,9 +255,13 @@ function createWindow(profileId?: string): BrowserWindow {
     if (action === 'external') void shell.openExternal(url)
   })
 
-  // Intercept window.open() calls and redirect to external browser
+  // Intercept window.open() calls and redirect to external browser. Nothing in the app
+  // calls window.open — this is a safety net for content the renderer merely displays —
+  // so it is held to the same http(s)-only rule as shell:openExternal. (will-navigate
+  // above stays unrestricted: mailto: links there are a deliberate, documented behaviour.)
   window.webContents.setWindowOpenHandler(({ url }: { url: string }) => {
-    void shell.openExternal(url)
+    const safeUrl = toHttpUrl(url)
+    if (safeUrl) void shell.openExternal(safeUrl)
     return { action: 'deny' }
   })
 

--- a/src/renderer/layout/LayoutToolbar.tsx
+++ b/src/renderer/layout/LayoutToolbar.tsx
@@ -4,15 +4,10 @@
 import { ReactNode } from 'react'
 import VersionIndicator from './VersionIndicator'
 import type { PanelDefinition } from '../panels'
-
-// Detect platform for keyboard shortcut display
-const isMac = navigator.userAgent.includes('Mac')
+import { isMac, modifierSymbol } from '../shared/utils/platform'
 
 // Keyboard shortcut helper
-const formatShortcut = (key: string) => {
-  const modifier = isMac ? '\u2318' : 'Ctrl+'
-  return `${modifier}${key}`
-}
+const formatShortcut = (key: string) => `${modifierSymbol}${key}`
 
 interface ToolbarPanelInfo extends PanelDefinition {
   shortcutKey: string | null

--- a/src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  shouldOpenTerminalLink,
+  createWebLinkHandler,
+  createTerminalLinkHandlers,
+  type TerminalLinkClick,
+} from './terminalLinkHandler'
+
+const click = (over: Partial<TerminalLinkClick> = {}): TerminalLinkClick => ({
+  button: 0,
+  metaKey: false,
+  ctrlKey: false,
+  ...over,
+})
+
+describe('shouldOpenTerminalLink', () => {
+  const HTTPS = 'https://example.com'
+
+  it('opens on ⌘+primary-click on macOS', () => {
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), HTTPS, true)).toBe(true)
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), 'http://example.com', true)).toBe(true)
+  })
+
+  it('opens on Ctrl+primary-click off macOS', () => {
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, false)).toBe(true)
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), 'http://example.com', false)).toBe(true)
+  })
+
+  it('does NOT open on Ctrl-click on macOS (that is the context-menu gesture)', () => {
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, true)).toBe(false)
+  })
+
+  it('does NOT open with the wrong-platform modifier', () => {
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), HTTPS, false)).toBe(false)
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, true)).toBe(false)
+  })
+
+  it('does NOT open on a plain click (leaves selection/cursor to xterm)', () => {
+    expect(shouldOpenTerminalLink(click(), HTTPS, true)).toBe(false)
+    expect(shouldOpenTerminalLink(click(), HTTPS, false)).toBe(false)
+  })
+
+  it('does NOT open on middle- or right-click even with the modifier', () => {
+    expect(shouldOpenTerminalLink(click({ metaKey: true, button: 1 }), HTTPS, true)).toBe(false)
+    expect(shouldOpenTerminalLink(click({ metaKey: true, button: 2 }), HTTPS, true)).toBe(false)
+  })
+
+  it('refuses non-http(s) schemes even with the modifier held', () => {
+    for (const uri of [
+      'file:///etc/passwd',
+      'javascript:alert(1)',
+      'mailto:a@b.com',
+      'localhost:5173',
+      '127.0.0.1:5173',
+      'ftp://example.com',
+    ]) {
+      expect(shouldOpenTerminalLink(click({ metaKey: true }), uri, true)).toBe(false)
+    }
+  })
+
+  it('is case-insensitive on the scheme', () => {
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), 'HTTPS://Example.com', true)).toBe(true)
+  })
+})
+
+describe('createWebLinkHandler', () => {
+  it('opens exactly the links that qualify', () => {
+    const openExternal = vi.fn()
+    const handler = createWebLinkHandler({ isMac: true, openExternal })
+
+    // qualifying: ⌘ + primary + https
+    handler({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com')
+
+    // non-qualifying: plain click, and a modified file: URL
+    handler({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://example.com')
+    handler({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'file:///etc/passwd')
+    expect(openExternal).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createTerminalLinkHandlers', () => {
+  it('gates OSC 8 links (linkHandler) with the same rule and forbids non-http protocols', () => {
+    const openExternal = vi.fn()
+    const { linkHandler } = createTerminalLinkHandlers({ isMac: true, openExternal })
+
+    // xterm must not fall back to its plain-click confirm()+window.open for non-http links.
+    expect(linkHandler.allowNonHttpProtocols).toBe(false)
+
+    linkHandler.activate({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com')
+
+    linkHandler.activate({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://example.com')
+    expect(openExternal).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes the same gate as onClick for detected URL text', () => {
+    const openExternal = vi.fn()
+    const { onClick } = createTerminalLinkHandlers({ isMac: false, openExternal })
+
+    onClick({ button: 0, metaKey: false, ctrlKey: true } as MouseEvent, 'http://x.dev')
+    onClick({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'http://x.dev')
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('http://x.dev')
+  })
+})

--- a/src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   shouldOpenTerminalLink,
-  createWebLinkHandler,
   createTerminalLinkHandlers,
   type TerminalLinkClick,
 } from './terminalLinkHandler'
@@ -63,43 +62,79 @@ describe('shouldOpenTerminalLink', () => {
   })
 })
 
-describe('createWebLinkHandler', () => {
-  it('opens exactly the links that qualify', () => {
-    const openExternal = vi.fn()
-    const handler = createWebLinkHandler({ isMac: true, openExternal })
-
-    // qualifying: ⌘ + primary + https
-    handler({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
-    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com')
-
-    // non-qualifying: plain click, and a modified file: URL
-    handler({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://example.com')
-    handler({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'file:///etc/passwd')
-    expect(openExternal).toHaveBeenCalledTimes(1)
-  })
-})
-
 describe('createTerminalLinkHandlers', () => {
-  it('gates OSC 8 links (linkHandler) with the same rule and forbids non-http protocols', () => {
+  const makeDeps = (isMac: boolean) => {
     const openExternal = vi.fn()
-    const { linkHandler } = createTerminalLinkHandlers({ isMac: true, openExternal })
+    const hint = { show: vi.fn(), hide: vi.fn() }
+    return { openExternal, hint, handlers: createTerminalLinkHandlers({ isMac, openExternal, hint }) }
+  }
+
+  it('gates OSC 8 links (linkHandler) with the same rule and forbids non-http protocols', () => {
+    const { openExternal, handlers } = makeDeps(true)
 
     // xterm must not fall back to its plain-click confirm()+window.open for non-http links.
-    expect(linkHandler.allowNonHttpProtocols).toBe(false)
+    expect(handlers.linkHandler.allowNonHttpProtocols).toBe(false)
 
-    linkHandler.activate({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
+    handlers.linkHandler.activate({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
     expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com')
 
-    linkHandler.activate({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://example.com')
+    handlers.linkHandler.activate({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://example.com')
     expect(openExternal).toHaveBeenCalledTimes(1)
   })
 
   it('exposes the same gate as onClick for detected URL text', () => {
-    const openExternal = vi.fn()
-    const { onClick } = createTerminalLinkHandlers({ isMac: false, openExternal })
+    const { openExternal, handlers } = makeDeps(false)
 
-    onClick({ button: 0, metaKey: false, ctrlKey: true } as MouseEvent, 'http://x.dev')
-    onClick({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'http://x.dev')
+    handlers.onClick({ button: 0, metaKey: false, ctrlKey: true } as MouseEvent, 'http://x.dev')
+    handlers.onClick({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'http://x.dev')
     expect(openExternal).toHaveBeenCalledExactlyOnceWith('http://x.dev')
+  })
+
+  it('refuses a non-http URI even with the modifier held (both paths)', () => {
+    const { openExternal, handlers } = makeDeps(true)
+    const modified = { button: 0, metaKey: true, ctrlKey: false } as MouseEvent
+
+    handlers.onClick(modified, 'file:///etc/passwd')
+    handlers.linkHandler.activate(modified, 'file:///etc/passwd')
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('shows the hint on hover and hides it on leave, for both link paths', () => {
+    const { hint, handlers } = makeDeps(true)
+    const event = { clientX: 10, clientY: 20 } as MouseEvent
+
+    handlers.linkProviderOptions.hover(event, 'https://example.com')
+    expect(hint.show).toHaveBeenCalledExactlyOnceWith(event, 'https://example.com')
+    handlers.linkProviderOptions.leave()
+    expect(hint.hide).toHaveBeenCalledOnce()
+
+    handlers.linkHandler.hover(event, 'https://example.com')
+    expect(hint.show).toHaveBeenCalledTimes(2)
+    handlers.linkHandler.leave()
+    expect(hint.hide).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not promise to open a URI the click gate would refuse', () => {
+    const { hint, handlers } = makeDeps(true)
+
+    handlers.linkProviderOptions.hover({} as MouseEvent, 'file:///etc/passwd')
+    expect(hint.show).not.toHaveBeenCalled()
+  })
+
+  it('hides the hint when a link is opened (no leave fires once focus goes to the browser)', () => {
+    const { hint, handlers } = makeDeps(true)
+
+    handlers.onClick({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
+    expect(hint.hide).toHaveBeenCalledOnce()
+  })
+
+  it('works without a hint (optional affordance)', () => {
+    const openExternal = vi.fn()
+    const { onClick, linkProviderOptions } = createTerminalLinkHandlers({ isMac: true, openExternal })
+
+    expect(() => linkProviderOptions.hover({} as MouseEvent, 'https://example.com')).not.toThrow()
+    expect(() => linkProviderOptions.leave()).not.toThrow()
+    onClick({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com')
   })
 })

--- a/src/renderer/panels/agent/hooks/terminalLinkHandler.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHandler.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure logic for the terminal's ⌘/⌃-click-to-open-URL behaviour (#149).
+ *
+ * Kept free of xterm and the DOM so it can be unit-tested directly. `useTerminalSetup`
+ * wires it into `@xterm/addon-web-links`, whose click handler is invoked with the raw
+ * `MouseEvent` and the detected URI.
+ */
+
+/** The parts of a `MouseEvent` the open-decision depends on. */
+export interface TerminalLinkClick {
+  button: number
+  metaKey: boolean
+  ctrlKey: boolean
+}
+
+/**
+ * Whether a click on a detected terminal link should open it.
+ *
+ * Requires the PRIMARY button plus the platform modifier — ⌘ on macOS, Ctrl elsewhere.
+ * (Ctrl-click on macOS is the context-menu gesture, so it must not open; middle/right
+ * clicks are excluded via the button check.) A plain click returns false, leaving xterm's
+ * normal selection/cursor behaviour untouched.
+ *
+ * The scheme is re-checked here even though the addon only detects http(s): agent output
+ * is untrusted, so this mirrors the renderer-side guard at
+ * `shared/utils/markdownComponents.tsx` (the main process restricts it further still).
+ */
+export function shouldOpenTerminalLink(
+  event: TerminalLinkClick,
+  uri: string,
+  isMac: boolean
+): boolean {
+  if (event.button !== 0) return false
+  const modifierHeld = isMac ? event.metaKey : event.ctrlKey
+  if (!modifierHeld) return false
+  return /^https?:\/\//i.test(uri)
+}
+
+/**
+ * Build the click handler passed to `new WebLinksAddon(...)`. Opens qualifying links
+ * through the injected `openExternal` (which the main process further restricts to http(s)).
+ */
+export function createWebLinkHandler(deps: {
+  isMac: boolean
+  openExternal: (uri: string) => void
+}): (event: MouseEvent, uri: string) => void {
+  return (event, uri) => {
+    if (shouldOpenTerminalLink(event, uri, deps.isMac)) {
+      deps.openExternal(uri)
+    }
+  }
+}
+
+/**
+ * Build both link hooks the terminal needs, gated by the same rule:
+ *  - `onClick` for `@xterm/addon-web-links` (URL-shaped text), and
+ *  - `linkHandler` for xterm's core OSC 8 hyperlinks.
+ *
+ * Both must be wired: without a `linkHandler`, OSC 8 links fall back to xterm's default —
+ * a blocking `confirm()` then `window.open` on any plain click — which would open some
+ * terminal links without the modifier, contradicting the feature. `allowNonHttpProtocols`
+ * stays false so xterm also refuses non-http(s) OSC 8 links before they reach the handler.
+ */
+export function createTerminalLinkHandlers(deps: {
+  isMac: boolean
+  openExternal: (uri: string) => void
+}): {
+  onClick: (event: MouseEvent, uri: string) => void
+  linkHandler: { activate: (event: MouseEvent, uri: string) => void; allowNonHttpProtocols: false }
+} {
+  const onClick = createWebLinkHandler(deps)
+  return {
+    onClick,
+    linkHandler: { activate: onClick, allowNonHttpProtocols: false },
+  }
+}

--- a/src/renderer/panels/agent/hooks/terminalLinkHandler.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHandler.ts
@@ -3,7 +3,8 @@
  *
  * Kept free of xterm and the DOM so it can be unit-tested directly. `useTerminalSetup`
  * wires it into `@xterm/addon-web-links`, whose click handler is invoked with the raw
- * `MouseEvent` and the detected URI.
+ * `MouseEvent` and the detected URI. The hover hint that tells the user a modifier is
+ * required is the one DOM-touching piece, and lives in `terminalLinkHint.ts`.
  */
 
 /** The parts of a `MouseEvent` the open-decision depends on. */
@@ -13,6 +14,24 @@ export interface TerminalLinkClick {
   ctrlKey: boolean
 }
 
+/** The hover affordance, injected so this module stays DOM-free. */
+export interface TerminalLinkHint {
+  show(event: MouseEvent, uri: string): void
+  hide(): void
+}
+
+/**
+ * Whether a URI is one the terminal will open at all.
+ *
+ * Re-checked here even though the addon only detects http(s): agent output is untrusted,
+ * so this mirrors the renderer-side guard at `shared/utils/markdownComponents.tsx` (the
+ * main process restricts it further still). It also gates the hover hint, so the terminal
+ * never offers to open something it would then refuse.
+ */
+export function isOpenableTerminalUri(uri: string): boolean {
+  return /^https?:\/\//i.test(uri)
+}
+
 /**
  * Whether a click on a detected terminal link should open it.
  *
@@ -20,10 +39,6 @@ export interface TerminalLinkClick {
  * (Ctrl-click on macOS is the context-menu gesture, so it must not open; middle/right
  * clicks are excluded via the button check.) A plain click returns false, leaving xterm's
  * normal selection/cursor behaviour untouched.
- *
- * The scheme is re-checked here even though the addon only detects http(s): agent output
- * is untrusted, so this mirrors the renderer-side guard at
- * `shared/utils/markdownComponents.tsx` (the main process restricts it further still).
  */
 export function shouldOpenTerminalLink(
   event: TerminalLinkClick,
@@ -33,44 +48,64 @@ export function shouldOpenTerminalLink(
   if (event.button !== 0) return false
   const modifierHeld = isMac ? event.metaKey : event.ctrlKey
   if (!modifierHeld) return false
-  return /^https?:\/\//i.test(uri)
+  return isOpenableTerminalUri(uri)
 }
 
-/**
- * Build the click handler passed to `new WebLinksAddon(...)`. Opens qualifying links
- * through the injected `openExternal` (which the main process further restricts to http(s)).
- */
-export function createWebLinkHandler(deps: {
+export interface TerminalLinkDeps {
   isMac: boolean
   openExternal: (uri: string) => void
-}): (event: MouseEvent, uri: string) => void {
+  /** Optional so callers without a container (and most tests) can skip the affordance. */
+  hint?: TerminalLinkHint
+}
+
+/** The click handler shared by the web-links addon and xterm's OSC 8 `linkHandler`. */
+function createWebLinkHandler(deps: TerminalLinkDeps): (event: MouseEvent, uri: string) => void {
   return (event, uri) => {
     if (shouldOpenTerminalLink(event, uri, deps.isMac)) {
+      // Hide first: focus leaves for the browser and xterm fires no `leave` for a link the
+      // pointer never left, so the hint would otherwise stay on screen.
+      deps.hint?.hide()
       deps.openExternal(uri)
     }
   }
 }
 
 /**
- * Build both link hooks the terminal needs, gated by the same rule:
- *  - `onClick` for `@xterm/addon-web-links` (URL-shaped text), and
+ * Build every link hook the terminal needs, all gated by the same rule:
+ *  - `onClick` / `linkProviderOptions` for `@xterm/addon-web-links` (URL-shaped text), and
  *  - `linkHandler` for xterm's core OSC 8 hyperlinks.
  *
- * Both must be wired: without a `linkHandler`, OSC 8 links fall back to xterm's default —
- * a blocking `confirm()` then `window.open` on any plain click — which would open some
- * terminal links without the modifier, contradicting the feature. `allowNonHttpProtocols`
+ * Both paths must be wired: without a `linkHandler`, OSC 8 links fall back to xterm's
+ * default — a blocking `confirm()` then `window.open` on any plain click — which would open
+ * some terminal links without the modifier, contradicting the feature. `allowNonHttpProtocols`
  * stays false so xterm also refuses non-http(s) OSC 8 links before they reach the handler.
+ *
+ * The hover hooks exist because xterm underlines a link and shows a pointer cursor whether
+ * or not the modifier is held: without a hint, a plain click is a dead end with no feedback.
+ * Both paths share the hint for the same reason they share the gate.
  */
-export function createTerminalLinkHandlers(deps: {
-  isMac: boolean
-  openExternal: (uri: string) => void
-}): {
+export function createTerminalLinkHandlers(deps: TerminalLinkDeps): {
   onClick: (event: MouseEvent, uri: string) => void
-  linkHandler: { activate: (event: MouseEvent, uri: string) => void; allowNonHttpProtocols: false }
+  linkProviderOptions: {
+    hover: (event: MouseEvent, uri: string) => void
+    leave: () => void
+  }
+  linkHandler: {
+    activate: (event: MouseEvent, uri: string) => void
+    hover: (event: MouseEvent, uri: string) => void
+    leave: () => void
+    allowNonHttpProtocols: false
+  }
 } {
   const onClick = createWebLinkHandler(deps)
+  const hover = (event: MouseEvent, uri: string): void => {
+    if (isOpenableTerminalUri(uri)) deps.hint?.show(event, uri)
+  }
+  const leave = (): void => deps.hint?.hide()
+
   return {
     onClick,
-    linkHandler: { activate: onClick, allowNonHttpProtocols: false },
+    linkProviderOptions: { hover, leave },
+    linkHandler: { activate: onClick, hover, leave, allowNonHttpProtocols: false },
   }
 }

--- a/src/renderer/panels/agent/hooks/terminalLinkHint.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHint.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createTerminalLinkHint } from './terminalLinkHint'
+import { modifierSymbol } from '../../../shared/utils/platform'
+
+describe('createTerminalLinkHint', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  const hintEl = () => container.firstElementChild as HTMLElement | null
+
+  it('mounts hidden inside the terminal container', () => {
+    createTerminalLinkHint(container)
+
+    expect(hintEl()).not.toBeNull()
+    expect(hintEl()!.style.display).toBe('none')
+  })
+
+  it('names the platform modifier so the user knows what the plain click was missing', () => {
+    createTerminalLinkHint(container)
+
+    expect(hintEl()!.textContent).toBe(`${modifierSymbol}click to open`)
+  })
+
+  it('carries xterm-hover so it does not swallow events into the terminal beneath', () => {
+    createTerminalLinkHint(container)
+
+    expect(hintEl()!.className).toContain('xterm-hover')
+    expect(hintEl()!.className).toContain('pointer-events-none')
+  })
+
+  it('shows at the pointer and hides again', () => {
+    const hint = createTerminalLinkHint(container)
+
+    hint.show({ clientX: 100, clientY: 200 } as MouseEvent, 'https://example.com')
+    expect(hintEl()!.style.display).toBe('')
+    // Offset off the pointer so the hint never covers the link it describes.
+    expect(hintEl()!.style.left).toBe('112px')
+    expect(hintEl()!.style.top).toBe('212px')
+
+    hint.hide()
+    expect(hintEl()!.style.display).toBe('none')
+  })
+
+  it('removes itself on dispose (it would otherwise outlive the terminal)', () => {
+    const hint = createTerminalLinkHint(container)
+    hint.dispose()
+
+    expect(hintEl()).toBeNull()
+  })
+})

--- a/src/renderer/panels/agent/hooks/terminalLinkHint.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHint.ts
@@ -1,0 +1,57 @@
+/**
+ * The "⌘ click to open" hint shown while the pointer is over a terminal link (#149).
+ *
+ * xterm underlines a link and switches the cursor to a pointer as soon as the mouse is over
+ * it, with no way to say "…but you need a modifier". Without this hint the first plain click
+ * is a dead end: the link *looks* clickable, nothing happens, and there is nothing to tell
+ * the user why. VS Code and iTerm2 solve it the same way.
+ *
+ * The element carries xterm's `xterm-hover` class as its docs require, so it does not swallow
+ * mouse events into the terminal beneath (belt-and-braces with `pointer-events-none`), and is
+ * positioned from the pointer rather than the buffer range — the `MouseEvent` is right there,
+ * and cell-to-pixel maths would have to track font size and zoom.
+ */
+import { modifierSymbol } from '../../../shared/utils/platform'
+
+/** Kept off the pointer so the hint never covers the link it describes. */
+const CURSOR_OFFSET_PX = 12
+
+const HINT_CLASSES =
+  'xterm-hover fixed z-50 pointer-events-none px-1.5 py-0.5 rounded border border-border ' +
+  'bg-bg-tertiary text-text-secondary text-2xs whitespace-nowrap shadow-lg'
+
+export interface TerminalLinkHintElement {
+  show(event: MouseEvent, uri: string): void
+  hide(): void
+  dispose(): void
+}
+
+/**
+ * Create the hint inside `container` (the element xterm is opened on).
+ *
+ * `dispose` must be called with the terminal — the setup effect's cleanup kills the PTY and
+ * the terminal together, and a detached hint would outlive both.
+ */
+export function createTerminalLinkHint(container: HTMLElement): TerminalLinkHintElement {
+  const el = document.createElement('div')
+  el.className = HINT_CLASSES
+  el.textContent = `${modifierSymbol}click to open`
+  el.style.display = 'none'
+  container.appendChild(el)
+
+  return {
+    show(event: MouseEvent): void {
+      el.style.display = ''
+      // Anchored above-right of the pointer. `fixed` means viewport coordinates, which is
+      // exactly what clientX/clientY are, so no ancestor needs to be positioned.
+      el.style.left = `${event.clientX + CURSOR_OFFSET_PX}px`
+      el.style.top = `${event.clientY + CURSOR_OFFSET_PX}px`
+    },
+    hide(): void {
+      el.style.display = 'none'
+    },
+    dispose(): void {
+      el.remove()
+    },
+  }
+}

--- a/src/renderer/panels/agent/hooks/terminalLinks.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinks.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import { createLinkWiring } from './terminalLinks'
+import { allowConsoleError } from '../../../../test/console-guard'
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class MockWebLinksAddon {
+    constructor(
+      public handler?: (event: MouseEvent, uri: string) => void,
+      public options?: { hover?: (event: MouseEvent, uri: string) => void; leave?: () => void },
+    ) {}
+  },
+}))
+
+/** Both modifiers, so the assertion holds whichever platform the test runs on. */
+const MODIFIED_CLICK = { button: 0, metaKey: true, ctrlKey: true, clientX: 1, clientY: 2 } as MouseEvent
+
+describe('createLinkWiring', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    vi.mocked(window.shell.openExternal).mockReset().mockResolvedValue(undefined)
+  })
+
+  it('wires both of xterm\'s link paths to the same gate', () => {
+    const links = createLinkWiring(container)
+
+    expect(links.addon).toBeInstanceOf(WebLinksAddon)
+    expect(links.linkHandler.allowNonHttpProtocols).toBe(false)
+
+    links.linkHandler.activate(MODIFIED_CLICK, 'https://osc8.example', undefined as never)
+    expect(window.shell.openExternal).toHaveBeenCalledExactlyOnceWith('https://osc8.example')
+  })
+
+  it('mounts a hint the addon can drive, and removes it on dispose', () => {
+    const links = createLinkWiring(container)
+    const addon = links.addon as unknown as {
+      options?: { hover?: (e: MouseEvent, uri: string) => void; leave?: () => void }
+    }
+
+    const hint = container.querySelector<HTMLElement>('.xterm-hover')
+    expect(hint!.style.display).toBe('none')
+
+    addon.options!.hover!(MODIFIED_CLICK, 'https://text.example')
+    expect(hint!.style.display).toBe('')
+    addon.options!.leave!()
+    expect(hint!.style.display).toBe('none')
+
+    links.dispose()
+    expect(container.querySelector('.xterm-hover')).toBeNull()
+  })
+
+  it('logs a failed open instead of leaving an unhandled rejection', async () => {
+    allowConsoleError()
+    vi.mocked(window.shell.openExternal).mockRejectedValue(new Error('no browser'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const links = createLinkWiring(container)
+
+    links.linkHandler.activate(MODIFIED_CLICK, 'https://example.com', undefined as never)
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled())
+
+    expect(consoleError.mock.calls[0][0]).toContain('failed to open link')
+    consoleError.mockRestore()
+  })
+})

--- a/src/renderer/panels/agent/hooks/terminalLinks.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinks.ts
@@ -1,0 +1,57 @@
+/**
+ * Wires ⌘-click (⌃-click on Win/Linux) an http(s) URL to open it externally (#149) into an
+ * xterm instance. The single entry point `useTerminalSetup` needs — it composes the three
+ * pieces so the setup effect stays a one-liner:
+ *
+ *   terminalLinkHandler.ts — the gate (pure: no xterm, no DOM)
+ *   terminalLinkHint.ts    — the "⌘click to open" affordance (DOM)
+ *   this module            — the xterm bindings for both of xterm's link paths
+ *
+ * Both paths must be wired. Detected URL text goes through the web-links addon; OSC 8
+ * hyperlinks go through the core `linkHandler`, and without one they fall back to xterm's
+ * default (a blocking `confirm()` then `window.open` on *any* plain click), which would open
+ * some links with no modifier at all. They share one gate and one hint so the two kinds of
+ * link are indistinguishable to the user.
+ */
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import type { ILinkHandler } from '@xterm/xterm'
+
+import { isMac } from '../../../shared/utils/platform'
+import { createTerminalLinkHandlers } from './terminalLinkHandler'
+import { createTerminalLinkHint } from './terminalLinkHint'
+
+export interface TerminalLinkWiring {
+  /** Passed to the `XTerm` constructor — covers OSC 8 hyperlinks. */
+  linkHandler: ILinkHandler
+  /** `loadAddon` this — covers URL-shaped text. */
+  addon: WebLinksAddon
+  /** Belongs in the setup effect's cleanup, beside `terminal.dispose()`. */
+  dispose: () => void
+}
+
+/**
+ * Build the link wiring for a terminal mounted on `container`.
+ *
+ * The gate wants the platform modifier plus the primary button, and re-checks the scheme —
+ * the main process restricts `shell.openExternal` to http(s) as well, since terminal output
+ * is untrusted. Open failures are logged rather than left as an unhandled rejection: a plain
+ * click still positions the cursor, so a failed open must not break the terminal.
+ */
+export function createLinkWiring(container: HTMLElement): TerminalLinkWiring {
+  const hint = createTerminalLinkHint(container)
+  const handlers = createTerminalLinkHandlers({
+    isMac,
+    hint,
+    openExternal: (uri) => {
+      window.shell.openExternal(uri).catch((err: unknown) => {
+        console.error('[terminal] failed to open link', err)
+      })
+    },
+  })
+
+  return {
+    linkHandler: handlers.linkHandler,
+    addon: new WebLinksAddon(handlers.onClick, handlers.linkProviderOptions),
+    dispose: () => hint.dispose(),
+  }
+}

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.test.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.test.ts
@@ -73,7 +73,10 @@ vi.mock('@xterm/addon-serialize', () => {
 vi.mock('@xterm/addon-web-links', () => {
   return {
     WebLinksAddon: class MockWebLinksAddon {
-      constructor(public handler?: (event: MouseEvent, uri: string) => void) {}
+      constructor(
+        public handler?: (event: MouseEvent, uri: string) => void,
+        public options?: { hover?: (event: MouseEvent, uri: string) => void; leave?: () => void },
+      ) {}
     },
   }
 })
@@ -246,7 +249,12 @@ describe('useTerminalSetup', () => {
     // Pull the click handler the addon actually received, rather than only asserting it loaded.
     const webLinks = mockTerminalLoadAddon.mock.calls
       .map(([addon]) => addon)
-      .find((addon) => addon instanceof WebLinksAddon) as { handler?: (e: MouseEvent, uri: string) => void } | undefined
+      .find((addon) => addon instanceof WebLinksAddon) as
+      | {
+          handler?: (e: MouseEvent, uri: string) => void
+          options?: { hover?: (e: MouseEvent, uri: string) => void; leave?: () => void }
+        }
+      | undefined
     expect(webLinks?.handler).toBeTypeOf('function')
 
     // 1) URL-shaped text (web-links addon): modifier-click opens (both modifiers set so the
@@ -266,6 +274,41 @@ describe('useTerminalSetup', () => {
     ctorOptions!.linkHandler!.activate!({ button: 0, metaKey: true, ctrlKey: true } as MouseEvent, 'https://osc8.example')
     ctorOptions!.linkHandler!.activate!({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://osc8.example')
     expect(window.shell.openExternal).toHaveBeenCalledExactlyOnceWith('https://osc8.example')
+  })
+
+  it('mounts a modifier hint that both link paths drive, and removes it on unmount (#149)', async () => {
+    const config = makeConfig({ sessionId: 'my-session' })
+    const containerRef = makeContainerRef()
+
+    const { unmount } = renderHook(() => useTerminalSetup(config, containerRef))
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+
+    const container = containerRef.current!
+    const hint = container.querySelector<HTMLElement>('.xterm-hover')
+    expect(hint).not.toBeNull()
+    expect(hint!.style.display).toBe('none')
+
+    const webLinks = mockTerminalLoadAddon.mock.calls
+      .map(([addon]) => addon)
+      .find((addon) => addon instanceof WebLinksAddon) as
+      | { options?: { hover?: (e: MouseEvent, uri: string) => void; leave?: () => void } }
+      | undefined
+
+    // URL-shaped text drives the hint via the addon's hover/leave options...
+    webLinks!.options!.hover!({ clientX: 5, clientY: 6 } as MouseEvent, 'https://text.example')
+    expect(hint!.style.display).toBe('')
+    webLinks!.options!.leave!()
+    expect(hint!.style.display).toBe('none')
+
+    // ...and OSC 8 links drive the same hint via the Terminal's linkHandler.
+    const ctorOptions = mockTerminalConstructor.mock.calls.at(-1)?.[0] as
+      | { linkHandler?: { hover?: (e: MouseEvent, uri: string) => void } }
+      | undefined
+    ctorOptions!.linkHandler!.hover!({ clientX: 5, clientY: 6 } as MouseEvent, 'https://osc8.example')
+    expect(hint!.style.display).toBe('')
+
+    unmount()
+    expect(container.querySelector('.xterm-hover')).toBeNull()
   })
 
   it('records the shell kind after create resolves and clears it on unmount', async () => {

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.test.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useTerminalSetup, type TerminalConfig } from './useTerminalSetup'
+import { WebLinksAddon } from '@xterm/addon-web-links'
 import { useSessionStore, type StatusChip } from '../../../store/sessions'
 import { useErrorStore } from '../../../store/errors'
 import { allowConsoleError } from '../../../../test/console-guard'
@@ -22,12 +23,14 @@ const mockTerminalOnScroll = vi.fn().mockReturnValue({ dispose: vi.fn() })
 const mockTerminalOnResize = vi.fn().mockReturnValue({ dispose: vi.fn() })
 const mockTerminalAttachCustomKeyEventHandler = vi.fn()
 const mockTerminalResize = vi.fn()
+const mockTerminalConstructor = vi.fn()
 
 const mockRegisterCsiHandler = vi.fn().mockReturnValue({ dispose: vi.fn() })
 
 vi.mock('@xterm/xterm', () => {
   return {
     Terminal: class MockTerminal {
+      constructor(options?: unknown) { mockTerminalConstructor(options) }
       write = mockTerminalWrite
       open = mockTerminalOpen
       dispose = mockTerminalDispose
@@ -63,6 +66,14 @@ vi.mock('@xterm/addon-serialize', () => {
   return {
     SerializeAddon: class MockSerializeAddon {
       serialize = mockSerializeAddonSerialize
+    },
+  }
+})
+
+vi.mock('@xterm/addon-web-links', () => {
+  return {
+    WebLinksAddon: class MockWebLinksAddon {
+      constructor(public handler?: (event: MouseEvent, uri: string) => void) {}
     },
   }
 })
@@ -223,6 +234,38 @@ describe('useTerminalSetup', () => {
         env: { TERM: 'xterm' },
       }),
     )
+  })
+
+  it('wires the web-links addon to the gated open handler (#149)', async () => {
+    const config = makeConfig({ sessionId: 'my-session' })
+    const containerRef = makeContainerRef()
+
+    renderHook(() => useTerminalSetup(config, containerRef))
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+
+    // Pull the click handler the addon actually received, rather than only asserting it loaded.
+    const webLinks = mockTerminalLoadAddon.mock.calls
+      .map(([addon]) => addon)
+      .find((addon) => addon instanceof WebLinksAddon) as { handler?: (e: MouseEvent, uri: string) => void } | undefined
+    expect(webLinks?.handler).toBeTypeOf('function')
+
+    // 1) URL-shaped text (web-links addon): modifier-click opens (both modifiers set so the
+    //    assertion is platform-independent), a plain click does not.
+    vi.mocked(window.shell.openExternal).mockClear()
+    webLinks!.handler!({ button: 0, metaKey: true, ctrlKey: true } as MouseEvent, 'https://text.example')
+    webLinks!.handler!({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://text.example')
+    expect(window.shell.openExternal).toHaveBeenCalledExactlyOnceWith('https://text.example')
+
+    // 2) OSC 8 hyperlinks (xterm linkHandler): the same gate must reach the Terminal constructor,
+    //    or OSC 8 links fall back to xterm's plain-click confirm()+window.open.
+    const ctorOptions = mockTerminalConstructor.mock.calls.at(-1)?.[0] as
+      | { linkHandler?: { activate?: (e: MouseEvent, uri: string) => void; allowNonHttpProtocols?: boolean } }
+      | undefined
+    expect(ctorOptions?.linkHandler?.allowNonHttpProtocols).toBe(false)
+    vi.mocked(window.shell.openExternal).mockClear()
+    ctorOptions!.linkHandler!.activate!({ button: 0, metaKey: true, ctrlKey: true } as MouseEvent, 'https://osc8.example')
+    ctorOptions!.linkHandler!.activate!({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://osc8.example')
+    expect(window.shell.openExternal).toHaveBeenCalledExactlyOnceWith('https://osc8.example')
   })
 
   it('records the shell kind after create resolves and clears it on unmount', async () => {

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.ts
@@ -12,15 +12,17 @@
  *   ptyDataHandler.ts — only scroll to bottom if wasRecentlyAtBottom().
  */
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { Terminal as XTerm } from '@xterm/xterm'
+import { Terminal as XTerm, type ILinkHandler } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { SerializeAddon } from '@xterm/addon-serialize'
+import { WebLinksAddon } from '@xterm/addon-web-links'
 
 import { useSessionStore } from '../../../store/sessions'
 import { useRepoStore } from '../../../store/repos'
 import { terminalBufferRegistry } from '../../../shared/utils/terminalBufferRegistry'
 import { ptyCaptureRegistry } from '../../../shared/utils/ptyCaptureRegistry'
 import { useTerminalKeyboard } from './useTerminalKeyboard'
+import { createTerminalLinkHandlers } from './terminalLinkHandler'
 import { usePlanDetection } from '../../../features/git/hooks/usePlanDetection'
 import { createPtyDataHandler } from './ptyDataHandler'
 import { ScrollLog, scrollLogRegistry } from '../utils/scrollLog'
@@ -384,7 +386,7 @@ function useTerminalState(config: TerminalConfig) {
  * Reads settings imperatively (getState) so the caller's setup effect need not
  * depend on them — see the call site for why that dependency is deliberately avoided.
  */
-function createConfiguredTerminal(): XTerm {
+function createConfiguredTerminal(linkHandler: ILinkHandler): XTerm {
   const { appearance, resolvedTheme } = useSettingsStore.getState()
   return new XTerm({
     theme: XTERM_THEMES[resolvedTheme],
@@ -396,6 +398,8 @@ function createConfiguredTerminal(): XTerm {
     scrollback: 5000,
     minimumContrastRatio: resolveTerminalContrast(appearance.terminalContrast, resolvedTheme),
     macOptionIsMeta: true,
+    // Route OSC 8 hyperlinks through the same gated handler as detected URL text (#149).
+    linkHandler,
   })
 }
 
@@ -421,7 +425,20 @@ export function useTerminalSetup(
     // as a hook dependency. THIS EFFECT'S CLEANUP KILLS THE PTY — adding theme or
     // fontSize to its deps would destroy the running agent on every appearance
     // change. The separate effect below applies changes to the live terminal instead.
-    const terminal = createConfiguredTerminal()
+    // ⌘-click (⌃-click on Win/Linux) an http(s) URL to open it externally (#149). One gated
+    // handler serves both detected URL text (web-links addon) and OSC 8 hyperlinks (xterm's
+    // linkHandler), on every terminal. The gate requires the platform modifier + primary button
+    // and re-checks the scheme (main further restricts shell.openExternal to http(s)).
+    const linkHandling = createTerminalLinkHandlers({
+      isMac: navigator.userAgent.includes('Mac'),
+      openExternal: (uri) => {
+        window.shell.openExternal(uri).catch((err: unknown) => {
+          console.error('[terminal] failed to open link', err)
+        })
+      },
+    })
+
+    const terminal = createConfiguredTerminal(linkHandling.linkHandler)
 
     const fitAddon = new FitAddon()
     terminal.loadAddon(fitAddon)
@@ -429,6 +446,8 @@ export function useTerminalSetup(
     const serializeAddon = new SerializeAddon()
     terminal.loadAddon(serializeAddon)
     s.serializeAddonRef.current = serializeAddon
+
+    terminal.loadAddon(new WebLinksAddon(linkHandling.onClick))
 
     terminal.open(containerRef.current)
 

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.ts
@@ -15,14 +15,13 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { Terminal as XTerm, type ILinkHandler } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { SerializeAddon } from '@xterm/addon-serialize'
-import { WebLinksAddon } from '@xterm/addon-web-links'
 
 import { useSessionStore } from '../../../store/sessions'
 import { useRepoStore } from '../../../store/repos'
 import { terminalBufferRegistry } from '../../../shared/utils/terminalBufferRegistry'
 import { ptyCaptureRegistry } from '../../../shared/utils/ptyCaptureRegistry'
 import { useTerminalKeyboard } from './useTerminalKeyboard'
-import { createTerminalLinkHandlers } from './terminalLinkHandler'
+import { createLinkWiring } from './terminalLinks'
 import { usePlanDetection } from '../../../features/git/hooks/usePlanDetection'
 import { createPtyDataHandler } from './ptyDataHandler'
 import { ScrollLog, scrollLogRegistry } from '../utils/scrollLog'
@@ -403,6 +402,7 @@ function createConfiguredTerminal(linkHandler: ILinkHandler): XTerm {
   })
 }
 
+
 export function useTerminalSetup(
   config: TerminalConfig,
   containerRef: React.RefObject<HTMLDivElement | null>,
@@ -425,20 +425,8 @@ export function useTerminalSetup(
     // as a hook dependency. THIS EFFECT'S CLEANUP KILLS THE PTY — adding theme or
     // fontSize to its deps would destroy the running agent on every appearance
     // change. The separate effect below applies changes to the live terminal instead.
-    // ⌘-click (⌃-click on Win/Linux) an http(s) URL to open it externally (#149). One gated
-    // handler serves both detected URL text (web-links addon) and OSC 8 hyperlinks (xterm's
-    // linkHandler), on every terminal. The gate requires the platform modifier + primary button
-    // and re-checks the scheme (main further restricts shell.openExternal to http(s)).
-    const linkHandling = createTerminalLinkHandlers({
-      isMac: navigator.userAgent.includes('Mac'),
-      openExternal: (uri) => {
-        window.shell.openExternal(uri).catch((err: unknown) => {
-          console.error('[terminal] failed to open link', err)
-        })
-      },
-    })
-
-    const terminal = createConfiguredTerminal(linkHandling.linkHandler)
+    const links = createLinkWiring(containerRef.current)
+    const terminal = createConfiguredTerminal(links.linkHandler)
 
     const fitAddon = new FitAddon()
     terminal.loadAddon(fitAddon)
@@ -447,7 +435,7 @@ export function useTerminalSetup(
     terminal.loadAddon(serializeAddon)
     s.serializeAddonRef.current = serializeAddon
 
-    terminal.loadAddon(new WebLinksAddon(linkHandling.onClick))
+    terminal.loadAddon(links.addon)
 
     terminal.open(containerRef.current)
 
@@ -620,6 +608,7 @@ export function useTerminalSetup(
       if (s.ptyIdRef.current) { void window.pty.kill(s.ptyIdRef.current); s.ptyIdRef.current = null }
       s.shellKindRef.current = null
       terminal.dispose()
+      links.dispose()
       if (s.updateTimeoutRef.current) clearTimeout(s.updateTimeoutRef.current)
       if (s.idleTimeoutRef.current) clearTimeout(s.idleTimeoutRef.current)
       if (isAgent && s.sessionIdRef.current && s.lastStatusRef.current === 'working') {

--- a/src/renderer/shared/components/PanelPicker.tsx
+++ b/src/renderer/shared/components/PanelPicker.tsx
@@ -9,6 +9,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { usePanelRegistry, MAX_SHORTCUT_PANELS } from '../../panels'
 import type { PanelDefinition } from '../../panels'
+import { modifierSymbol } from '../utils/platform'
 
 interface PanelPickerProps {
   toolbarPanels: string[]
@@ -16,12 +17,7 @@ interface PanelPickerProps {
   onClose: () => void
 }
 
-// Detect if we're on Mac for keyboard shortcut display
-const isMac = navigator.userAgent.includes('Mac')
-const formatShortcut = (key: string) => {
-  const modifier = isMac ? '⌘' : 'Ctrl+'
-  return `${modifier}${key}`
-}
+const formatShortcut = (key: string) => `${modifierSymbol}${key}`
 
 function ToolbarPanelRow({
   panel,

--- a/src/renderer/shared/components/ShortcutsModal.tsx
+++ b/src/renderer/shared/components/ShortcutsModal.tsx
@@ -1,13 +1,11 @@
 /**
  * Modal displaying all keyboard shortcuts grouped by category.
  */
+import { isMac, modifierName as modKey } from '../utils/platform'
+
 interface ShortcutsModalProps {
   onClose: () => void
 }
-
-// Detect if we're on Mac for keyboard shortcut display
-const isMac = typeof navigator !== 'undefined' && navigator.userAgent.toUpperCase().includes('MAC')
-const modKey = isMac ? 'Cmd' : 'Ctrl'
 
 interface ShortcutGroup {
   title: string

--- a/src/renderer/shared/utils/platform.test.ts
+++ b/src/renderer/shared/utils/platform.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { isMac, modifierSymbol, modifierName } from './platform'
+
+describe('platform', () => {
+  // jsdom's default user agent is not a Mac one, so this pins the detection direction
+  // rather than restating the implementation.
+  it('detects the platform from the user agent', () => {
+    expect(isMac).toBe(navigator.userAgent.toUpperCase().includes('MAC'))
+  })
+
+  it('derives both modifier spellings from the same answer', () => {
+    expect(modifierSymbol).toBe(isMac ? '⌘' : 'Ctrl+')
+    expect(modifierName).toBe(isMac ? 'Cmd' : 'Ctrl')
+  })
+})

--- a/src/renderer/shared/utils/platform.test.ts
+++ b/src/renderer/shared/utils/platform.test.ts
@@ -1,15 +1,55 @@
-import { describe, it, expect } from 'vitest'
-import { isMac, modifierSymbol, modifierName } from './platform'
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+/**
+ * The module reads `navigator` once at import time, so each case stubs the user agent and
+ * re-imports. Asserting against the ambient `navigator` instead would be both a restatement
+ * of the implementation and environment-dependent — it passes under an environment that
+ * defines `navigator` and throws under one that doesn't.
+ */
+async function loadPlatform(userAgent: string | undefined) {
+  vi.stubGlobal('navigator', userAgent === undefined ? undefined : { userAgent })
+  vi.resetModules()
+  return import('./platform')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
 
 describe('platform', () => {
-  // jsdom's default user agent is not a Mac one, so this pins the detection direction
-  // rather than restating the implementation.
-  it('detects the platform from the user agent', () => {
-    expect(isMac).toBe(navigator.userAgent.toUpperCase().includes('MAC'))
+  it('detects macOS and reports its modifier', async () => {
+    const { isMac, modifierSymbol, modifierName } = await loadPlatform(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+    )
+
+    expect(isMac).toBe(true)
+    expect(modifierSymbol).toBe('⌘')
+    expect(modifierName).toBe('Cmd')
   })
 
-  it('derives both modifier spellings from the same answer', () => {
-    expect(modifierSymbol).toBe(isMac ? '⌘' : 'Ctrl+')
-    expect(modifierName).toBe(isMac ? 'Cmd' : 'Ctrl')
+  it('reports Ctrl off macOS', async () => {
+    const { isMac, modifierSymbol, modifierName } = await loadPlatform(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+    )
+
+    expect(isMac).toBe(false)
+    expect(modifierSymbol).toBe('Ctrl+')
+    expect(modifierName).toBe('Ctrl')
+  })
+
+  it('matches case-insensitively (the variant one call site had drifted to)', async () => {
+    const { isMac } = await loadPlatform('mozilla/5.0 (macintosh; intel mac os x)')
+
+    expect(isMac).toBe(true)
+  })
+
+  it('falls back to non-Mac where there is no navigator at all', async () => {
+    // Importable from a non-DOM test environment rather than throwing at module scope.
+    const { isMac, modifierName } = await loadPlatform(undefined)
+
+    expect(isMac).toBe(false)
+    expect(modifierName).toBe('Ctrl')
   })
 })

--- a/src/renderer/shared/utils/platform.ts
+++ b/src/renderer/shared/utils/platform.ts
@@ -1,0 +1,19 @@
+/**
+ * Platform detection for the renderer.
+ *
+ * The same `navigator.userAgent.includes('Mac')` line had been copied into four modules,
+ * one of which drifted to a case-insensitive variant — so "is this a Mac?" could in
+ * principle answer differently in two places. It decides both what modifier the UI
+ * *displays* (⌘ vs Ctrl) and what modifier the terminal's link handling *accepts*, so the
+ * two must agree by construction.
+ *
+ * The `typeof navigator` guard keeps this importable from non-DOM test environments.
+ */
+export const isMac =
+  typeof navigator !== 'undefined' && navigator.userAgent.toUpperCase().includes('MAC')
+
+/** The platform's primary modifier, as a symbol for display: `⌘` on macOS, `Ctrl+` elsewhere. */
+export const modifierSymbol = isMac ? '⌘' : 'Ctrl+'
+
+/** The platform's primary modifier, spelled out for prose and shortcut tables. */
+export const modifierName = isMac ? 'Cmd' : 'Ctrl'

--- a/tests/features/terminal-links/terminal-links.spec.ts
+++ b/tests/features/terminal-links/terminal-links.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Feature Documentation: ⌘/⌃-click a URL in the terminal to open it (#149)
+ *
+ * URLs printed in the terminal (PR links, docs, localhost dev servers) become
+ * clickable via `@xterm/addon-web-links`: ⌘-click (⌃-click on Windows/Linux) opens
+ * them in the default browser through `window.shell.openExternal`. A plain click still
+ * positions the cursor, and only http(s) URLs are opened.
+ *
+ * The browser-open itself is not observable in E2E (`shell:openExternal` no-ops under
+ * E2E_TEST), so the interaction logic — modifier gating, primary-button-only, http(s)
+ * scheme filtering — is verified in the unit tests
+ * (`src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts`). This walkthrough
+ * documents the visible state: a real URL rendered in the terminal.
+ *
+ * Run with: pnpm test:feature-docs terminal-links
+ */
+import { test, expect, resetApp } from '../_shared/electron-fixture'
+import type { Page } from '@playwright/test'
+import path from 'path'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+import { screenshotElement } from '../_shared/screenshot-helpers'
+import { generateFeaturePage, generateIndex, FeatureStep } from '../_shared/template'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const FEATURE_DIR = __dirname
+const SCREENSHOTS = path.join(FEATURE_DIR, 'screenshots')
+const FEATURES_ROOT = path.join(__dirname, '..')
+
+/** The URL the fake agent prints (scripts/fake-claude.sh). */
+const AGENT_URL = 'https://github.com/Broomy-AI/broomy/pull/149'
+
+/** Read serialized terminal buffer content from the in-app registry. */
+async function getTerminalContent(p: Page): Promise<string> {
+  return p.evaluate(() => {
+    const registry = (window as unknown as {
+      __terminalBufferRegistry?: { getSessionIds: () => string[]; getBuffer: (id: string) => string | null }
+    }).__terminalBufferRegistry
+    if (!registry) return ''
+    for (const id of registry.getSessionIds()) {
+      if (id.endsWith('-user')) continue
+      const buf = registry.getBuffer(id)
+      if (buf && buf.length > 0) return buf
+    }
+    return ''
+  })
+}
+
+let page: Page
+const steps: FeatureStep[] = []
+
+test.beforeAll(async () => {
+  await fs.promises.mkdir(SCREENSHOTS, { recursive: true })
+  ;({ page } = await resetApp())
+})
+
+test.afterAll(async () => {
+  await generateFeaturePage(
+    {
+      title: 'Click a URL in the Terminal to Open It',
+      description:
+        '⌘-click (⌃-click on Windows/Linux) a URL printed in the terminal to open it in the ' +
+        'default browser. A plain click still positions the cursor, and only http(s) URLs open.',
+      steps,
+    },
+    FEATURE_DIR,
+  )
+  await generateIndex(FEATURES_ROOT)
+})
+
+test.describe.serial('Feature: Click a URL in the Terminal', () => {
+  test('A URL printed in the terminal is a ⌘/⌃-clickable link', async () => {
+    // Wait for the fake agent to finish so its URL line is in the terminal buffer.
+    await expect.poll(() => getTerminalContent(page), { timeout: 15000 }).toContain(AGENT_URL)
+
+    const agentPanel = page.locator('[data-panel-id="agent"]')
+    await expect(agentPanel).toBeVisible()
+
+    await screenshotElement(page, agentPanel, path.join(SCREENSHOTS, '01-url-in-terminal.png'), {
+      maxHeight: 500,
+    })
+    steps.push({
+      screenshotPath: 'screenshots/01-url-in-terminal.png',
+      caption: 'A URL printed in the terminal is clickable',
+      description:
+        'Agents constantly print URLs — PR links from `gh pr create`, docs, localhost dev ' +
+        'servers. The web-links addon detects the URL (and xterm handles OSC 8 hyperlinks) and ' +
+        'underlines it on hover. ⌘-click (⌃-click on Windows/Linux) opens it via ' +
+        'window.shell.openExternal — the same external-browser path the rest of the app uses, so ' +
+        'the Electron window never navigates away. A plain click still positions the cursor, and ' +
+        'only http(s) URLs open (file:, javascript:, mailto: and scheme-less text are ignored). ' +
+        'The open itself is not observable in E2E, so the modifier/button/scheme gating is ' +
+        'proven in terminalLinkHandler.test.ts.',
+    })
+  })
+})

--- a/tests/features/terminal-links/terminal-links.spec.ts
+++ b/tests/features/terminal-links/terminal-links.spec.ts
@@ -6,11 +6,14 @@
  * them in the default browser through `window.shell.openExternal`. A plain click still
  * positions the cursor, and only http(s) URLs are opened.
  *
+ * Hovering shows a "⌘click to open" hint, because xterm underlines a link whether or not
+ * the modifier is held.
+ *
  * The browser-open itself is not observable in E2E (`shell:openExternal` no-ops under
  * E2E_TEST), so the interaction logic — modifier gating, primary-button-only, http(s)
  * scheme filtering — is verified in the unit tests
- * (`src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts`). This walkthrough
- * documents the visible state: a real URL rendered in the terminal.
+ * (`src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts`, `terminalLinkHint.test.ts`).
+ * This walkthrough documents the visible state: a real URL rendered in the terminal.
  *
  * Run with: pnpm test:feature-docs terminal-links
  */
@@ -87,7 +90,9 @@ test.describe.serial('Feature: Click a URL in the Terminal', () => {
       description:
         'Agents constantly print URLs — PR links from `gh pr create`, docs, localhost dev ' +
         'servers. The web-links addon detects the URL (and xterm handles OSC 8 hyperlinks) and ' +
-        'underlines it on hover. ⌘-click (⌃-click on Windows/Linux) opens it via ' +
+        'underlines it on hover, alongside a "⌘click to open" hint — xterm underlines a link ' +
+        'whether or not the modifier is held, so without the hint a plain click would be a dead ' +
+        'end with no explanation. ⌘-click (⌃-click on Windows/Linux) opens it via ' +
         'window.shell.openExternal — the same external-browser path the rest of the app uses, so ' +
         'the Electron window never navigates away. A plain click still positions the cursor, and ' +
         'only http(s) URLs open (file:, javascript:, mailto: and scheme-less text are ignored). ' +


### PR DESCRIPTION
Closes #149.

## Background and Motivation

URLs printed in the terminal — PR links from `gh pr create`, docs, `localhost` dev servers — couldn't be opened by click the way iTerm2 / Terminal.app / VS Code allow. You had to select → copy → switch to a browser → paste. This adds **⌘-click (⌃-click on Windows/Linux)** to open them.

## Design Decisions

- **One gated handler for both link types.** `@xterm/addon-web-links` detects URL-shaped text, and xterm's `linkHandler` covers **OSC 8** hyperlinks. Both are wired to the same handler (`terminalLinkHandler.ts`), which opens only when the **platform modifier + primary button** are used and the scheme is `http(s)`. Wiring `linkHandler` matters: without it, OSC 8 links fall back to xterm's default — a blocking `confirm()` then `window.open` on *any* plain click — which would open some links without the modifier.
- **Scope: all terminals.** The issue says "agent terminal," but the terminal setup hook is shared by agent, user-shell and Services terminals, so registering there gives every terminal the feature. Simpler (no gate) and URLs are URLs regardless of which terminal printed them. Flagging the slightly broader scope here.
- **Defense-in-depth at the privileged boundary.** #149 is the first path where *untrusted* terminal content reaches `shell.openExternal`, so the main handler now accepts only `http(s)` and dispatches the WHATWG-normalized `href` (rejecting `file:`, `javascript:`, `mailto:`, scheme-less text, and malformed/backslash forms). Every existing caller already passes `http(s)`, so no behaviour change for them.
- **Best-effort open.** A plain click still positions the cursor; renderer open rejections are caught + logged rather than left unhandled.

## Proposed Changes

- **`terminalLinkHandler.ts`** (new) — pure `shouldOpenTerminalLink` (button + platform-modifier + `^https?://`) and `createTerminalLinkHandlers` returning the `onClick` (web-links) and `linkHandler` (OSC 8) hooks.
- **`useTerminalSetup.ts`** — registers `WebLinksAddon` and passes `linkHandler` into the `XTerm` constructor.
- **`main/handlers/shell.ts`** — `shell:openExternal` now validates + normalizes via `toHttpUrl`.
- **Dependency** — adds `@xterm/addon-web-links@^0.11.0` (matches `@xterm/xterm@^5.5.0`).
- **Tests + docs** — `terminalLinkHandler.test.ts`, main-guard tests, addon/`linkHandler` wiring test; `scripts/fake-claude.sh` prints a URL; a `tests/features/terminal-links` walkthrough.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [ ] `pnpm test:unit` (coverage at or above 90% lines) — all **3907** unit tests pass; the changed files are well covered (`shell.ts` guard 100%, `terminalLinkHandler.ts` fully exercised — modifier/button/scheme table). Global line coverage sits at **88.9%** on `main` today (untested appearance hooks from the accessibility foundation); this PR only adds covered lines and doesn't lower it. Left unchecked to stay honest about the global number.
- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 72 passed

Note: `shell:openExternal` deliberately no-ops under E2E, so the URL-open can't be asserted there — the modifier/button/scheme gating is proven in `terminalLinkHandler.test.ts`, and the feature-doc asserts the URL renders in the terminal.

---

Follow-up to the merged appearance PRs, per your invite. Based directly on current `main`.
