### PR TITLE
Add native context menu to web view right-click

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,6 +27,7 @@ import { writeCrashLog, appendErrorLog } from './crashLog'
 import { disposePtyListenersForWindow, disposeAllPtyListeners } from './handlers/pty'
 import { navigationAction } from './navigation'
 import { toHttpUrl } from './externalUrl'
+import { showWebviewContextMenu } from './webviewMenu'
 import { treeKill } from './treeKill'
 import { sweepOrphanedPtys, clearOwnMarkers } from './ptyMarkers'
 
@@ -179,6 +180,11 @@ function createWindow(profileId?: string): BrowserWindow {
         window.webContents.send('webview:find-in-page')
       }
     })
+
+    // Guest pages render no context menu on their own — build and pop up a
+    // native one for the standard right-click actions (copy/paste, links,
+    // navigation). See webviewMenu.ts.
+    webContents.on('context-menu', (_e, params) => showWebviewContextMenu(webContents, window, params))
   })
 
   // Track the first window as mainWindow for backwards compat

--- a/src/main/webviewContextMenu.test.ts
+++ b/src/main/webviewContextMenu.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { buildWebviewMenuItems, type WebviewMenuParams, type WebviewNavState } from './webviewContextMenu'
+
+const noFlags = { canCut: false, canCopy: false, canPaste: false, canSelectAll: false }
+
+function params(overrides: Partial<WebviewMenuParams> = {}): WebviewMenuParams {
+  return { isEditable: false, editFlags: noFlags, selectionText: '', linkURL: '', ...overrides }
+}
+
+const noNav: WebviewNavState = { canGoBack: false, canGoForward: false }
+
+const actions = (items: ReturnType<typeof buildWebviewMenuItems>) =>
+  items.filter((i) => i.type !== 'separator').map((i) => (i as { action: string }).action)
+
+describe('buildWebviewMenuItems', () => {
+  it('always offers navigation controls, even on a plain page with no selection', () => {
+    const items = buildWebviewMenuItems(params(), noNav)
+    expect(actions(items)).toEqual(['back', 'forward', 'reload'])
+  })
+
+  it('reflects navigation availability in enabled state', () => {
+    const items = buildWebviewMenuItems(params(), { canGoBack: true, canGoForward: false })
+    const byAction = new Map(items.filter((i) => i.type !== 'separator').map((i) => [(i as { action: string }).action, i]))
+    expect((byAction.get('back') as { enabled: boolean }).enabled).toBe(true)
+    expect((byAction.get('forward') as { enabled: boolean }).enabled).toBe(false)
+    expect((byAction.get('reload') as { enabled: boolean }).enabled).toBe(true)
+  })
+
+  it('offers Copy and Select All when there is a text selection', () => {
+    const items = buildWebviewMenuItems(
+      params({ selectionText: 'hello', editFlags: { ...noFlags, canCopy: true, canSelectAll: true } }),
+      noNav,
+    )
+    expect(actions(items)).toEqual(['copy', 'selectAll', 'back', 'forward', 'reload'])
+  })
+
+  it('offers Cut/Copy/Paste/Select All in an editable field, gated by edit flags', () => {
+    const items = buildWebviewMenuItems(
+      params({ isEditable: true, editFlags: { canCut: true, canCopy: true, canPaste: false, canSelectAll: true } }),
+      noNav,
+    )
+    expect(actions(items)).toEqual(['cut', 'copy', 'paste', 'selectAll', 'back', 'forward', 'reload'])
+    const paste = items.find((i) => i.type !== 'separator' && (i as { action: string }).action === 'paste')
+    expect((paste as { enabled: boolean }).enabled).toBe(false)
+  })
+
+  it('offers link actions carrying the URL when right-clicking a hyperlink', () => {
+    const items = buildWebviewMenuItems(params({ linkURL: 'https://example.com/page' }), noNav)
+    expect(actions(items)).toEqual(['openLink', 'copyLink', 'back', 'forward', 'reload'])
+    const open = items.find((i) => i.type !== 'separator' && (i as { action: string }).action === 'openLink')
+    expect((open as { url?: string }).url).toBe('https://example.com/page')
+  })
+
+  it('ignores a non-http(s) link URL (no open/copy for javascript: or file:)', () => {
+    const items = buildWebviewMenuItems(params({ linkURL: 'javascript:alert(1)' }), noNav)
+    expect(actions(items)).toEqual(['back', 'forward', 'reload'])
+  })
+
+  it('separates the context-specific section from the navigation section', () => {
+    const items = buildWebviewMenuItems(params({ selectionText: 'x', editFlags: { ...noFlags, canCopy: true } }), noNav)
+    const sepIndex = items.findIndex((i) => i.type === 'separator')
+    expect(sepIndex).toBeGreaterThan(0)
+    expect(sepIndex).toBeLessThan(items.length - 1)
+  })
+})

