### PR TITLE
fix: base new sessions on the latest default branch, whatever it's called

### DIFF
--- a/src/main/handlers/gitBranch.test.ts
+++ b/src/main/handlers/gitBranch.test.ts
@@ -326,8 +326,17 @@ describe('gitBranch handlers', () => {
       expect(await handlers['git:defaultBranch'](null, '/repo')).toBe('develop')
     })
 
+    it('asks origin when the symbolic ref is missing', async () => {
+      mockGitInstance.raw
+        .mockRejectedValueOnce(new Error('no ref'))
+        .mockResolvedValueOnce('ref: refs/heads/trunk\tHEAD\nabc123\tHEAD\n') // ls-remote --symref
+      const handlers = setupHandlers()
+      expect(await handlers['git:defaultBranch'](null, '/repo')).toBe('trunk')
+    })
+
     it('falls back to main when symbolic ref fails', async () => {
       mockGitInstance.raw.mockRejectedValueOnce(new Error('no ref'))
+        .mockRejectedValueOnce(new Error('remote unreachable')) // ls-remote --symref
         .mockResolvedValueOnce('') // rev-parse --verify main succeeds
       const handlers = setupHandlers()
       expect(await handlers['git:defaultBranch'](null, '/repo')).toBe('main')
@@ -336,6 +345,7 @@ describe('gitBranch handlers', () => {
     it('falls back to master when main does not exist', async () => {
       mockGitInstance.raw
         .mockRejectedValueOnce(new Error('no ref'))
+        .mockRejectedValueOnce(new Error('remote unreachable')) // ls-remote --symref
         .mockRejectedValueOnce(new Error('no main'))
         .mockResolvedValueOnce('') // rev-parse --verify master succeeds
       const handlers = setupHandlers()

--- a/src/main/handlers/gitBranch.ts
+++ b/src/main/handlers/gitBranch.ts
@@ -214,8 +214,11 @@ async function handleDefaultBranch(ctx: HandlerContext, repoPath: string) {
   }
 
   try {
-    const git = simpleGit(expandHomePath(repoPath))
-    return await getDefaultBranch(git)
+    // allowRemote: this handler runs on explicit user action (adding a repo,
+    // creating a session), not on the git-polling path, so it can afford to
+    // ask origin when refs/remotes/origin/HEAD is missing.
+    const git = withNonInteractive(simpleGit(expandHomePath(repoPath)))
+    return await getDefaultBranch(git, true)
   } catch {
     return 'main'
   }

--- a/src/main/handlers/gitUtils.test.ts
+++ b/src/main/handlers/gitUtils.test.ts
@@ -47,4 +47,30 @@ describe('getDefaultBranch', () => {
     vi.mocked(git.raw).mockResolvedValueOnce('  refs/remotes/origin/main  \n')
     expect(await getDefaultBranch(git)).toBe('main')
   })
+
+  it('asks origin when symbolic-ref is missing and allowRemote is set', async () => {
+    vi.mocked(git.raw)
+      .mockRejectedValueOnce(new Error('no symbolic ref'))
+      .mockResolvedValueOnce('ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n')
+    expect(await getDefaultBranch(git, true)).toBe('develop')
+  })
+
+  it('does not contact origin unless allowRemote is set', async () => {
+    vi.mocked(git.raw)
+      .mockRejectedValueOnce(new Error('no symbolic ref'))
+      .mockResolvedValueOnce('abc123') // origin/main exists
+    expect(await getDefaultBranch(git)).toBe('main')
+    // Only symbolic-ref and rev-parse ran — no ls-remote in between.
+    expect(git.raw).toHaveBeenCalledTimes(2)
+    expect(git.raw).toHaveBeenLastCalledWith(['rev-parse', '--verify', 'origin/main'])
+  })
+
+  it('falls back to name guessing when origin is unreachable', async () => {
+    vi.mocked(git.raw)
+      .mockRejectedValueOnce(new Error('no symbolic ref'))
+      .mockRejectedValueOnce(new Error('could not read from remote'))
+      .mockRejectedValueOnce(new Error('no origin/main'))
+      .mockResolvedValueOnce('abc123') // origin/master exists
+    expect(await getDefaultBranch(git, true)).toBe('master')
+  })
 })

--- a/src/main/handlers/gitUtils.ts
+++ b/src/main/handlers/gitUtils.ts
@@ -6,21 +6,37 @@ import type { SimpleGit } from 'simple-git'
 /**
  * Detect the default branch for a repository by checking (in order):
  * 1. The symbolic ref `refs/remotes/origin/HEAD`
- * 2. Whether `origin/main` exists
- * 3. Whether `origin/master` exists
- * 4. Falls back to 'main'
+ * 2. What origin itself reports HEAD points at (`ls-remote --symref`),
+ *    only when `allowRemote` is set
+ * 3. Whether `origin/main` exists
+ * 4. Whether `origin/master` exists
+ * 5. Falls back to 'main'
+ *
+ * Step 2 matters for repos whose default branch is neither `main` nor
+ * `master`: `refs/remotes/origin/HEAD` is not always present (it is only
+ * written by clone and by recent git versions on fetch), and without it the
+ * name-guessing in steps 3-4 would silently pick an unrelated branch. It hits
+ * the network, so callers on the git-polling path leave `allowRemote` off.
  */
-export async function getDefaultBranch(git: SimpleGit): Promise<string> {
+export async function getDefaultBranch(git: SimpleGit, allowRemote = false): Promise<string> {
   try {
     const ref = await git.raw(['symbolic-ref', 'refs/remotes/origin/HEAD'])
     return ref.trim().replace('refs/remotes/origin/', '')
-  } catch {
-    for (const candidate of ['main', 'master']) {
-      try {
-        await git.raw(['rev-parse', '--verify', `origin/${candidate}`])
-        return candidate
-      } catch { /* try next candidate */ }
-    }
-    return 'main'
+  } catch { /* fall through */ }
+
+  if (allowRemote) {
+    try {
+      const out = await git.raw(['ls-remote', '--symref', 'origin', 'HEAD'])
+      const match = /^ref:\s+refs\/heads\/(\S+)\s+HEAD$/m.exec(out)
+      if (match) return match[1]
+    } catch { /* remote unreachable — fall through to name guessing */ }
   }
+
+  for (const candidate of ['main', 'master']) {
+    try {
+      await git.raw(['rev-parse', '--verify', `origin/${candidate}`])
+      return candidate
+    } catch { /* try next candidate */ }
+  }
+  return 'main'
 }

--- a/src/renderer/features/git/baseRef.test.ts
+++ b/src/renderer/features/git/baseRef.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolveBaseRef } from './baseRef'
+
+const defaultBranch = vi.fn()
+const fetchBranch = vi.fn()
+
+beforeEach(() => {
+  defaultBranch.mockReset()
+  fetchBranch.mockReset()
+  fetchBranch.mockResolvedValue({ success: true })
+  ;(window as unknown as { git: unknown }).git = { defaultBranch, fetchBranch }
+})
+
+describe('resolveBaseRef', () => {
+  it('bases the new branch on the remote-tracking ref, not the local branch', async () => {
+    defaultBranch.mockResolvedValue('master')
+
+    const result = await resolveBaseRef('/repo/main', 'master')
+
+    expect(result).toBe('origin/master')
+    expect(fetchBranch).toHaveBeenCalledWith('/repo/main', 'master')
+  })
+
+  it('prefers the live default branch over the value stored in config', async () => {
+    defaultBranch.mockResolvedValue('main')
+
+    const result = await resolveBaseRef('/repo/main', 'master')
+
+    expect(result).toBe('origin/main')
+    expect(fetchBranch).toHaveBeenCalledWith('/repo/main', 'main')
+  })
+
+  it('falls back to the stored default branch when git cannot resolve one', async () => {
+    defaultBranch.mockRejectedValue(new Error('not a repo'))
+
+    const result = await resolveBaseRef('/repo/main', 'develop')
+
+    expect(result).toBe('origin/develop')
+  })
+
+  it('falls back to the stored default branch when git returns an empty name', async () => {
+    defaultBranch.mockResolvedValue('')
+
+    const result = await resolveBaseRef('/repo/main', 'develop')
+
+    expect(result).toBe('origin/develop')
+  })
+
+  it('throws instead of silently branching from stale code when the fetch fails', async () => {
+    defaultBranch.mockResolvedValue('master')
+    fetchBranch.mockResolvedValue({ success: false, error: 'network down' })
+
+    await expect(resolveBaseRef('/repo/main', 'master')).rejects.toThrow(/network down/)
+  })
+})

--- a/src/renderer/features/git/baseRef.ts
+++ b/src/renderer/features/git/baseRef.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolves the ref that a brand-new session branch should be created from.
+ *
+ * New branches are based on `origin/<defaultBranch>` rather than the local
+ * `<defaultBranch>` ref, because the local ref is only current when the main
+ * worktree happens to have the default branch checked out *and* the pull
+ * succeeded. Neither is guaranteed: a dirty or diverged main worktree makes
+ * `git pull` abort the merge (it still updates the remote-tracking ref), and
+ * nothing pins the folder named `main/` to a branch actually called `main`.
+ * Basing on the remote-tracking ref removes both assumptions.
+ *
+ * The default branch is also re-resolved from git instead of trusting the
+ * value stored in config, which is captured once when the repo is added and
+ * goes stale if the repo later renames its default branch.
+ */
+
+/** Returns the ref to pass as the worktree base, e.g. `origin/master`. */
+export async function resolveBaseRef(mainDir: string, storedDefaultBranch: string): Promise<string> {
+  let defaultBranch = storedDefaultBranch
+  try {
+    const resolved = await window.git.defaultBranch(mainDir)
+    if (resolved) defaultBranch = resolved
+  } catch {
+    // Fall back to the stored value.
+  }
+
+  const fetchResult = await window.git.fetchBranch(mainDir, defaultBranch)
+  if (!fetchResult.success) {
+    throw new Error(
+      `Couldn't fetch the latest "${defaultBranch}" from origin, so the new branch would be based on stale code.\n\n${fetchResult.error || ''}`.trim()
+    )
+  }
+
+  return `origin/${defaultBranch}`
+}

--- a/src/renderer/features/sessions/newSession/NewBranchView.test.tsx
+++ b/src/renderer/features/sessions/newSession/NewBranchView.test.tsx
@@ -129,7 +129,7 @@ describe('NewBranchView', () => {
         '/repos/my-project/main',
         '/repos/my-project/feature/auth',
         'feature/auth',
-        'main'
+        'origin/main'
       )
       expect(onComplete).toHaveBeenCalledWith(
         '/repos/my-project/feature/auth',

--- a/src/renderer/features/sessions/newSession/NewBranchView.tsx
+++ b/src/renderer/features/sessions/newSession/NewBranchView.tsx
@@ -9,6 +9,7 @@ import type { ManagedRepo, GitHubIssue } from '../../../../preload/index'
 import { issueToBranchName } from '../../../shared/utils/slugify'
 import { DialogErrorBanner } from '../../../shared/components/ErrorBanner'
 import { AuthSetupSection } from '../../../shared/components/AuthSetupSection'
+import { resolveBaseRef } from '../../git/baseRef'
 
 export function NewBranchView({
   repo,
@@ -62,12 +63,16 @@ export function NewBranchView({
       const mainDir = `${repo.rootDir}/main`
       const worktreePath = `${repo.rootDir}/${branchName}`
 
-      // Pull latest on main first
+      // Resolve and fetch the base ref first — this is what the new branch is
+      // built on, so it must be current regardless of the main worktree's state.
+      const baseRef = await resolveBaseRef(mainDir, repo.defaultBranch)
+
+      // Best-effort refresh of the main worktree itself.
       await window.git.pull(mainDir)
 
       // Create worktree with new branch — tolerate "already exists" on retry
       // (e.g. if worktree was created but push failed on first attempt)
-      const result = await window.git.worktreeAdd(mainDir, worktreePath, branchName, repo.defaultBranch)
+      const result = await window.git.worktreeAdd(mainDir, worktreePath, branchName, baseRef)
       if (!result.success && !result.error?.includes('already exists')) {
         throw new Error(result.error || 'Failed to create worktree')
       }

--- a/src/renderer/panels/settings/useBackgroundInit.test.ts
+++ b/src/renderer/panels/settings/useBackgroundInit.test.ts
@@ -17,6 +17,8 @@ describe('useBackgroundInit', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(window.git.pull).mockResolvedValue({ success: true })
+    vi.mocked(window.git.defaultBranch).mockResolvedValue('main')
+    vi.mocked(window.git.fetchBranch).mockResolvedValue({ success: true })
     vi.mocked(window.git.worktreeAdd).mockResolvedValue({ success: true })
     vi.mocked(window.git.pushNewBranch).mockResolvedValue({ success: true })
     vi.mocked(window.git.worktreeRemove).mockResolvedValue({ success: true })
@@ -63,8 +65,48 @@ describe('useBackgroundInit', () => {
       })
 
       expect(window.git.pull).toHaveBeenCalledWith('/repos/proj/main')
-      expect(window.git.worktreeAdd).toHaveBeenCalledWith('/repos/proj/main', '/repos/proj/feature/test', 'feature/test', 'main')
+      expect(window.git.worktreeAdd).toHaveBeenCalledWith('/repos/proj/main', '/repos/proj/feature/test', 'feature/test', 'origin/main')
       expect(window.git.pushNewBranch).toHaveBeenCalledWith('/repos/proj/feature/test', 'feature/test')
+    })
+
+    it('bases the branch on origin/<default> for repos whose default is not "main"', async () => {
+      vi.mocked(window.git.defaultBranch).mockResolvedValue('master')
+      const deps = makeDeps()
+      const { result } = renderHook(() => useBackgroundInit(deps))
+
+      act(() => {
+        result.current.handleStartBranchSession({
+          repo: { id: 'r1', rootDir: '/repos/proj', defaultBranch: 'master' },
+          branchName: 'feat',
+          agentId: null,
+        })
+      })
+
+      await vi.waitFor(() => {
+        expect(deps.finalizeSession).toHaveBeenCalledWith('init-session-1')
+      })
+
+      expect(window.git.fetchBranch).toHaveBeenCalledWith('/repos/proj/main', 'master')
+      expect(window.git.worktreeAdd).toHaveBeenCalledWith('/repos/proj/main', '/repos/proj/feat', 'feat', 'origin/master')
+    })
+
+    it('fails the session rather than branching from stale code when the fetch fails', async () => {
+      vi.mocked(window.git.fetchBranch).mockResolvedValue({ success: false, error: 'network down' })
+      const deps = makeDeps()
+      const { result } = renderHook(() => useBackgroundInit(deps))
+
+      act(() => {
+        result.current.handleStartBranchSession({
+          repo: { id: 'r1', rootDir: '/repos/proj', defaultBranch: 'main' },
+          branchName: 'feat',
+          agentId: null,
+        })
+      })
+
+      await vi.waitFor(() => {
+        expect(deps.failSession).toHaveBeenCalledWith('init-session-1', expect.stringContaining('network down'))
+      })
+      expect(window.git.worktreeAdd).not.toHaveBeenCalled()
     })
 
     it('calls failSession when pull fails', async () => {

--- a/src/renderer/panels/settings/useBackgroundInit.ts
+++ b/src/renderer/panels/settings/useBackgroundInit.ts
@@ -3,6 +3,7 @@
  * is already visible in the sidebar, so the UI feels instant.
  */
 import { useCallback, useRef } from 'react'
+import { resolveBaseRef } from '../../features/git/baseRef'
 
 interface BackgroundInitDeps {
   addInitializingSession: (params: { directory: string; branch: string; agentId: string | null; extra?: { repoId?: string; issueNumber?: number; issueTitle?: string; issueUrl?: string; name?: string } }) => string
@@ -53,10 +54,16 @@ export function useBackgroundInit({
 
     void (async () => {
       try {
+        const baseRef = await resolveBaseRef(mainDir, repo.defaultBranch)
+        if (isAborted(controller.signal)) return
+
+        // Best-effort: keep the main worktree itself up to date too. It aborts
+        // if that worktree is dirty or diverged, which must not affect the base
+        // the new branch is created from — hence the origin/ ref above.
         await window.git.pull(mainDir)
         if (isAborted(controller.signal)) return
 
-        const result = await window.git.worktreeAdd(mainDir, worktreePath, branchName, repo.defaultBranch)
+        const result = await window.git.worktreeAdd(mainDir, worktreePath, branchName, baseRef)
         if (!result.success && !result.error?.includes('already exists')) {
           throw new Error(result.error || 'Failed to create worktree')
         }


### PR DESCRIPTION
## Background and Motivation

New sessions sometimes weren't based on the latest default branch, most often on repos that don't call it `main`.

Two independent causes, both reproduced against real git repos:

**1. The base was the *local* default-branch ref.** It was refreshed only by a `git pull` in `<rootDir>/main` whose result was discarded (`useBackgroundInit.ts:56`, `NewBranchView.tsx:66`). That assumes the folder named `main/` always has the default branch checked out, cleanly, with a working upstream — nothing enforces that link. With a dirty main worktree:

```
pull exit: Updating 05b5d55..735eb35 / Aborting     ← merge failed, error discarded
upstream tip: 735eb35   new branch base: 05b5d55    ← two commits stale
```

Note `git pull` *does* update `origin/master` before aborting the merge — only the local ref stays behind, so basing on the local ref is precisely what loses the update. When the default branch is literally `main` the folder and branch names coincide, so drift is rare; on `master`/`develop` repos nothing keeps them in sync.

**2. `getDefaultBranch` guessed by name.** When `refs/remotes/origin/HEAD` was missing it probed `origin/main`, then `origin/master`, else returned the literal string `'main'`. For a repo defaulting to `develop` that also has a stale legacy `main` branch, it picked `main` — an unrelated branch. The new worktree contained `STALE-legacy` instead of `dev-latest`. This one can only fire on repos not named `main`.

## Design Decisions

- **Base on `origin/<default>`, not the local branch.** The remote-tracking ref is updated by an explicit fetch regardless of what the main worktree has checked out or whether it's dirty. This removes both assumptions rather than patching the pull.
- **A failed fetch throws.** Silently branching from stale code is the bug; failing the session visibly is strictly better.
- **`ls-remote --symref` is opt-in.** It hits the network, so it's gated behind an `allowRemote` flag enabled only from the `git:defaultBranch` IPC handler, which runs on explicit user action. Git-polling callers keep the offline-only behaviour, per the repo's "never poll external APIs on a timer" rule.
- **`pull` is kept, demoted.** It still refreshes the main worktree for the user's benefit, but is no longer load-bearing for correctness.
- **Config's `defaultBranch` is re-resolved at use time** rather than trusted; it's captured once when the repo is added and goes stale if the repo later renames its default branch. It remains the fallback when git can't answer.

## Proposed Changes

**New base-ref resolution** — `src/renderer/features/git/baseRef.ts`
`resolveBaseRef(mainDir, storedDefaultBranch)` re-resolves the default branch from git, fetches it, and returns `origin/<default>`. Throws on fetch failure.

**Session creation** — `useBackgroundInit.ts` (instant path), `NewBranchView.tsx` (legacy path)
Both now pass the resolved `origin/<default>` to `worktreeAdd`.

**Default-branch detection** — `gitUtils.ts`, `gitBranch.ts`
`getDefaultBranch` gains a step between the symbolic-ref read and the name guessing: ask origin via `ls-remote --symref origin HEAD`. Gated behind `allowRemote`, enabled only from `handleDefaultBranch`.

Verified against the repro: with a dirty main worktree, `fetch origin master` + base `origin/master` now yields the server tip. `pushNewBranch` immediately resets the new branch's upstream to `origin/<branch>`, so branching from a remote ref leaves no incorrect tracking.

**Not included** (flagging rather than folding in): the corrected default branch isn't written back to config, so a repo with a stale stored `defaultBranch` still displays the old name in Settings. It's no longer used for branching. Happy to do that as a follow-up.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (coverage at or above 90% lines)
- [x] Ran all E2E tests locally (`pnpm test:e2e`)

```
pnpm lint          → clean
pnpm typecheck     → clean
pnpm check:all     → All 2 check(s) passed
pnpm test:unit     → Test Files 235 passed (235) / Tests 4219 passed (4219)
coverage           → overall 90.5% lines
                     baseRef.ts 100%, gitUtils.ts 100%, useBackgroundInit.ts 100%,
                     NewBranchView.tsx 100%, gitBranch.ts 94.23%
pnpm test:e2e      → 76 passed (1.1m)
```

New unit coverage: `baseRef.test.ts` (5 cases incl. non-`main` defaults, config-drift, fetch failure), `gitUtils.test.ts` / `gitBranch.test.ts` (remote lookup, `allowRemote` gating, unreachable-origin fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNT2PfoFEP1qnNziWB2Zox
