### PR TITLE
fix: count team review requests and comment-only reviews for the waiting chip

### DIFF
--- a/src/main/handlers/ghComments.test.ts
+++ b/src/main/handlers/ghComments.test.ts
@@ -424,17 +424,19 @@ describe('ghComments handlers', () => {
       login?: string
       reviews?: unknown[]
       requestedReviewers?: string[]
+      requestedTeams?: string[]
       lastPushTime?: string
       prComments?: string[]
       issueComments?: string[]
     }) {
       const slug = opts.slug ?? 'user/repo'
       const login = opts.login ?? 'octocat'
+      const requested = { users: opts.requestedReviewers ?? [], teams: opts.requestedTeams ?? [] }
       vi.mocked(execFile)
         .mockReturnValueOnce({ stdout: `${slug}\n`, stderr: '' } as never)
         .mockReturnValueOnce({ stdout: `${login}\n`, stderr: '' } as never)
         .mockReturnValueOnce({ stdout: JSON.stringify(opts.reviews ?? []), stderr: '' } as never)
-        .mockReturnValueOnce({ stdout: JSON.stringify(opts.requestedReviewers ?? []), stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify(requested), stderr: '' } as never)
         .mockReturnValueOnce({ stdout: `${opts.lastPushTime ?? '2024-01-01T00:00:00Z'}\n`, stderr: '' } as never)
         .mockReturnValueOnce({ stdout: JSON.stringify(opts.prComments ?? []), stderr: '' } as never)
         .mockReturnValueOnce({ stdout: JSON.stringify(opts.issueComments ?? []), stderr: '' } as never)
@@ -461,6 +463,47 @@ describe('ghComments handlers', () => {
       })
       const handlers = setupHandlers()
       expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(false)
+    })
+
+    it('returns true when a reviewer only commented and has not been re-requested', async () => {
+      mockFeedbackCalls({
+        reviews: [{ author: 'reviewer1', state: 'COMMENTED' }],
+        requestedReviewers: [],
+        // Comments predate the push, so the only signal is the unresolved review.
+        lastPushTime: '2024-02-01T00:00:00Z',
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(true)
+    })
+
+    it('returns false when the commenting reviewer has been re-requested', async () => {
+      mockFeedbackCalls({
+        reviews: [{ author: 'reviewer1', state: 'COMMENTED' }],
+        requestedReviewers: ['reviewer1'],
+        lastPushTime: '2024-02-01T00:00:00Z',
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(false)
+    })
+
+    it('returns false when the only submitted review is an approval', async () => {
+      mockFeedbackCalls({
+        reviews: [{ author: 'reviewer1', state: 'APPROVED' }],
+        requestedReviewers: [],
+        lastPushTime: '2024-02-01T00:00:00Z',
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(false)
+    })
+
+    it('ignores a pending team request when deciding whether a review is unresolved', async () => {
+      mockFeedbackCalls({
+        reviews: [{ author: 'reviewer1', state: 'COMMENTED' }],
+        requestedTeams: ['reviewer1'],
+        lastPushTime: '2024-02-01T00:00:00Z',
+      })
+      const handlers = setupHandlers()
+      expect(await handlers['gh:prFeedbackStatus'](null, '/repo', 42)).toBe(true)
     })
 
     it('returns true when a human comment was posted after the last push', async () => {
@@ -491,8 +534,10 @@ describe('ghComments handlers', () => {
       const jqArgs = calls.flatMap(call => (call[1] as string[]) ?? [])
       const jqFilters = jqArgs.filter(arg => arg.includes('.user'))
 
-      // Reviews query excludes bots
-      expect(jqFilters.some(f => f.includes('.user.type != "Bot"') && f.includes('.state'))).toBe(true)
+      // Reviews query excludes bots and the PR author
+      const reviewsFilter = jqFilters.find(f => f.includes('.state'))
+      expect(reviewsFilter).toContain('.user.type != "Bot"')
+      expect(reviewsFilter).toContain('.user.login != "octocat"')
       // Both comment queries (review + issue) include the bot exclusion
       const commentFilters = jqFilters.filter(f => f.includes('.created_at'))
       expect(commentFilters).toHaveLength(2)
@@ -518,6 +563,7 @@ describe('ghComments handlers', () => {
     it('counts approvals, pending re-requests, and other reviews', async () => {
       vi.mocked(execFile)
         .mockReturnValueOnce({ stdout: 'user/repo\n', stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: 'octocat\n', stderr: '' } as never)
         .mockReturnValueOnce({
           stdout: JSON.stringify([
             { author: 'a', state: 'APPROVED' },
@@ -525,31 +571,80 @@ describe('ghComments handlers', () => {
           ]),
           stderr: '',
         } as never)
-        .mockReturnValueOnce({ stdout: JSON.stringify(['c']), stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify({ users: ['c'], teams: [] }), stderr: '' } as never)
 
       const handlers = setupHandlers()
       const result = await handlers['gh:prApprovalStatus'](null, '/repo', 1)
       expect(result).toEqual({ approved: 1, pending: 1, otherReviews: 1 })
     })
 
-    it('counts a re-requested reviewer as pending, ignoring their stale review state', async () => {
+    it('counts a requested team as pending when no individual reviewer is requested', async () => {
       vi.mocked(execFile)
         .mockReturnValueOnce({ stdout: 'user/repo\n', stderr: '' } as never)
-        // 'a' has a stale CHANGES_REQUESTED review but has been re-requested...
+        .mockReturnValueOnce({ stdout: 'octocat\n', stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify([]), stderr: '' } as never)
         .mockReturnValueOnce({
-          stdout: JSON.stringify([{ author: 'a', state: 'CHANGES_REQUESTED' }]),
+          stdout: JSON.stringify({ users: [], teams: ['orpc-experts'] }),
           stderr: '',
         } as never)
-        // ...so 'a' appears in requested_reviewers and must be counted as pending only.
-        .mockReturnValueOnce({ stdout: JSON.stringify(['a']), stderr: '' } as never)
 
       const handlers = setupHandlers()
       const result = await handlers['gh:prApprovalStatus'](null, '/repo', 1)
       expect(result).toEqual({ approved: 0, pending: 1, otherReviews: 0 })
     })
 
+    it('counts requested users and teams together', async () => {
+      vi.mocked(execFile)
+        .mockReturnValueOnce({ stdout: 'user/repo\n', stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: 'octocat\n', stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify([]), stderr: '' } as never)
+        .mockReturnValueOnce({
+          stdout: JSON.stringify({ users: ['a'], teams: ['t1', 't2'] }),
+          stderr: '',
+        } as never)
+
+      const handlers = setupHandlers()
+      const result = await handlers['gh:prApprovalStatus'](null, '/repo', 1)
+      expect(result).toEqual({ approved: 0, pending: 3, otherReviews: 0 })
+    })
+
+    it('counts a re-requested reviewer as pending, ignoring their stale review state', async () => {
+      vi.mocked(execFile)
+        .mockReturnValueOnce({ stdout: 'user/repo\n', stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: 'octocat\n', stderr: '' } as never)
+        // 'a' has a stale CHANGES_REQUESTED review but has been re-requested...
+        .mockReturnValueOnce({
+          stdout: JSON.stringify([{ author: 'a', state: 'CHANGES_REQUESTED' }]),
+          stderr: '',
+        } as never)
+        // ...so 'a' appears in requested_reviewers and must be counted as pending only.
+        .mockReturnValueOnce({ stdout: JSON.stringify({ users: ['a'], teams: [] }), stderr: '' } as never)
+
+      const handlers = setupHandlers()
+      const result = await handlers['gh:prApprovalStatus'](null, '/repo', 1)
+      expect(result).toEqual({ approved: 0, pending: 1, otherReviews: 0 })
+    })
+
+    it('excludes the PR author from the reviews query', async () => {
+      vi.mocked(execFile)
+        .mockReturnValueOnce({ stdout: 'user/repo\n', stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: 'octocat\n', stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify([]), stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: JSON.stringify({ users: [], teams: [] }), stderr: '' } as never)
+
+      const handlers = setupHandlers()
+      await handlers['gh:prApprovalStatus'](null, '/repo', 1)
+
+      const jqArgs = vi.mocked(execFile).mock.calls.flatMap(call => (call[1] as string[]) ?? [])
+      const reviewsFilter = jqArgs.find(arg => arg.includes('.state'))
+      expect(reviewsFilter).toContain('.user.login != "octocat"')
+      expect(reviewsFilter).toContain('.user.type != "Bot"')
+    })
+
     it('returns neutral counts when the repo slug cannot be resolved', async () => {
-      vi.mocked(execFile).mockReturnValueOnce({ stdout: '\n', stderr: '' } as never)
+      vi.mocked(execFile)
+        .mockReturnValueOnce({ stdout: '\n', stderr: '' } as never)
+        .mockReturnValueOnce({ stdout: 'octocat\n', stderr: '' } as never)
 
       const handlers = setupHandlers()
       const result = await handlers['gh:prApprovalStatus'](null, '/repo', 1)

--- a/src/main/handlers/ghComments.ts
+++ b/src/main/handlers/ghComments.ts
@@ -30,18 +30,93 @@ function parseJsonLines(stdout: string): unknown[] {
 }
 
 /**
- * Checks whether a PR has actionable feedback: either someone requested changes
- * (and hasn't been re-requested for review), or there are comments since the last push.
+ * The reviewers GitHub still has an open review request for. Teams matter as much
+ * as individuals: a PR whose only outstanding request is on a team is still waiting
+ * on a review, and `.users` is empty in that case.
+ */
+interface RequestedReviewers {
+  /** Logins of individually requested users. */
+  users: string[]
+  /** Slugs of requested teams. GitHub drops the request once any member reviews. */
+  teams: string[]
+}
+
+/** The `--jq` filter that shapes /requested_reviewers into {@link RequestedReviewers}. */
+const REQUESTED_REVIEWERS_JQ = '{users: [.users[].login], teams: [.teams[].slug]}'
+
+function parseRequestedReviewers(stdout: string): RequestedReviewers {
+  const parsed = JSON.parse(stdout.trim() || '{}') as Partial<RequestedReviewers>
+  return { users: parsed.users ?? [], teams: parsed.teams ?? [] }
+}
+
+/** Total outstanding review requests, counting each requested team as one. */
+function pendingReviewerCount(requested: RequestedReviewers): number {
+  return requested.users.length + requested.teams.length
+}
+
+/** The review state of a PR at a point in time, as both chip computations need it. */
+interface ReviewSnapshot {
+  /**
+   * Latest submitted review state per reviewer, excluding the PR author and bots.
+   * Draft (PENDING) reviews are not visible to anyone else, so they are dropped.
+   */
+  latestByAuthor: Map<string, string>
+  requested: RequestedReviewers
+}
+
+/**
+ * Fetches the submitted reviews and open review requests for a PR.
+ *
+ * The PR author is excluded along with bots: GitHub lets you leave COMMENTED
+ * reviews on your own PR, and those are not reviewer feedback.
+ */
+async function fetchReviewSnapshot(
+  dir: string, slug: string, login: string, prNumber: number,
+): Promise<ReviewSnapshot> {
+  const [reviewsResult, requestedResult] = await Promise.all([
+    execFileAsync('gh', [
+      'api', `repos/${slug}/pulls/${prNumber}/reviews`, '--jq',
+      `[.[] | select(.user.login != "${login}" and .user.type != "Bot") | {author: .user.login, state: .state}]`,
+    ], { cwd: dir, encoding: 'utf-8', timeout: 15000 }),
+    execFileAsync('gh', [
+      'api', `repos/${slug}/pulls/${prNumber}/requested_reviewers`, '--jq',
+      REQUESTED_REVIEWERS_JQ,
+    ], { cwd: dir, encoding: 'utf-8', timeout: 10000 }),
+  ])
+
+  const reviews: { author: string; state: string }[] = JSON.parse(reviewsResult.stdout.trim() || '[]')
+  const latestByAuthor = new Map<string, string>()
+  for (const review of reviews) {
+    if (review.state === 'PENDING') continue
+    latestByAuthor.set(review.author, review.state)
+  }
+
+  return { latestByAuthor, requested: parseRequestedReviewers(requestedResult.stdout) }
+}
+
+/** Resolves the repo's owner/name slug and the authenticated user's login. */
+async function fetchSlugAndLogin(dir: string): Promise<{ slug: string; login: string }> {
+  const [slugResult, userResult] = await Promise.all([
+    execFileAsync('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], { cwd: dir, encoding: 'utf-8', timeout: 10000 }),
+    execFileAsync('gh', ['api', 'user', '--jq', '.login'], { encoding: 'utf-8', timeout: 10000 }),
+  ])
+  return { slug: slugResult.stdout.trim(), login: userResult.stdout.trim() }
+}
+
+/**
+ * Checks whether a PR has actionable feedback: either someone left a review that
+ * did not approve (and hasn't been re-requested for review), or there are comments
+ * since the last push.
+ *
+ * The non-approving-review rule mirrors GitHub's own UI: GitHub shows the
+ * re-request icon next to any reviewer with a submitted review and no open
+ * request, so a plain COMMENTED review is feedback to act on just like
+ * CHANGES_REQUESTED is.
  */
 async function fetchPrFeedbackStatus(repoDir: string, prNumber: number): Promise<boolean> {
   try {
     const dir = expandHomePath(repoDir)
-    const [slugResult, userResult] = await Promise.all([
-      execFileAsync('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], { cwd: dir, encoding: 'utf-8', timeout: 10000 }),
-      execFileAsync('gh', ['api', 'user', '--jq', '.login'], { encoding: 'utf-8', timeout: 10000 }),
-    ])
-    const slug = slugResult.stdout.trim()
-    const login = userResult.stdout.trim()
+    const { slug, login } = await fetchSlugAndLogin(dir)
     if (!slug || !login) return false
 
     // Exclude the PR author and bot accounts. Bots (GitHub Apps like
@@ -50,18 +125,9 @@ async function fetchPrFeedbackStatus(repoDir: string, prNumber: number): Promise
     // feedback.
     const humanReviewerFilter = `select(.user.login != "${login}" and .user.type != "Bot")`
 
-    // Fetch in parallel: reviews, requested reviewers, last push time, comments
-    const [reviewsResult, requestedResult, lastPushResult, prCommentsResult, issueCommentsResult] = await Promise.all([
-      // All reviews on this PR (exclude bot reviews)
-      execFileAsync('gh', [
-        'api', `repos/${slug}/pulls/${prNumber}/reviews`, '--jq',
-        '[.[] | select(.user.type != "Bot") | {author: .user.login, state: .state}]',
-      ], { cwd: dir, encoding: 'utf-8', timeout: 15000 }),
-      // Currently requested reviewers
-      execFileAsync('gh', [
-        'api', `repos/${slug}/pulls/${prNumber}/requested_reviewers`, '--jq',
-        '[.users[].login]',
-      ], { cwd: dir, encoding: 'utf-8', timeout: 10000 }),
+    // Fetch in parallel: reviews + requested reviewers, last push time, comments
+    const [snapshot, lastPushResult, prCommentsResult, issueCommentsResult] = await Promise.all([
+      fetchReviewSnapshot(dir, slug, login, prNumber),
       // Timestamp of the latest event on the head branch (last push)
       execFileAsync('gh', [
         'api', `repos/${slug}/pulls/${prNumber}`, '--jq',
@@ -79,23 +145,12 @@ async function fetchPrFeedbackStatus(repoDir: string, prNumber: number): Promise
       ], { cwd: dir, encoding: 'utf-8', timeout: 15000 }),
     ])
 
-    // 1. Check for unresolved "changes requested" reviews
-    // A reviewer's changes_requested is unresolved if they are NOT in the requested_reviewers
-    // list (re-requesting review clears the old review state on GitHub's side, but the reviewer
+    // 1. Check for unresolved non-approving reviews
+    // A review is unresolved if its author is NOT in the requested_reviewers list
+    // (re-requesting review clears the old review state on GitHub's side, but the reviewer
     // appears in requested_reviewers until they submit a new review).
-    const reviews: { author: string; state: string }[] = JSON.parse(reviewsResult.stdout.trim() || '[]')
-    const requestedReviewers: string[] = JSON.parse(requestedResult.stdout.trim() || '[]')
-
-    // Group reviews by author, keeping only the latest state per author
-    const latestReviewByAuthor = new Map<string, string>()
-    for (const review of reviews) {
-      if (review.state === 'PENDING') continue
-      latestReviewByAuthor.set(review.author, review.state)
-    }
-
-    // Check if any reviewer's latest review is CHANGES_REQUESTED and they haven't been re-requested
-    for (const [author, state] of latestReviewByAuthor) {
-      if (state === 'CHANGES_REQUESTED' && !requestedReviewers.includes(author)) {
+    for (const [author, state] of snapshot.latestByAuthor) {
+      if (state !== 'APPROVED' && !snapshot.requested.users.includes(author)) {
         return true
       }
     }
@@ -132,46 +187,27 @@ export interface PrApprovalCounts {
  * Counts PR reviews for the waiting/approved chip. Mirrors fetchPrFeedbackStatus's
  * re-request handling: a reviewer who was re-requested (appears in
  * requested_reviewers) is counted as pending, not by their stale review state.
+ * A requested team counts as one pending reviewer — a PR can be waiting on a team
+ * with no individually requested user at all.
  */
 async function fetchPrApprovalStatus(repoDir: string, prNumber: number): Promise<PrApprovalCounts> {
   const empty: PrApprovalCounts = { approved: 0, pending: 0, otherReviews: 0 }
   try {
     const dir = expandHomePath(repoDir)
-    const slugResult = await execFileAsync('gh', [
-      'repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner',
-    ], { cwd: dir, encoding: 'utf-8', timeout: 10000 })
-    const slug = slugResult.stdout.trim()
-    if (!slug) return empty
+    const { slug, login } = await fetchSlugAndLogin(dir)
+    if (!slug || !login) return empty
 
-    const [reviewsResult, requestedResult] = await Promise.all([
-      execFileAsync('gh', [
-        'api', `repos/${slug}/pulls/${prNumber}/reviews`, '--jq',
-        '[.[] | select(.user.type != "Bot") | {author: .user.login, state: .state}]',
-      ], { cwd: dir, encoding: 'utf-8', timeout: 15000 }),
-      execFileAsync('gh', [
-        'api', `repos/${slug}/pulls/${prNumber}/requested_reviewers`, '--jq',
-        '[.users[].login]',
-      ], { cwd: dir, encoding: 'utf-8', timeout: 10000 }),
-    ])
-
-    const reviews: { author: string; state: string }[] = JSON.parse(reviewsResult.stdout.trim() || '[]')
-    const requestedReviewers: string[] = JSON.parse(requestedResult.stdout.trim() || '[]')
-
-    const latestByAuthor = new Map<string, string>()
-    for (const review of reviews) {
-      if (review.state === 'PENDING') continue
-      latestByAuthor.set(review.author, review.state)
-    }
+    const { latestByAuthor, requested } = await fetchReviewSnapshot(dir, slug, login, prNumber)
 
     let approved = 0
     let otherReviews = 0
     for (const [author, state] of latestByAuthor) {
-      if (requestedReviewers.includes(author)) continue // re-requested -> counted as pending
+      if (requested.users.includes(author)) continue // re-requested -> counted as pending
       if (state === 'APPROVED') approved++
       else otherReviews++
     }
 
-    return { approved, pending: requestedReviewers.length, otherReviews }
+    return { approved, pending: pendingReviewerCount(requested), otherReviews }
   } catch {
     return empty
   }

--- a/src/renderer/features/git/reviewState.ts
+++ b/src/renderer/features/git/reviewState.ts
@@ -12,7 +12,10 @@ export type ReviewState = 'none' | 'waiting' | 'approved'
 export interface PrApprovalStatus {
   /** Reviewers whose latest submitted review is APPROVED (and not re-requested). */
   approved: number
-  /** Requested reviewers who have not yet submitted a review. */
+  /**
+   * Outstanding review requests that have not been answered. Counts requested
+   * teams as well as individuals — a PR can be waiting on a team alone.
+   */
   pending: number
   /** Reviewers whose latest submitted review is not APPROVED (changes/comments). */
   otherReviews: number


### PR DESCRIPTION
## Background and Motivation

Two bugs made the `waiting` chip wrong.

- **PRs waiting on a team showed as `open`.** `requested_reviewers` was read as `[.users[].login]`, ignoring `.teams`. psi-product#5213 is waiting on the `psi-orpc-experts` team and returns `{"teams":["psi-orpc-experts"],"users":[]}` with no reviews — so `pending` was 0, the review state came out `none`, and the chip fell back to `open`.
- **A comment-only review left the chip on `waiting`.** Only `CHANGES_REQUESTED` counted as feedback. A `COMMENTED` review landed in `otherReviews` (→ `waiting`), and if the comments predated the last push, the comments-since-push check didn't catch it either.

The rule we now match is GitHub's own: anything that makes GitHub show the re-request icon next to a reviewer is feedback to act on.

## Design Decisions

- **A requested team counts as one pending reviewer.** GitHub drops the team's request as soon as any member submits a review, so the team behaves like a single reviewer for chip purposes — no need to expand membership.
- **Feedback is now "latest submitted review is not `APPROVED`, and the reviewer has no open re-request"** rather than an enumeration of states. That covers `COMMENTED` and `DISMISSED` alongside `CHANGES_REQUESTED` without having to chase GitHub's state list.
- **The PR author is excluded from the reviews query.** This one is load-bearing for the change above: GitHub lets you leave `COMMENTED` reviews on your own PR, and psi-product#5286 has three of them by the author. Without this, broadening past `CHANGES_REQUESTED` would report feedback on your own PR. The author was already excluded from the comment queries but not the review one; `prApprovalStatus` had the same gap, inflating `otherReviews`.
- **`fetchMyReviewStatus` is left alone.** It still reads only `.users`, so a request routed via a team isn't seen there — but it answers "have I reviewed this", not the waiting chip, and its fallback already returns `pending`. Out of scope; worth a separate look.

Note that `feedback` outranks `approved` in `computeStatusChip`, so a PR with one comment-only review and one approval now shows `feedback` rather than `approved`. That follows from the rule above, but it is a behavior change beyond the two bugs.

## Proposed Changes

- **`requested_reviewers` parsing** — new `RequestedReviewers` type plus a shared jq filter `{users: [.users[].login], teams: [.teams[].slug]}`, used by both chip computations. `pending` is now users + teams.
- **Feedback rule** — `fetchPrFeedbackStatus` treats any non-approving latest review from a reviewer with no open re-request as feedback.
- **Author exclusion** — the reviews query in both `fetchPrFeedbackStatus` and `fetchPrApprovalStatus` now filters out the authenticated user as well as bots.
- **Deduplication** — extracted `fetchReviewSnapshot` (reviews + requested reviewers + latest-review-per-author grouping) and `fetchSlugAndLogin`, which the two functions previously kept as separate near-identical copies. Parallelism is preserved: the snapshot is one element of the outer `Promise.all`.
- **Docs** — `PrApprovalStatus.pending` in `reviewState.ts` now states that teams count.

## Verification

Beyond the checklist below, the handlers were run against the live GitHub API (unit tests mock `execFile`, so they cannot catch a bad jq expression):

```
5213 approval: { approved: 0, pending: 1, otherReviews: 0 }               -> waiting  (was open)
5286 feedback: false  approval: { approved: 0, pending: 1, otherReviews: 0 }  -> waiting
5314 feedback: false  approval: { approved: 1, pending: 0, otherReviews: 0 }  -> approved
```

Old-vs-new logic was also replayed across all 35 open psi-product PRs authored by the reporter: **3 change (5322, 5292, 5213), all `open` → `waiting`, all waiting on `psi-orpc-experts`. No PR regresses.**

Not verified: the `COMMENTED` → feedback path has unit coverage but no live confirmation, because none of those 35 PRs currently hit it — every comment-only reviewer happens to be re-requested, which correctly keeps them `waiting`. The app itself was not launched; the handler return shape and renderer wiring are unchanged.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (coverage at or above 90% lines)
- [x] Ran all E2E tests locally (`pnpm test:e2e`)

```
lint          clean
typecheck     clean
check:all     All 2 check(s) passed
test:unit     244 files, 4407 passed
coverage      exit 0 - ghComments.ts 97.26% stmts / 99.24% lines; overall 90.79% lines
test:e2e      77 passed (1.1m)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Y4L8mS9hRKDpQQN2o7cCy