--- a/src/main/webviewContextMenu.ts
+++ b/src/main/webviewContextMenu.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure builder for the right-click menu shown over a <webview> guest page.
+ *
+ * Electron guests render NO context menu on their own — the embedder must catch
+ * the guest's `context-menu` event and pop up a native Menu itself. Kept out of
+ * index.ts (importing that module boots the app) so the item logic stays
+ * unit-testable; index.ts maps each item's `action` onto the guest webContents.
+ *
+ * The menu always ends with Back / Forward / Reload; a context-specific section
+ * (link actions, or edit/selection actions) is prepended and separated from it.
+ */
+import { toHttpUrl } from './externalUrl'
+
+export interface WebviewMenuParams {
+  isEditable: boolean
+  editFlags: { canCut: boolean; canCopy: boolean; canPaste: boolean; canSelectAll: boolean }
+  selectionText: string
+  linkURL: string
+}
+
+export interface WebviewNavState {
+  canGoBack: boolean
+  canGoForward: boolean
+}
+
+export type WebviewMenuActionId =
+  | 'cut'
+  | 'copy'
+  | 'paste'
+  | 'selectAll'
+  | 'copyLink'
+  | 'openLink'
+  | 'back'
+  | 'forward'
+  | 'reload'
+
+export type WebviewMenuItem =
+  | { type: 'separator' }
+  | { type: 'item'; label: string; action: WebviewMenuActionId; enabled: boolean; url?: string }
+
+export function buildWebviewMenuItems(params: WebviewMenuParams, nav: WebviewNavState): WebviewMenuItem[] {
+  const contextItems: WebviewMenuItem[] = []
+
+  // Only http(s) links are actionable — refuse javascript:/file:/data: etc.,
+  // matching the shell:openExternal guard the "Open in browser" button uses.
+  const safeLink = toHttpUrl(params.linkURL)
+  if (safeLink) {
+    contextItems.push({ type: 'item', label: 'Open Link in Browser', action: 'openLink', enabled: true, url: safeLink })
+    contextItems.push({ type: 'item', label: 'Copy Link Address', action: 'copyLink', enabled: true, url: safeLink })
+  }
+
+  if (params.isEditable) {
+    contextItems.push({ type: 'item', label: 'Cut', action: 'cut', enabled: params.editFlags.canCut })
+    contextItems.push({ type: 'item', label: 'Copy', action: 'copy', enabled: params.editFlags.canCopy })
+    contextItems.push({ type: 'item', label: 'Paste', action: 'paste', enabled: params.editFlags.canPaste })
+    contextItems.push({ type: 'item', label: 'Select All', action: 'selectAll', enabled: params.editFlags.canSelectAll })
+  } else if (params.selectionText) {
+    contextItems.push({ type: 'item', label: 'Copy', action: 'copy', enabled: params.editFlags.canCopy })
+    contextItems.push({ type: 'item', label: 'Select All', action: 'selectAll', enabled: params.editFlags.canSelectAll })
+  }
+
+  const navItems: WebviewMenuItem[] = [
+    { type: 'item', label: 'Back', action: 'back', enabled: nav.canGoBack },
+    { type: 'item', label: 'Forward', action: 'forward', enabled: nav.canGoForward },
+    { type: 'item', label: 'Reload', action: 'reload', enabled: true },
+  ]
+
+  return contextItems.length > 0 ? [...contextItems, { type: 'separator' }, ...navItems] : navItems
+}

