### PR TITLE
fix(tests): expect origin/<default> as the worktree base for issue branches

### DIFF
--- a/src/renderer/panels/settings/useBackgroundInit.test.ts
+++ b/src/renderer/panels/settings/useBackgroundInit.test.ts
@@ -238,7 +238,7 @@ describe('useBackgroundInit', () => {
           '/repos/proj/main',
           '/repos/proj/issue/42-fix-login-bug',
           'issue/42-fix-login-bug',
-          'main',
+          'origin/main',
         )
       })
     })


### PR DESCRIPTION
## Background and Motivation

**Main is currently red**, and has been since two PRs landed close together and produced a semantic conflict neither could see in its own CI run:

- **#158** (`8451b43`, "default issue sessions to the issue/<number>- folder") added the test `nests the worktree under issue/ for an issue-derived branch name`, asserting `worktreeAdd` is called with base `'main'`.
- **#159** (`a7ad7e9`, "base new branches on freshly fetched origin/<default>") changed new branches to be based on `origin/<default>` via `resolveBaseRef()`, so a session never branches from stale local code.

Each was green on its own branch. Merged together, the assertion from the first contradicts the behavior of the second.

```
AssertionError: expected "vi.fn()" to be called with arguments: [ '/repos/proj/main', …(3) ]
    "/repos/proj/main",
    "/repos/proj/issue/42-fix-login-bug",
    "issue/42-fix-login-bug",
-   "main",
+   "origin/main",
```

## Design Decisions

**The source is correct; only the test is stale.** `resolveBaseRef` (`src/renderer/features/git/baseRef.ts:18`) returning `origin/<default>` is the deliberate, desired behavior — and the sibling tests in the very same file confirm it, both passing today:

- `bases the branch on origin/<default> for repos whose default is not "main"`
- `fails the session rather than branching from stale code when the fetch fails`

So this changes one expected argument rather than touching `useBackgroundInit.ts`. The test's actual subject — that an issue-derived branch nests its worktree under `issue/` — is unchanged and still asserted.

## Proposed Changes

- `src/renderer/panels/settings/useBackgroundInit.test.ts` — one expectation, `'main'` -> `'origin/main'`.

## Testing

Full `/validate` run on this branch:

```
pnpm lint       -> clean
pnpm typecheck  -> clean
pnpm check:all  -> All 2 check(s) passed
pnpm test:unit  -> Test Files 235 passed (235) / Tests 4249 passed (4249)
coverage        -> Lines: 90.53% (9090/10040), above the 90% threshold
pnpm test:e2e   -> 76 passed (1.1m)
```

Baseline confirmed before changing anything: checked out `origin/main` clean and reproduced the failure there (`Tests 1 failed | 15 passed (16)`), so this is main's breakage and not something inherited from another branch.

No screenshot walkthrough (`/feature-doc`): test-only change, no product surface.

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (coverage at or above 90% lines)
- [x] Ran all E2E tests locally (`pnpm test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bMikFq4F1Jic8BcAkXytT
