### PR TITLE
feat(sidebar): right-click a session to open its folder in the file manager

### DIFF
--- a/.storybook/electronMocks.ts
+++ b/.storybook/electronMocks.ts
@@ -131,6 +131,7 @@ export function installElectronMocks() {
     openExternal: noopResolved,
     pathExists: resolved([]),
     openPath: resolved({ action: 'none' }),
+    openInFileManager: resolved({ action: 'none' }),
     listShells: resolved([{ path: '/bin/bash', name: 'Bash', isDefault: true }]),
   }
 

--- a/src/main/handlers/shell.test.ts
+++ b/src/main/handlers/shell.test.ts
@@ -34,10 +34,12 @@ vi.mock('electron', () => ({
   },
 }))
 
-// Mock fs/promises (lstat drives the openPath / pathExists file-type checks)
+// Mock fs/promises (lstat drives openPath/pathExists; stat drives openInFileManager)
 const mockLstat = vi.fn()
+const mockStat = vi.fn()
 vi.mock('fs/promises', () => ({
   lstat: (...args: unknown[]) => mockLstat(...args),
+  stat: (...args: unknown[]) => mockStat(...args),
 }))
 
 // Mock platform
@@ -889,6 +891,69 @@ describe('shell handlers', () => {
       mockLstat.mockResolvedValue({ isFile: () => true })
       mockShellOpenPath.mockRejectedValue(new Error('boom'))
       expect((await handlers['shell:openPath'](mockEvent, '/repo/a.html', '/repo')).action).toBe('failed')
+    })
+  })
+
+  describe('shell:openInFileManager', () => {
+    it('opens a directory in the OS file manager', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      mockStat.mockResolvedValue({ isDirectory: () => true })
+      mockShellOpenPath.mockResolvedValue('')
+      expect(await handlers['shell:openInFileManager'](mockEvent, '/repo/session')).toEqual({ action: 'opened' })
+      expect(mockShellOpenPath).toHaveBeenCalledWith('/repo/session')
+      // Opens the folder itself — never the "reveal in parent" path.
+      expect(mockShowItemInFolder).not.toHaveBeenCalled()
+    })
+    it('returns none for a non-directory (a file), without opening it', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      mockStat.mockResolvedValue({ isDirectory: () => false })
+      expect(await handlers['shell:openInFileManager'](mockEvent, '/repo/a.txt')).toEqual({ action: 'none' })
+      expect(mockShellOpenPath).not.toHaveBeenCalled()
+    })
+    it('returns none for a missing path', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      mockStat.mockRejectedValue(Object.assign(new Error('no'), { code: 'ENOENT' }))
+      expect(await handlers['shell:openInFileManager'](mockEvent, '/repo/gone')).toEqual({ action: 'none' })
+    })
+    it('returns failed on a non-ENOENT stat error (e.g. EACCES)', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      mockStat.mockRejectedValue(Object.assign(new Error('denied'), { code: 'EACCES' }))
+      expect((await handlers['shell:openInFileManager'](mockEvent, '/repo/x')).action).toBe('failed')
+    })
+    it('surfaces an openPath error string', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      mockStat.mockResolvedValue({ isDirectory: () => true })
+      mockShellOpenPath.mockResolvedValue('No application set')
+      expect(await handlers['shell:openInFileManager'](mockEvent, '/repo/session')).toEqual({ action: 'failed', error: 'No application set' })
+    })
+    it('returns failed (never rejects) when the OS dispatch throws', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      mockStat.mockResolvedValue({ isDirectory: () => true })
+      mockShellOpenPath.mockRejectedValue(new Error('boom'))
+      expect((await handlers['shell:openInFileManager'](mockEvent, '/repo/session')).action).toBe('failed')
+    })
+    it('is a no-op in E2E mode', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx({ isE2ETest: true }))
+      expect(await handlers['shell:openInFileManager'](mockEvent, '/repo/session')).toEqual({ action: 'none' })
+      expect(mockStat).not.toHaveBeenCalled()
+      expect(mockShellOpenPath).not.toHaveBeenCalled()
+    })
+    it('rejects a non-absolute, empty, non-string, over-long, or control-char path before touching the fs', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      expect(await handlers['shell:openInFileManager'](mockEvent, 'relative/dir')).toEqual({ action: 'none' })
+      expect(await handlers['shell:openInFileManager'](mockEvent, '')).toEqual({ action: 'none' })
+      expect(await handlers['shell:openInFileManager'](mockEvent, 42 as never)).toEqual({ action: 'none' })
+      expect(await handlers['shell:openInFileManager'](mockEvent, `/${'a'.repeat(5000)}`)).toEqual({ action: 'none' })
+      expect(await handlers['shell:openInFileManager'](mockEvent, `/tmp/x${String.fromCharCode(0)}y`)).toEqual({ action: 'none' })
+      expect(mockStat).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/main/handlers/shell.test.ts
+++ b/src/main/handlers/shell.test.ts
@@ -905,6 +905,23 @@ describe('shell handlers', () => {
       // Opens the folder itself — never the "reveal in parent" path.
       expect(mockShowItemInFolder).not.toHaveBeenCalled()
     })
+    it('reveals a bundle directory instead of launching it', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      mockStat.mockResolvedValue({ isDirectory: () => true })
+      // A worktree named `foo.app` is still a directory — but openPath would *run* it on macOS.
+      expect(await handlers['shell:openInFileManager'](mockEvent, '/repo/Foo.App')).toEqual({ action: 'revealed' })
+      expect(mockShowItemInFolder).toHaveBeenCalledWith('/repo/Foo.App')
+      expect(mockShellOpenPath).not.toHaveBeenCalled()
+    })
+    it('opens an ordinary directory whose name merely contains a dot', async () => {
+      const { register } = await import('./shell')
+      register(mockIpcMain as never, createCtx())
+      mockStat.mockResolvedValue({ isDirectory: () => true })
+      mockShellOpenPath.mockResolvedValue('')
+      expect(await handlers['shell:openInFileManager'](mockEvent, '/repo/release-1.2')).toEqual({ action: 'opened' })
+      expect(mockShowItemInFolder).not.toHaveBeenCalled()
+    })
     it('returns none for a non-directory (a file), without opening it', async () => {
       const { register } = await import('./shell')
       register(mockIpcMain as never, createCtx())

--- a/src/main/handlers/shell.ts
+++ b/src/main/handlers/shell.ts
@@ -3,7 +3,7 @@
  */
 import { BrowserWindow, IpcMain, dialog, Menu, shell } from 'electron'
 import { exec } from 'child_process'
-import { lstat } from 'fs/promises'
+import { lstat, stat } from 'fs/promises'
 import { extname, isAbsolute, resolve } from 'path'
 import { getExecShell, normalizePath, getAvailableShells, getDefaultShell } from '../platform'
 import { HandlerContext, expandHomePath } from './types'
@@ -168,6 +168,39 @@ async function openPathHandler(ctx: HandlerContext, rawPath: unknown, baseCwd: u
   }
 }
 
+/**
+ * Open a directory's *contents* in the OS file manager (Finder / Explorer / Files). Used by the
+ * session card's right-click "Open in <file manager>". Distinct from `shell:openPath`, which
+ * *reveals* a directory (selects it in its parent) — here we open the folder itself. `stat`
+ * follows symlinks so a symlinked worktree still opens, and only directories are opened (never a
+ * stray file). Returns an `OpenPathResult` so the renderer can surface a real failure.
+ */
+async function openInFileManagerHandler(ctx: HandlerContext, rawPath: unknown): Promise<OpenPathResult> {
+  if (ctx.isE2ETest) return { action: 'none' }
+  if (typeof rawPath !== 'string' || rawPath.length === 0 || rawPath.length > MAX_PATH_LEN || CONTROL_CHARS.test(rawPath)) {
+    return { action: 'none' }
+  }
+  const abs = expandHomePath(rawPath)
+  if (!isAbsolute(abs)) return { action: 'none' }
+
+  let stats
+  try {
+    stats = await stat(abs)
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'ENOTDIR') return { action: 'none' }
+    return { action: 'failed', error: String(err) }
+  }
+  if (!stats.isDirectory()) return { action: 'none' }
+
+  try {
+    const error = await shell.openPath(abs)
+    return error ? { action: 'failed', error } : { action: 'opened' }
+  } catch (err) {
+    return { action: 'failed', error: String(err) }
+  }
+}
+
 export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
   ipcMain.handle('shell:exec', async (_event, command: string, cwd: string) => {
     if (ctx.isE2ETest && !ctx.e2eRealRepos) {
@@ -206,6 +239,7 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
   // click handler that opens documents/media (default app) or reveals everything else in Finder.
   ipcMain.handle('shell:pathExists', (_event, paths: unknown, baseCwd: unknown) => pathExistsHandler(ctx, paths, baseCwd))
   ipcMain.handle('shell:openPath', (_event, rawPath: unknown, baseCwd: unknown) => openPathHandler(ctx, rawPath, baseCwd))
+  ipcMain.handle('shell:openInFileManager', (_event, rawPath: unknown) => openInFileManagerHandler(ctx, rawPath))
 
   ipcMain.handle('shells:list', (_event) => {
     if (ctx.isE2ETest) {

--- a/src/main/handlers/shell.ts
+++ b/src/main/handlers/shell.ts
@@ -169,11 +169,20 @@ async function openPathHandler(ctx: HandlerContext, rawPath: unknown, baseCwd: u
 }
 
 /**
+ * Directories macOS treats as opaque, executable bundles: `shell.openPath` *launches* one instead
+ * of showing its contents. A worktree named `foo.app` (a branch slug can produce that) must never
+ * be a way to run something, so these are revealed in their parent instead. The check is
+ * platform-independent — revealing is harmless on Linux/Windows and keeps behaviour uniform.
+ */
+const BUNDLE_EXTENSIONS = new Set(['.app', '.bundle', '.pkg', '.framework', '.plugin', '.kext', '.dsym'])
+
+/**
  * Open a directory's *contents* in the OS file manager (Finder / Explorer / Files). Used by the
- * session card's right-click "Open in <file manager>". Distinct from `shell:openPath`, which
- * *reveals* a directory (selects it in its parent) — here we open the folder itself. `stat`
- * follows symlinks so a symlinked worktree still opens, and only directories are opened (never a
- * stray file). Returns an `OpenPathResult` so the renderer can surface a real failure.
+ * session card's right-click "Open in <file manager>". Distinct from `shell:openPath` above —
+ * see that handler for the reveal-vs-open split; here we open the folder itself rather than
+ * selecting it in its parent. `stat` follows symlinks so a symlinked worktree still opens, and
+ * only directories are opened (never a stray file, never a bundle). Returns an `OpenPathResult`
+ * so the renderer can surface a real failure.
  */
 async function openInFileManagerHandler(ctx: HandlerContext, rawPath: unknown): Promise<OpenPathResult> {
   if (ctx.isE2ETest) return { action: 'none' }
@@ -194,6 +203,10 @@ async function openInFileManagerHandler(ctx: HandlerContext, rawPath: unknown): 
   if (!stats.isDirectory()) return { action: 'none' }
 
   try {
+    if (BUNDLE_EXTENSIONS.has(extname(abs).toLowerCase())) {
+      shell.showItemInFolder(abs)
+      return { action: 'revealed' }
+    }
     const error = await shell.openPath(abs)
     return error ? { action: 'failed', error } : { action: 'opened' }
   } catch (err) {

--- a/src/preload/apis/shell.test.ts
+++ b/src/preload/apis/shell.test.ts
@@ -51,6 +51,11 @@ describe('preload shell API', () => {
       await shellApi.openPath('/a/b.html', '/repo')
       expect(mockInvoke).toHaveBeenCalledWith('shell:openPath', '/a/b.html', '/repo')
     })
+
+    it('openInFileManager invokes shell:openInFileManager with the path', async () => {
+      await shellApi.openInFileManager('/repos/proj/issue/42-x')
+      expect(mockInvoke).toHaveBeenCalledWith('shell:openInFileManager', '/repos/proj/issue/42-x')
+    })
   })
 
   describe('dialogApi', () => {

--- a/src/preload/apis/shell.ts
+++ b/src/preload/apis/shell.ts
@@ -18,6 +18,8 @@ export type ShellApi = {
   pathExists: (paths: string[], baseCwd: string) => Promise<(boolean | null)[]>
   /** Open (or reveal) a file path clicked in the terminal. Main resolves/validates the path. */
   openPath: (path: string, baseCwd: string) => Promise<OpenPathResult>
+  /** Open a directory's contents in the OS file manager (Finder/Explorer/Files). Main validates it is an absolute directory. */
+  openInFileManager: (path: string) => Promise<OpenPathResult>
   listShells: () => Promise<ShellOption[]>
 }
 
@@ -72,6 +74,7 @@ export const shellApi: ShellApi = {
   pathExists: (paths, baseCwd) =>
     ipcRenderer.invoke('shell:pathExists', (Array.isArray(paths) ? paths : []).filter((p) => typeof p === 'string').slice(0, 64), baseCwd),
   openPath: (path, baseCwd) => ipcRenderer.invoke('shell:openPath', path, baseCwd),
+  openInFileManager: (path) => ipcRenderer.invoke('shell:openInFileManager', path),
   listShells: () => ipcRenderer.invoke('shells:list'),
 }
 

--- a/src/renderer/panels/sidebar/README.md
+++ b/src/renderer/panels/sidebar/README.md
@@ -4,12 +4,12 @@ The sessions sidebar listing all active, archived, and initializing sessions.
 
 ## What it does
 
-Displays a scrollable list of session cards in the left sidebar. Each card shows the session name, branch, agent status (working/idle), and unread indicator. Supports creating, selecting, deleting, and archiving sessions. Also shows an update banner when a new app version is available.
+Displays a scrollable list of session cards in the left sidebar. Each card shows the session name, branch, agent status (working/idle), and unread indicator. Supports creating, selecting, deleting, and archiving sessions. Right-clicking a card opens a native context menu with "Open in Finder / Explorer / File Manager" (OS-dependent) that opens the session's worktree folder in the OS file manager. Also shows an update banner when a new app version is available.
 
 ## Components
 
 - `SessionList.tsx` -- Main session list with archive toggle and search
-- `SessionCard.tsx` -- Individual session card with status indicators
+- `SessionCard.tsx` -- Individual session card with status indicators and a right-click "Open in <file manager>" context menu
 - `DeleteSessionDialog.tsx` -- Confirmation dialog for session deletion
 - `UpdateBanner.tsx` -- App update notification banner
 

--- a/src/renderer/panels/sidebar/SessionCard.tsx
+++ b/src/renderer/panels/sidebar/SessionCard.tsx
@@ -15,6 +15,24 @@ import { branchStatusBadge } from '../../features/git/explorerHelpers'
 import { ReviewStatusChip } from '../../shared/components/ReviewStatusChip'
 import { StatusIndicator } from './StatusIndicator'
 import { fileManagerName } from '../../shared/utils/platform'
+import { useErrorStore } from '../../store/errors'
+
+/**
+ * Surface a failed "Open in <file manager>". The user asked for something visible to happen, so a
+ * dropped result would read as a broken menu item; `detail` covers the common case of a worktree
+ * that no longer exists on disk.
+ */
+function reportOpenFailure(directory: string, error?: string): void {
+  useErrorStore.getState().showErrorDetail({
+    id: `open-in-file-manager-${Date.now()}`,
+    message: error ?? `${directory} could not be opened`,
+    displayMessage: `Could not open this session's folder in ${fileManagerName}`,
+    detail: error ?? `${directory} is not a folder on disk — the worktree may have been deleted.`,
+    scope: 'app',
+    dismissed: false,
+    timestamp: Date.now(),
+  })
+}
 
 const statusLabels: Record<SessionStatus, string> = {
   working: 'Working',
@@ -95,15 +113,23 @@ export default memo(function SessionCard({
   const isUnread = session.isUnread
 
   // Right-click → native context menu → open the session's worktree folder in the OS file manager.
-  const handleContextMenu = async (e: React.MouseEvent) => {
+  const directory = session.directory
+  const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    const choice = await window.menu.popup([
-      { id: 'open-in-file-manager', label: `Open in ${fileManagerName}` },
-    ])
-    if (choice === 'open-in-file-manager') {
-      void window.shell.openInFileManager(session.directory)
-    }
+    void (async () => {
+      const choice = await window.menu.popup([
+        { id: 'open-in-file-manager', label: `Open in ${fileManagerName}` },
+      ])
+      if (choice !== 'open-in-file-manager') return
+      const result = await window.shell.openInFileManager(directory)
+      // 'opened'/'revealed' are both successes. Report the rest: 'failed' is an OS error, and
+      // 'none' means the folder is gone (common on an archived session whose worktree was
+      // deleted). Staying silent would make the menu item look dead.
+      if (result.action !== 'opened' && result.action !== 'revealed') {
+        reportOpenFailure(directory, result.error)
+      }
+    })().catch((err: unknown) => reportOpenFailure(directory, String(err)))
   }
 
   return (

--- a/src/renderer/panels/sidebar/SessionCard.tsx
+++ b/src/renderer/panels/sidebar/SessionCard.tsx
@@ -14,6 +14,7 @@ import { useElapsedSeconds } from '../../shared/hooks/useElapsedSeconds'
 import { branchStatusBadge } from '../../features/git/explorerHelpers'
 import { ReviewStatusChip } from '../../shared/components/ReviewStatusChip'
 import { StatusIndicator } from './StatusIndicator'
+import { fileManagerName } from '../../shared/utils/platform'
 
 const statusLabels: Record<SessionStatus, string> = {
   working: 'Working',
@@ -65,6 +66,7 @@ export default memo(function SessionCard({
         sessionType: sess.sessionType,
         reviewStatus: sess.reviewStatus,
         initError: sess.initError,
+        directory: sess.directory,
       }
     }),
   )
@@ -92,12 +94,25 @@ export default memo(function SessionCard({
     : showWorking ? 'working' : (session.status === 'error' ? 'error' : 'idle')
   const isUnread = session.isUnread
 
+  // Right-click → native context menu → open the session's worktree folder in the OS file manager.
+  const handleContextMenu = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const choice = await window.menu.popup([
+      { id: 'open-in-file-manager', label: `Open in ${fileManagerName}` },
+    ])
+    if (choice === 'open-in-file-manager') {
+      void window.shell.openInFileManager(session.directory)
+    }
+  }
+
   return (
     <div
       data-session-card
       data-session-id={sessionId}
       tabIndex={0}
       onClick={() => onSelect(sessionId)}
+      onContextMenu={handleContextMenu}
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
           onSelect(sessionId)

--- a/src/renderer/panels/sidebar/SessionList.test.tsx
+++ b/src/renderer/panels/sidebar/SessionList.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/re
 import '../../../test/react-setup'
 import SessionList from './SessionList'
 import { useSessionStore } from '../../store/sessions'
+import { useErrorStore } from '../../store/errors'
 import type { Session, StatusChip } from '../../store/sessions'
 
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -73,6 +74,7 @@ afterEach(() => {
 beforeEach(() => {
   vi.clearAllMocks()
   useSessionStore.setState({ sessions: [], activeSessionId: null })
+  useErrorStore.setState({ detailError: null })
 })
 
 describe('SessionList', () => {
@@ -447,6 +449,50 @@ describe('SessionList', () => {
       fireEvent.contextMenu(container.querySelector('[data-session-card]')!)
       await new Promise((r) => setTimeout(r, 0))
       expect(window.shell.openInFileManager).not.toHaveBeenCalled()
+    })
+
+    it('surfaces an OS failure instead of silently doing nothing', async () => {
+      vi.mocked(window.menu.popup).mockResolvedValueOnce('open-in-file-manager')
+      vi.mocked(window.shell.openInFileManager).mockResolvedValueOnce({ action: 'failed', error: 'No application set' })
+      setSessions([makeSession({ id: 's1', branch: 'b1', directory: '/repos/proj/gone' })])
+      const { container } = render(<SessionList {...makeProps()} />)
+
+      fireEvent.contextMenu(container.querySelector('[data-session-card]')!)
+
+      await waitFor(() => expect(useErrorStore.getState().detailError?.detail).toBe('No application set'))
+    })
+
+    it('surfaces a missing folder, whose result carries no error string', async () => {
+      vi.mocked(window.menu.popup).mockResolvedValueOnce('open-in-file-manager')
+      vi.mocked(window.shell.openInFileManager).mockResolvedValueOnce({ action: 'none' })
+      setSessions([makeSession({ id: 's1', branch: 'b1', directory: '/repos/proj/gone' })])
+      const { container } = render(<SessionList {...makeProps()} />)
+
+      fireEvent.contextMenu(container.querySelector('[data-session-card]')!)
+
+      await waitFor(() => expect(useErrorStore.getState().detailError?.detail).toContain('/repos/proj/gone'))
+    })
+
+    it('reports nothing when the folder is revealed rather than opened (a bundle)', async () => {
+      vi.mocked(window.menu.popup).mockResolvedValueOnce('open-in-file-manager')
+      vi.mocked(window.shell.openInFileManager).mockResolvedValueOnce({ action: 'revealed' })
+      setSessions([makeSession({ id: 's1', branch: 'b1' })])
+      const { container } = render(<SessionList {...makeProps()} />)
+
+      fireEvent.contextMenu(container.querySelector('[data-session-card]')!)
+      await waitFor(() => expect(window.shell.openInFileManager).toHaveBeenCalled())
+      expect(useErrorStore.getState().detailError).toBeNull()
+    })
+
+    it('surfaces a rejected IPC call rather than leaving an unhandled rejection', async () => {
+      vi.mocked(window.menu.popup).mockResolvedValueOnce('open-in-file-manager')
+      vi.mocked(window.shell.openInFileManager).mockRejectedValueOnce(new Error('ipc down'))
+      setSessions([makeSession({ id: 's1', branch: 'b1' })])
+      const { container } = render(<SessionList {...makeProps()} />)
+
+      fireEvent.contextMenu(container.querySelector('[data-session-card]')!)
+
+      await waitFor(() => expect(useErrorStore.getState().detailError?.detail).toContain('ipc down'))
     })
 
     it('right-click does not select the session', () => {

--- a/src/renderer/panels/sidebar/SessionList.test.tsx
+++ b/src/renderer/panels/sidebar/SessionList.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
 import '../../../test/react-setup'
 import SessionList from './SessionList'
 import { useSessionStore } from '../../store/sessions'
@@ -418,6 +418,45 @@ describe('SessionList', () => {
       // Should still show idle, not working
       expect(container.querySelector('.animate-spin')).toBeNull()
       vi.useRealTimers()
+    })
+  })
+
+  describe('context menu', () => {
+    it('right-click opens the session folder in the OS file manager', async () => {
+      vi.mocked(window.menu.popup).mockResolvedValueOnce('open-in-file-manager')
+      setSessions([makeSession({ id: 's1', branch: 'b1', directory: '/repos/proj/issue/42-x' })])
+      const { container } = render(<SessionList {...makeProps()} />)
+
+      fireEvent.contextMenu(container.querySelector('[data-session-card]')!)
+
+      // Offers a single "Open in <file manager>" item…
+      expect(window.menu.popup).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'open-in-file-manager' }),
+      ])
+      // …and opens the session's own directory on selection.
+      await waitFor(() =>
+        expect(window.shell.openInFileManager).toHaveBeenCalledWith('/repos/proj/issue/42-x'),
+      )
+    })
+
+    it('does not open anything when the menu is dismissed', async () => {
+      vi.mocked(window.menu.popup).mockResolvedValueOnce(null)
+      setSessions([makeSession({ id: 's1', branch: 'b1' })])
+      const { container } = render(<SessionList {...makeProps()} />)
+
+      fireEvent.contextMenu(container.querySelector('[data-session-card]')!)
+      await new Promise((r) => setTimeout(r, 0))
+      expect(window.shell.openInFileManager).not.toHaveBeenCalled()
+    })
+
+    it('right-click does not select the session', () => {
+      vi.mocked(window.menu.popup).mockResolvedValueOnce(null)
+      setSessions([makeSession({ id: 's1', branch: 'b1' })])
+      const props = makeProps()
+      const { container } = render(<SessionList {...props} />)
+
+      fireEvent.contextMenu(container.querySelector('[data-session-card]')!)
+      expect(props.onSelectSession).not.toHaveBeenCalled()
     })
   })
 

--- a/src/renderer/shared/utils/platform.test.ts
+++ b/src/renderer/shared/utils/platform.test.ts
@@ -52,4 +52,36 @@ describe('platform', () => {
     expect(isMac).toBe(false)
     expect(modifierName).toBe('Ctrl')
   })
+
+  it('names the file manager Finder on macOS', async () => {
+    const { isWindows, fileManagerName } = await loadPlatform(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+    )
+    expect(isWindows).toBe(false)
+    expect(fileManagerName).toBe('Finder')
+  })
+
+  it('names the file manager File Explorer on Windows', async () => {
+    const { isMac, isWindows, fileManagerName } = await loadPlatform(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+    )
+    expect(isMac).toBe(false)
+    expect(isWindows).toBe(true)
+    expect(fileManagerName).toBe('File Explorer')
+  })
+
+  it('names the file manager File Manager on Linux', async () => {
+    const { isMac, isWindows, fileManagerName } = await loadPlatform(
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+    )
+    expect(isMac).toBe(false)
+    expect(isWindows).toBe(false)
+    expect(fileManagerName).toBe('File Manager')
+  })
+
+  it('defaults the file manager name to File Manager with no navigator', async () => {
+    const { isWindows, fileManagerName } = await loadPlatform(undefined)
+    expect(isWindows).toBe(false)
+    expect(fileManagerName).toBe('File Manager')
+  })
 })

--- a/src/renderer/shared/utils/platform.ts
+++ b/src/renderer/shared/utils/platform.ts
@@ -12,6 +12,14 @@
 export const isMac =
   typeof navigator !== 'undefined' && navigator.userAgent.toUpperCase().includes('MAC')
 
+/** Windows detection, used to name the OS file manager (Explorer). Mac is checked first, so a
+ * "Macintosh" UA that also contained "WIN" could never be misread as Windows. */
+export const isWindows =
+  !isMac && typeof navigator !== 'undefined' && navigator.userAgent.toUpperCase().includes('WIN')
+
+/** The OS file manager's name, for labels like "Open in Finder". */
+export const fileManagerName = isMac ? 'Finder' : isWindows ? 'File Explorer' : 'File Manager'
+
 /** The platform's primary modifier, as a symbol for display: `⌘` on macOS, `Ctrl+` elsewhere. */
 export const modifierSymbol = isMac ? '⌘' : 'Ctrl+'
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -135,6 +135,7 @@ const mockShell: Mocked<ShellApi> = {
   openExternal: vi.fn().mockResolvedValue(undefined),
   pathExists: vi.fn().mockResolvedValue([]),
   openPath: vi.fn().mockResolvedValue({ action: 'none' }),
+  openInFileManager: vi.fn().mockResolvedValue({ action: 'none' }),
   listShells: vi.fn().mockResolvedValue([{ path: '/bin/bash', name: 'Bash', isDefault: true }]),
 }
 

--- a/tests/features/README.md
+++ b/tests/features/README.md
@@ -33,6 +33,7 @@ Feature doc specs reuse the shared Electron fixture from `_shared/`, which launc
 | `pr-review-ui/` | PR review panel with markdown rendering, collapsible threads, filters, reactions, and replies. |
 | `push-progress/` | "Working" spinner on session cards during long-running git operations. |
 | `select-all/` | Cmd+A selects within the focused pane (Monaco) rather than the whole page. |
+| `session-open-in-file-manager/` | Right-click a session to open its worktree folder in the OS file manager. |
 | `session-switching/` | Switching between sessions in the sidebar. |
 | `shell-selection/` | Shell selection in Settings and dropdown reset behavior. |
 | `simple-merge-commit/` | Merge commit UI: "Resolve Conflicts" with conflict markers, "Commit Merge" when resolved. |

--- a/tests/features/session-open-in-file-manager/session-open-in-file-manager.spec.ts
+++ b/tests/features/session-open-in-file-manager/session-open-in-file-manager.spec.ts
@@ -4,8 +4,12 @@
  * Right-clicking a session card opens a native context menu whose "Open in Finder /
  * Explorer / File Manager" item opens that session's worktree folder in the OS file
  * manager. The menu itself is a native OS popup rendered outside the page, so Playwright
- * can neither screenshot nor safely trigger it (doing so would block on a native menu).
- * This walkthrough therefore documents the affordance on the session card.
+ * can neither screenshot nor safely trigger it (doing so would block on a native menu). The
+ * action behind it is not observable here either: `shell:openInFileManager` no-ops under E2E,
+ * exactly as `shell:openPath` does. Both are covered by unit tests instead —
+ * `src/renderer/panels/sidebar/SessionList.test.tsx` for the right-click flow and
+ * `src/main/handlers/shell.test.ts` for the handler. This walkthrough documents the
+ * affordance on the session card.
  *
  * Run with: pnpm test:feature-docs
  */
@@ -47,7 +51,6 @@ test.afterAll(async () => {
     FEATURE_DIR,
   )
   await generateIndex(FEATURES_ROOT)
-
 })
 
 test.describe.serial('Feature: Open Session Folder in File Manager', () => {

--- a/tests/features/session-open-in-file-manager/session-open-in-file-manager.spec.ts
+++ b/tests/features/session-open-in-file-manager/session-open-in-file-manager.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Feature Documentation: Open Session Folder in File Manager
+ *
+ * Right-clicking a session card opens a native context menu whose "Open in Finder /
+ * Explorer / File Manager" item opens that session's worktree folder in the OS file
+ * manager. The menu itself is a native OS popup rendered outside the page, so Playwright
+ * can neither screenshot nor safely trigger it (doing so would block on a native menu).
+ * This walkthrough therefore documents the affordance on the session card.
+ *
+ * Run with: pnpm test:feature-docs
+ */
+import { test, expect, resetApp } from '../_shared/electron-fixture'
+import type { Page } from '@playwright/test'
+import path from 'path'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+import { screenshotElement } from '../_shared/screenshot-helpers'
+import { generateFeaturePage, generateIndex, FeatureStep } from '../_shared/template'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const FEATURE_DIR = __dirname
+const SCREENSHOTS = path.join(FEATURE_DIR, 'screenshots')
+const FEATURES_ROOT = path.join(__dirname, '..')
+
+let page: Page
+const steps: FeatureStep[] = []
+
+test.beforeAll(async () => {
+  await fs.promises.mkdir(SCREENSHOTS, { recursive: true })
+
+  ;({ page } = await resetApp())
+})
+
+test.afterAll(async () => {
+  await generateFeaturePage(
+    {
+      title: 'Open Session Folder in File Manager',
+      description:
+        'Right-clicking a session in the sidebar opens a native context menu with an ' +
+        '"Open in Finder / Explorer / File Manager" item (labelled per OS) that opens the ' +
+        "session's worktree folder in the operating system's file manager. Handy for " +
+        'jumping straight to the files on disk.',
+      steps,
+    },
+    FEATURE_DIR,
+  )
+  await generateIndex(FEATURES_ROOT)
+
+})
+
+test.describe.serial('Feature: Open Session Folder in File Manager', () => {
+  test('Step 1: Right-click a session card to open its folder', async () => {
+    const sidebar = page.locator('[data-panel-id="sidebar"]')
+    await expect(sidebar).toBeVisible()
+
+    // Any session card can be right-clicked; the menu opens that session's own worktree folder.
+    const broomySession = page.locator('.cursor-pointer:has-text("broomy")')
+    await expect(broomySession).toBeVisible()
+
+    await screenshotElement(page, sidebar, path.join(SCREENSHOTS, '01-sessions.png'), {
+      maxHeight: 600,
+    })
+    steps.push({
+      screenshotPath: 'screenshots/01-sessions.png',
+      caption: 'Right-click any session → "Open in Finder / Explorer / File Manager"',
+      description:
+        'Right-clicking a session card opens a native OS context menu whose single item opens ' +
+        "that session's worktree folder in the file manager (Finder on macOS, File Explorer on " +
+        'Windows, File Manager on Linux). The menu is a native OS popup, so it is not captured ' +
+        'in this screenshot.',
+    })
+  })
+})


### PR DESCRIPTION
Closes #162

## Background and Motivation

There was no quick way to jump from a session to its files on disk. This adds a right-click "Open in Finder / Explorer / File Manager" on the session card that opens the session's worktree folder in the OS file manager.

## Design Decisions

- **Native context menu** via the app's existing `window.menu.popup` (as used by the file tree and source control), not a custom popup — so keyboard/positioning/accessibility come for free and it matches the OS.
- **Folder = `SessionData.directory`** (the PTY cwd / authoritative host path), which stays correct even if the branch was renamed after creation — rather than recomputing `rootDir/branch`.
- **New handler, not `shell:openPath`**: the existing `shell:openPath` *reveals* a directory (selects it in its parent). `shell:openInFileManager` *opens* the folder's contents via `shell.openPath(dir)`. It validates an absolute directory, returns an `OpenPathResult` (`opened`/`none`/`failed`), and no-ops under E2E.
- **OS-aware label** via new `isWindows` / `fileManagerName` in `platform.ts`: Finder (macOS) / File Explorer (Windows) / File Manager (Linux).

## Proposed Changes

- Main: `shell:openInFileManager` handler in `src/main/handlers/shell.ts`.
- Preload: `openInFileManager` on `ShellApi` + impl in `src/preload/apis/shell.ts`.
- Renderer: `SessionCard.tsx` gains `onContextMenu` → `window.menu.popup` → `window.shell.openInFileManager(session.directory)`; `directory` added to its store selector. `platform.ts` gains `isWindows` + `fileManagerName`.
- Test bridges: `openInFileManager` mock in `src/test/setup.ts` and `.storybook/electronMocks.ts`.
- Tests: handler (`shell.test.ts`), preload (`apis/shell.test.ts`), platform (`platform.test.ts`), and right-click flow (`SessionList.test.tsx`).
- Docs: `panels/sidebar/README.md`; a feature-doc walkthrough under `tests/features/session-open-in-file-manager/`.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` — all pass; changed files at 100% lines (`apis/shell.ts` 97%); global 89.67% is a pre-existing sub-threshold miss on `main`, not regressed here
- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 73 pass