--- a/src/main/webviewMenu.ts
+++ b/src/main/webviewMenu.ts
@@ -1,0 +1,49 @@
+/**
+ * Impure wiring for the <webview> right-click menu: maps the pure item list from
+ * webviewContextMenu.ts onto the guest webContents and pops up a native Menu.
+ *
+ * Kept apart from the builder (which stays electron-free and unit-tested) so this
+ * file can import Menu/clipboard/shell without dragging the electron runtime into
+ * the builder's tests.
+ */
+import { Menu, clipboard, shell, type WebContents, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { buildWebviewMenuItems } from './webviewContextMenu'
+
+export function showWebviewContextMenu(
+  webContents: WebContents,
+  window: BrowserWindow,
+  params: Electron.ContextMenuParams,
+): void {
+  const items = buildWebviewMenuItems(
+    {
+      isEditable: params.isEditable,
+      editFlags: params.editFlags,
+      selectionText: params.selectionText,
+      linkURL: params.linkURL,
+    },
+    { canGoBack: webContents.canGoBack(), canGoForward: webContents.canGoForward() },
+  )
+
+  const template: MenuItemConstructorOptions[] = items.map((item) => {
+    if (item.type === 'separator') return { type: 'separator' }
+    return {
+      label: item.label,
+      enabled: item.enabled,
+      click: () => {
+        switch (item.action) {
+          case 'cut': return webContents.cut()
+          case 'copy': return webContents.copy()
+          case 'paste': return webContents.paste()
+          case 'selectAll': return webContents.selectAll()
+          case 'copyLink': if (item.url) clipboard.writeText(item.url); return
+          case 'openLink': if (item.url) void shell.openExternal(item.url); return
+          case 'back': if (webContents.canGoBack()) webContents.goBack(); return
+          case 'forward': if (webContents.canGoForward()) webContents.goForward(); return
+          case 'reload': return webContents.reload()
+        }
+      },
+    }
+  })
+
+  Menu.buildFromTemplate(template).popup({ window })
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
         'src/test/**',
         'src/renderer/main.tsx',
         'src/main/index.ts',
+        // Impure <webview> context-menu wiring (Menu/clipboard/shell on the guest
+        // webContents); its item logic lives in the unit-tested webviewContextMenu.ts.
+        'src/main/webviewMenu.ts',
         'src/preload/index.ts',
         'src/renderer/vite-env.d.ts',
         'src/preload/apis/types.ts',


### PR DESCRIPTION
## Background and Motivation

Right-clicking anywhere inside a web view (the `<webview>`-based Web Page viewer) did nothing. Electron `<webview>` guest pages render **no context menu on their own** — the embedder has to listen for the guest webContents' `context-menu` event and pop up a native `Menu` itself. That listener was simply absent: `did-attach-webview` only wired `before-input-event` (for Cmd+F).

## Design Decisions

- **Pure builder + thin wiring**, matching the existing `navigation.ts` / `externalUrl.ts` pattern. `webviewContextMenu.ts` decides the item list from the click params and is fully unit-tested with no Electron import; `webviewMenu.ts` holds the impure `Menu`/`clipboard`/`shell` wiring that maps each item's action onto the guest `webContents`. Splitting the two also keeps `src/main/index.ts` under the 500-line lint cap.
- **Link URLs are validated through the existing `toHttpUrl` guard**, so only http(s) links get Open/Copy actions — consistent with the "Open in browser" button and the `shell:openExternal` boundary.
- `webviewMenu.ts` is added to the coverage `exclude` list (like the other real-Electron main files, e.g. `agentSdk.ts`); its logic is covered via the pure builder's tests. Native `Menu.popup` menus are OS-drawn and invisible to Playwright, so the menu contents can't be asserted in E2E.

## Proposed Changes

- **`src/main/webviewContextMenu.ts`** (new) — pure `buildWebviewMenuItems`: link actions for hyperlinks, cut/copy/paste in editable fields, copy + select-all on a text selection, and always Back/Forward/Reload with correct enabled state.
- **`src/main/webviewMenu.ts`** (new) — `showWebviewContextMenu` maps actions onto the guest webContents (`.copy()`, `.paste()`, `shell.openExternal`, `clipboard.writeText`, navigation) and pops up the native menu.
- **`src/main/index.ts`** — one-line `context-menu` listener added inside `did-attach-webview`.
- **`src/main/webviewContextMenu.test.ts`** (new) — 7 tests covering the builder.
- **`vitest.config.ts`** — exclude the impure wiring module from coverage.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [ ] `pnpm test:unit` (coverage at or above 90% lines)
- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 73 passed

New builder: 7/7 unit tests pass. Global line coverage is 89.64%, a **pre-existing** shortfall on this branch (baseline was 89.63% before this change — verified via stash; this change nudges it up). The gap is in unrelated files (e.g. `sessionBranchActions.ts` at 71%), not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
