### PR TITLE
Make Claude Code [file]/[image] terminal chips clickable via OSC 8

### DIFF
--- a/docs/terminal-integration.md
+++ b/docs/terminal-integration.md
@@ -288,10 +288,28 @@ button. A plain click still positions the cursor. `terminalLinkHandler.ts` owns 
 |---|---|---|---|
 | URLs (#149) | `@xterm/addon-web-links` + xterm's OSC 8 `linkHandler` | `shell:openExternal` | `terminalLinks.ts` |
 | File paths (#153) | `FilePathLinkProvider` (hand-written `ILinkProvider`) | `shell:openPath` | `terminalPathLinkProvider.ts` |
+| Claude's `[file]`/`[image]` chips (#164) | xterm's OSC 8 `linkHandler` — Claude emits them as `file://` hyperlinks | `shell:openPath` | `terminalLinkHandler.ts` |
 
-Both share the hover hint from `terminalLinkHint.ts` ("⌘click to open"), because xterm underlines
-a link and shows a pointer cursor whether or not the modifier is held — without the hint, a plain
-click is a dead end with no feedback.
+All three share the hover hint from `terminalLinkHint.ts` ("⌘click to open"), because xterm
+underlines a link and shows a pointer cursor whether or not the modifier is held — without the hint,
+a plain click is a dead end with no feedback.
+
+Notes specific to the OSC 8 chips:
+
+- **Broomy asks for them**: `FORCE_HYPERLINK=1` on the host PTY, since xterm's terminal name isn't
+  one `supports-hyperlinks` recognises. Per-session `agentEnv` merges after, so `FORCE_HYPERLINK=0`
+  turns it back off. It is deliberately absent from the isolated `dockerEnv`.
+- **`file://` never reaches `openExternal`** — it goes through the same gated `shell:openPath` as a
+  bare path. `fileUriToPath` accepts only a canonical `file:///…`, decoded exactly once, and fails
+  closed on an encoded slash, query/fragment, remote host, control characters, or over-length input.
+- **`allowNonHttpProtocols` is per terminal**: true on a host terminal so `file://` is delivered,
+  false for an isolated session, where a container path must not resolve against the host. A scheme
+  we don't open reaches `activate` and does nothing.
+- **The hint names the target when the label hides it.** An OSC 8 label is arbitrary agent output and
+  need not match its URI, so `linkHintDetail` compares the target with the row under the pointer and
+  spells it out only when that row doesn't already show it — quiet for a truthful chip, explicit for
+  a deceptive one. It fails toward showing, so a chip whose path is half off-row still gets the full
+  target, shortened from the middle to keep the filename.
 
 Notes specific to file-path links:
 

--- a/scripts/fake-claude.sh
+++ b/scripts/fake-claude.sh
@@ -51,6 +51,17 @@ echo "View the PR at https://github.com/Broomy-AI/broomy/pull/149"
 # feature-doc screenshot would both show plain text and quietly misrepresent the feature.
 printf '<h1>Broomy preview</h1>\n' > /tmp/broomy-preview.html
 echo "Wrote the design doc to /tmp/broomy-preview.html"
+
+# Claude Code prints file "chips" as OSC 8 hyperlinks (#164) rather than plain text: the link is
+# attached to the terminal CELLS, so it survives the hard wrap a long chip path almost always hits.
+# Emitted here as the real escape sequence (ESC ] 8 ; ; <uri> ST <label> ESC ] 8 ; ; ST) so the
+# walkthrough and the dev-mode demo exercise exactly the path a real agent takes.
+printf '\e]8;;file:///tmp/broomy-preview.html\e\\[file]/tmp/broomy-preview.html (1.2KB)\e]8;;\e\\\n'
+
+# A chip whose LABEL disagrees with its URI. Terminal output is untrusted — an OSC 8 label is
+# arbitrary text and need not describe where the link goes — so the hover hint has to spell the real
+# target out. This deliberately deceptive chip is what proves it (#164 anti-spoofing).
+printf '\e]8;;file:///tmp/broomy-preview.html\e\\[image]/tmp/holiday-photo.png (495.3KB)\e]8;;\e\\\n'
 echo ""
 
 # Now go idle (stop outputting)

--- a/src/main/handlers/pty.test.ts
+++ b/src/main/handlers/pty.test.ts
@@ -452,6 +452,21 @@ describe('pty handlers', () => {
       expect(spawnEnv.PLAIN).toBe('/absolute/path')
     })
 
+    it('sets FORCE_HYPERLINK so Claude emits OSC 8 chip links, overridable per session (#164)', async () => {
+      const { register } = await import('./pty')
+      const ctx = createCtx()
+      register(mockIpcMain as never, ctx)
+      mockPtySpawn.mockReturnValue(createMockPtyProcess())
+      mockBrowserWindowFromWebContents.mockReturnValue(mockSenderWindow)
+
+      await handlers['pty:create'](mockEvent, { id: 'fh-default', cwd: '/tmp' })
+      expect(mockPtySpawn.mock.calls[0][2].env.FORCE_HYPERLINK).toBe('1')
+
+      // A per-session env value merges AFTER baseEnv, so the user can turn it back off.
+      await handlers['pty:create'](mockEvent, { id: 'fh-override', cwd: '/tmp', env: { FORCE_HYPERLINK: '0' } })
+      expect(mockPtySpawn.mock.calls[1][2].env.FORCE_HYPERLINK).toBe('0')
+    })
+
     it('skips default CLAUDE_CONFIG_DIR in agent env', async () => {
       const { register } = await import('./pty')
       const { homedir } = await import('os')

--- a/src/main/handlers/pty.ts
+++ b/src/main/handlers/pty.ts
@@ -381,10 +381,19 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
     // its synchronized full-screen redraws are written to the main buffer.
     // See xtermjs/xterm.js#5784 and #5801. Per-session env (agentEnv) is
     // merged after this, so users can override with CLAUDE_CODE_NO_FLICKER=0.
+    //
+    // FORCE_HYPERLINK=1 makes Claude Code emit its `[file]`/`[image]` chips (and
+    // other file/URL references) as OSC 8 hyperlinks even though xterm's PTY name
+    // isn't a terminal `supports-hyperlinks` recognizes on its own (#164). Without
+    // it Claude falls back to plain text and a hard-wrapped chip can't be linked;
+    // with it the link rides on the cells and survives the wrap. The renderer honors
+    // the resulting `file://` OSC 8 links (terminalLinkHandler.ts). Override with
+    // FORCE_HYPERLINK=0 per session via agentEnv (merged after).
     const baseEnv = {
       ...process.env,
       PATH: enhancedPath(process.env.PATH),
       CLAUDE_CODE_NO_FLICKER: '1',
+      FORCE_HYPERLINK: '1',
     } as Record<string, string>
     delete baseEnv.CLAUDE_CONFIG_DIR
 

--- a/src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   shouldOpenTerminalLink,
+  isOpenableTerminalUri,
+  fileUriToPath,
   createTerminalLinkHandlers,
   type TerminalLinkClick,
 } from './terminalLinkHandler'
@@ -12,129 +14,197 @@ const click = (over: Partial<TerminalLinkClick> = {}): TerminalLinkClick => ({
   ...over,
 })
 
+describe('fileUriToPath', () => {
+  it('decodes a canonical file:// URL to a path, exactly once', () => {
+    expect(fileUriToPath('file:///Users/x.png')).toBe('/Users/x.png')
+    expect(fileUriToPath('file:///Users/a%20b.png')).toBe('/Users/a b.png') // %20 → space
+    expect(fileUriToPath('file:///Users/a%2520b.png')).toBe('/Users/a%20b.png') // %2520 → literal %20
+    expect(fileUriToPath('file://localhost/Users/x.png')).toBe('/Users/x.png')
+    expect(fileUriToPath('FILE:///Users/x.png')).toBe('/Users/x.png') // scheme is case-insensitive
+  })
+
+  it('rejects anything outside the safe file-URL contract', () => {
+    for (const uri of [
+      'file:///a%2Fb', // encoded slash (upper)
+      'file:///a%2fb', // encoded slash (lower)
+      'file:///a%00b', // NUL
+      'file:///a%7Fb', // DEL (post-decode \p{Cc})
+      'file:///a%C2%80b', // C1 control U+0080 (post-decode \p{Cc})
+      'file:///a	b', // raw TAB (URL would strip it)
+      'file:///a\\b', // raw backslash (URL would rewrite to /)
+      'file:///a%zz', // malformed %-escape
+      'file:///a%', // trailing %
+      'file:relative', // shorthand/relative (new URL('file:x').pathname is /x)
+      'file:/Users/x', // single-slash shorthand
+      'file:////path', // extra slash after the authority
+      'file://example.com/a', // remote host
+      'file:///a?q=1', // query
+      'file:///a#frag', // fragment
+      'http://example.com', // not file
+      'javascript:alert(1)',
+      `file:///${'a'.repeat(20000)}`, // overlong raw input
+    ]) {
+      expect(fileUriToPath(uri)).toBeNull()
+    }
+  })
+})
+
+describe('isOpenableTerminalUri', () => {
+  it('always accepts http(s)', () => {
+    expect(isOpenableTerminalUri('https://example.com', false)).toBe(true)
+    expect(isOpenableTerminalUri('http://example.com', false)).toBe(true)
+  })
+
+  it('accepts a valid file:// only when allowFileUris', () => {
+    expect(isOpenableTerminalUri('file:///Users/x.png', true)).toBe(true)
+    expect(isOpenableTerminalUri('file:///Users/x.png', false)).toBe(false)
+    expect(isOpenableTerminalUri('file://host/x', true)).toBe(false) // invalid file URL
+  })
+
+  it('refuses every other scheme', () => {
+    for (const uri of ['javascript:alert(1)', 'mailto:a@b.com', 'ftp://x', 'localhost:5173']) {
+      expect(isOpenableTerminalUri(uri, true)).toBe(false)
+    }
+  })
+})
+
 describe('shouldOpenTerminalLink', () => {
   const HTTPS = 'https://example.com'
 
   it('opens on ⌘+primary-click on macOS', () => {
-    expect(shouldOpenTerminalLink(click({ metaKey: true }), HTTPS, true)).toBe(true)
-    expect(shouldOpenTerminalLink(click({ metaKey: true }), 'http://example.com', true)).toBe(true)
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), HTTPS, true, true)).toBe(true)
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), 'http://example.com', true, true)).toBe(true)
   })
 
   it('opens on Ctrl+primary-click off macOS', () => {
-    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, false)).toBe(true)
-    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), 'http://example.com', false)).toBe(true)
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, false, true)).toBe(true)
   })
 
   it('does NOT open on Ctrl-click on macOS (that is the context-menu gesture)', () => {
-    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, true)).toBe(false)
-  })
-
-  it('does NOT open with the wrong-platform modifier', () => {
-    expect(shouldOpenTerminalLink(click({ metaKey: true }), HTTPS, false)).toBe(false)
-    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, true)).toBe(false)
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, true, true)).toBe(false)
   })
 
   it('does NOT open on a plain click (leaves selection/cursor to xterm)', () => {
-    expect(shouldOpenTerminalLink(click(), HTTPS, true)).toBe(false)
-    expect(shouldOpenTerminalLink(click(), HTTPS, false)).toBe(false)
+    expect(shouldOpenTerminalLink(click(), HTTPS, true, true)).toBe(false)
   })
 
   it('does NOT open on middle- or right-click even with the modifier', () => {
-    expect(shouldOpenTerminalLink(click({ metaKey: true, button: 1 }), HTTPS, true)).toBe(false)
-    expect(shouldOpenTerminalLink(click({ metaKey: true, button: 2 }), HTTPS, true)).toBe(false)
+    expect(shouldOpenTerminalLink(click({ metaKey: true, button: 1 }), HTTPS, true, true)).toBe(false)
+    expect(shouldOpenTerminalLink(click({ metaKey: true, button: 2 }), HTTPS, true, true)).toBe(false)
   })
 
-  it('refuses non-http(s) schemes even with the modifier held', () => {
-    for (const uri of [
-      'file:///etc/passwd',
-      'javascript:alert(1)',
-      'mailto:a@b.com',
-      'localhost:5173',
-      '127.0.0.1:5173',
-      'ftp://example.com',
-    ]) {
-      expect(shouldOpenTerminalLink(click({ metaKey: true }), uri, true)).toBe(false)
+  it('opens a valid file:// only when allowFileUris; refuses other non-http schemes always', () => {
+    const mod = click({ metaKey: true })
+    expect(shouldOpenTerminalLink(mod, 'file:///Users/x.png', true, true)).toBe(true)
+    expect(shouldOpenTerminalLink(mod, 'file:///Users/x.png', true, false)).toBe(false) // isolated
+    for (const uri of ['javascript:alert(1)', 'mailto:a@b.com', 'ftp://example.com', 'localhost:5173']) {
+      expect(shouldOpenTerminalLink(mod, uri, true, true)).toBe(false)
     }
   })
 
   it('is case-insensitive on the scheme', () => {
-    expect(shouldOpenTerminalLink(click({ metaKey: true }), 'HTTPS://Example.com', true)).toBe(true)
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), 'HTTPS://Example.com', true, true)).toBe(true)
   })
 })
 
 describe('createTerminalLinkHandlers', () => {
-  const makeDeps = (isMac: boolean) => {
+  const mod = { button: 0, metaKey: true, ctrlKey: false } as MouseEvent
+  const plain = { button: 0, metaKey: false, ctrlKey: false } as MouseEvent
+  const makeDeps = (isMac: boolean, allowFileUris = true) => {
     const openExternal = vi.fn()
+    const openPath = vi.fn()
     const hint = { show: vi.fn(), hide: vi.fn() }
-    return { openExternal, hint, handlers: createTerminalLinkHandlers({ isMac, openExternal, hint }) }
+    return {
+      openExternal,
+      openPath,
+      hint,
+      handlers: createTerminalLinkHandlers({ isMac, openExternal, openPath, allowFileUris, hint }),
+    }
   }
 
-  it('gates OSC 8 links (linkHandler) with the same rule and forbids non-http protocols', () => {
-    const { openExternal, handlers } = makeDeps(true)
+  it('allows non-http OSC 8 delivery on host terminals so file:// links reach the handler', () => {
+    expect(makeDeps(true, true).handlers.linkHandler.allowNonHttpProtocols).toBe(true)
+    expect(makeDeps(true, false).handlers.linkHandler.allowNonHttpProtocols).toBe(false) // isolated
+  })
 
-    // xterm must not fall back to its plain-click confirm()+window.open for non-http links.
-    expect(handlers.linkHandler.allowNonHttpProtocols).toBe(false)
-
-    handlers.linkHandler.activate({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
+  it('opens an http URL via openExternal (linkHandler + onClick), gated by the modifier', () => {
+    const { openExternal, openPath, handlers } = makeDeps(true)
+    handlers.linkHandler.activate(mod, 'https://example.com')
     expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com')
-
-    handlers.linkHandler.activate({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://example.com')
-    expect(openExternal).toHaveBeenCalledTimes(1)
+    handlers.linkHandler.activate(plain, 'https://example.com')
+    expect(openExternal).toHaveBeenCalledTimes(1) // plain click ignored
+    expect(openPath).not.toHaveBeenCalled()
   })
 
-  it('exposes the same gate as onClick for detected URL text', () => {
-    const { openExternal, handlers } = makeDeps(false)
-
-    handlers.onClick({ button: 0, metaKey: false, ctrlKey: true } as MouseEvent, 'http://x.dev')
-    handlers.onClick({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'http://x.dev')
-    expect(openExternal).toHaveBeenCalledExactlyOnceWith('http://x.dev')
-  })
-
-  it('refuses a non-http URI even with the modifier held (both paths)', () => {
-    const { openExternal, handlers } = makeDeps(true)
-    const modified = { button: 0, metaKey: true, ctrlKey: false } as MouseEvent
-
-    handlers.onClick(modified, 'file:///etc/passwd')
-    handlers.linkHandler.activate(modified, 'file:///etc/passwd')
+  it('opens a file:// OSC 8 link via openPath with the DECODED path', () => {
+    const { openExternal, openPath, handlers } = makeDeps(true)
+    handlers.linkHandler.activate(mod, 'file:///Users/a%20b.png')
+    expect(openPath).toHaveBeenCalledExactlyOnceWith('/Users/a b.png')
     expect(openExternal).not.toHaveBeenCalled()
   })
 
-  it('shows the hint on hover and hides it on leave, for both link paths', () => {
+  it('does not open a file:// link without the modifier', () => {
+    const { openPath, handlers } = makeDeps(true)
+    handlers.linkHandler.activate(plain, 'file:///Users/x.png')
+    expect(openPath).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-file, non-http schemes even with the modifier (no open action)', () => {
+    const { openExternal, openPath, handlers } = makeDeps(true)
+    for (const uri of ['javascript:alert(1)', 'mailto:a@b.com', 'file://host/x']) {
+      handlers.linkHandler.activate(mod, uri)
+      handlers.onClick(mod, uri)
+    }
+    expect(openExternal).not.toHaveBeenCalled()
+    expect(openPath).not.toHaveBeenCalled()
+  })
+
+  it('refuses a file:// link in an isolated session (allowFileUris false)', () => {
+    const { openPath, handlers } = makeDeps(true, false)
+    handlers.linkHandler.activate(mod, 'file:///Users/x.png')
+    expect(openPath).not.toHaveBeenCalled()
+  })
+
+  it('hover shows the decoded path for a file link, the plain hint for a URL, nothing otherwise', () => {
     const { hint, handlers } = makeDeps(true)
     const event = { clientX: 10, clientY: 20 } as MouseEvent
 
-    handlers.linkProviderOptions.hover(event, 'https://example.com')
-    expect(hint.show).toHaveBeenCalledExactlyOnceWith(event, 'https://example.com')
-    handlers.linkProviderOptions.leave()
-    expect(hint.hide).toHaveBeenCalledOnce()
+    handlers.linkHandler.hover(event, 'file:///Users/a%20b.png')
+    expect(hint.show).toHaveBeenCalledExactlyOnceWith(event, '/Users/a b.png')
 
-    handlers.linkHandler.hover(event, 'https://example.com')
-    expect(hint.show).toHaveBeenCalledTimes(2)
-    handlers.linkHandler.leave()
-    expect(hint.hide).toHaveBeenCalledTimes(2)
+    handlers.linkProviderOptions.hover(event, 'https://example.com')
+    expect(hint.show).toHaveBeenLastCalledWith(event, undefined) // URL → static "⌘click to open"
+
+    handlers.linkHandler.hover(event, 'javascript:alert(1)')
+    expect(hint.show).toHaveBeenCalledTimes(2) // unsupported scheme → no hint
   })
 
-  it('does not promise to open a URI the click gate would refuse', () => {
-    const { hint, handlers } = makeDeps(true)
-
-    handlers.linkProviderOptions.hover({} as MouseEvent, 'file:///etc/passwd')
+  it('does not show a file hint in an isolated session', () => {
+    const { hint, handlers } = makeDeps(true, false)
+    handlers.linkHandler.hover({} as MouseEvent, 'file:///Users/x.png')
     expect(hint.show).not.toHaveBeenCalled()
   })
 
-  it('hides the hint when a link is opened (no leave fires once focus goes to the browser)', () => {
+  it('hides the hint on leave and when a link is opened', () => {
     const { hint, handlers } = makeDeps(true)
-
-    handlers.onClick({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
+    handlers.linkHandler.leave()
     expect(hint.hide).toHaveBeenCalledOnce()
+    handlers.onClick(mod, 'https://example.com')
+    expect(hint.hide).toHaveBeenCalledTimes(2)
   })
 
   it('works without a hint (optional affordance)', () => {
     const openExternal = vi.fn()
-    const { onClick, linkProviderOptions } = createTerminalLinkHandlers({ isMac: true, openExternal })
-
+    const openPath = vi.fn()
+    const { onClick, linkProviderOptions } = createTerminalLinkHandlers({
+      isMac: true,
+      openExternal,
+      openPath,
+      allowFileUris: true,
+    })
     expect(() => linkProviderOptions.hover({} as MouseEvent, 'https://example.com')).not.toThrow()
     expect(() => linkProviderOptions.leave()).not.toThrow()
-    onClick({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, 'https://example.com')
-    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com')
+    onClick(mod, 'file:///Users/x.png')
+    expect(openPath).toHaveBeenCalledExactlyOnceWith('/Users/x.png')
   })
 })

--- a/src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHandler.test.ts
@@ -3,6 +3,7 @@ import {
   shouldOpenTerminalLink,
   isOpenableTerminalUri,
   fileUriToPath,
+  linkHintDetail,
   createTerminalLinkHandlers,
   type TerminalLinkClick,
 } from './terminalLinkHandler'
@@ -84,8 +85,14 @@ describe('shouldOpenTerminalLink', () => {
     expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, true, true)).toBe(false)
   })
 
+  it('does NOT open with the wrong-platform modifier', () => {
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), HTTPS, false, true)).toBe(false)
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), HTTPS, true, true)).toBe(false)
+  })
+
   it('does NOT open on a plain click (leaves selection/cursor to xterm)', () => {
     expect(shouldOpenTerminalLink(click(), HTTPS, true, true)).toBe(false)
+    expect(shouldOpenTerminalLink(click(), HTTPS, false, true)).toBe(false)
   })
 
   it('does NOT open on middle- or right-click even with the modifier', () => {
@@ -104,6 +111,40 @@ describe('shouldOpenTerminalLink', () => {
 
   it('is case-insensitive on the scheme', () => {
     expect(shouldOpenTerminalLink(click({ metaKey: true }), 'HTTPS://Example.com', true, true)).toBe(true)
+  })
+})
+
+describe('linkHintDetail', () => {
+  const CHIP = '[image]/Users/x/quiz.png (495.3KB)'
+
+  it('stays quiet when the hovered row already shows the target', () => {
+    expect(linkHintDetail('file:///Users/x/quiz.png', CHIP, true)).toBeUndefined()
+    expect(linkHintDetail('https://example.com/a', 'see https://example.com/a', true)).toBeUndefined()
+  })
+
+  it('spells out a target the row does not show — the spoofed label', () => {
+    // A chip whose label says one file and whose URI points at another.
+    expect(linkHintDetail('file:///Users/x/other.html', CHIP, true)).toBe('/Users/x/other.html')
+    // The same trick over http: an honest-looking label, a different host.
+    expect(linkHintDetail('https://evil.example', 'docs.example.com', true)).toBe('https://evil.example')
+  })
+
+  it('spells out the target when only PART of a hard-wrapped path is on the hovered row', () => {
+    // The anchor row of a wrapped chip holds `…/qu`; the rest is on the continuation row.
+    expect(linkHintDetail('file:///Users/x/quiz.png', '[image]/Users/x/qu', true)).toBe('/Users/x/quiz.png')
+  })
+
+  it('ignores the wrap indent when matching, so an unwrapped continuation row stays quiet', () => {
+    expect(linkHintDetail('file:///Users/x/quiz.png', '  /Users/x/quiz.png  ', true)).toBeUndefined()
+  })
+
+  it('fails toward showing when the row is unreadable', () => {
+    expect(linkHintDetail('file:///Users/x/quiz.png', undefined, true)).toBe('/Users/x/quiz.png')
+  })
+
+  it('has nothing to say about a link that will not open', () => {
+    expect(linkHintDetail('file:///Users/x/quiz.png', undefined, false)).toBeUndefined() // isolated
+    expect(linkHintDetail('javascript:alert(1)', undefined, true)).toBeUndefined()
   })
 })
 
@@ -165,18 +206,37 @@ describe('createTerminalLinkHandlers', () => {
     expect(openPath).not.toHaveBeenCalled()
   })
 
-  it('hover shows the decoded path for a file link, the plain hint for a URL, nothing otherwise', () => {
+  it('hover spells out an OSC 8 target the row hides, stays quiet for detected URL text', () => {
     const { hint, handlers } = makeDeps(true)
     const event = { clientX: 10, clientY: 20 } as MouseEvent
 
+    // No range (and so no row to read) → the target is shown.
     handlers.linkHandler.hover(event, 'file:///Users/a%20b.png')
     expect(hint.show).toHaveBeenCalledExactlyOnceWith(event, '/Users/a b.png')
 
+    // Detected URL text: the label IS the URI, so nothing to add.
     handlers.linkProviderOptions.hover(event, 'https://example.com')
-    expect(hint.show).toHaveBeenLastCalledWith(event, undefined) // URL → static "⌘click to open"
+    expect(hint.show).toHaveBeenLastCalledWith(event)
 
     handlers.linkHandler.hover(event, 'javascript:alert(1)')
     expect(hint.show).toHaveBeenCalledTimes(2) // unsupported scheme → no hint
+  })
+
+  it('reads the hovered row via the range, and stays quiet when that row shows the target', () => {
+    const readRow = vi.fn((row: number) => (row === 7 ? '[image]/Users/a b.png (2KB)' : '[image]/Users/a'))
+    const hint = { show: vi.fn(), hide: vi.fn() }
+    const handlers = createTerminalLinkHandlers({
+      isMac: true, openExternal: vi.fn(), openPath: vi.fn(), allowFileUris: true, hint, readRow,
+    })
+    const event = { clientX: 1, clientY: 2 } as MouseEvent
+    const range = (y: number) => ({ start: { x: 1, y }, end: { x: 20, y } })
+
+    handlers.linkHandler.hover(event, 'file:///Users/a%20b.png', range(7))
+    expect(readRow).toHaveBeenCalledWith(7) // 1-based absolute buffer row, as xterm reports it
+    expect(hint.show).toHaveBeenLastCalledWith(event, undefined) // whole path visible → no repeat
+
+    handlers.linkHandler.hover(event, 'file:///Users/a%20b.png', range(3)) // wrapped: half the path
+    expect(hint.show).toHaveBeenLastCalledWith(event, '/Users/a b.png')
   })
 
   it('does not show a file hint in an isolated session', () => {

--- a/src/renderer/panels/agent/hooks/terminalLinkHandler.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHandler.ts
@@ -10,8 +10,9 @@
  *    honoring them makes even a hard-wrapped chip clickable — the link rides on the cells (#164).
  * Every other scheme reaches `activate` but opens nothing.
  *
- * The hover hint (`terminalLinkHint.ts`) is the one DOM-touching piece; for a `file://` link it
- * shows the DECODED path so a deceptive label can't hide the real target.
+ * The hover hint (`terminalLinkHint.ts`) is the one DOM-touching piece; for an OSC 8 link whose
+ * label doesn't already show its target it spells the target out, so a deceptive label can't hide
+ * where the click goes (`linkHintDetail`).
  */
 
 /** The parts of a `MouseEvent` the open-decision depends on. */
@@ -21,11 +22,21 @@ export interface TerminalLinkClick {
   ctrlKey: boolean
 }
 
-/** The hover affordance, injected so this module stays DOM-free. `detail` (a `file://` link's
- *  decoded path) is appended to the "⌘click to open" hint; omit it for URLs. */
+/** The hover affordance, injected so this module stays DOM-free. `detail` (the link's real target)
+ *  is appended to the "⌘click to open" hint, and is passed ONLY when the link's own visible text
+ *  doesn't already show it — see `linkHintDetail`. */
 export interface TerminalLinkHint {
   show(event: MouseEvent, detail?: string): void
   hide(): void
+}
+
+/**
+ * Structural stand-in for xterm's `IBufferRange`, so this module stays xterm-free. `y` is the
+ * 1-based ABSOLUTE buffer row xterm reports for an OSC 8 link (`buffer.active.getLine(y - 1)`).
+ */
+export interface TerminalLinkRange {
+  start: { x: number; y: number }
+  end: { x: number; y: number }
 }
 
 /**
@@ -81,6 +92,31 @@ export function isOpenableTerminalUri(uri: string, allowFileUris: boolean): bool
   return allowFileUris && fileUriToPath(uri) !== null
 }
 
+/** Whitespace-insensitive, because a hard-wrapped chip splits its path across rows with an indent. */
+const squash = (text: string): string => text.replace(/\s+/g, '')
+
+/**
+ * The link's real target, to append to the hover hint — or `undefined` when the link's own visible
+ * text already shows it and the hint would just repeat the terminal.
+ *
+ * This is the anti-spoofing check (#164). An OSC 8 hyperlink's LABEL is arbitrary agent output and
+ * need not match its URI: a chip reading `[image]/safe.png` can point at `file:///…/other.html`,
+ * and an `https` link reading `docs.example.com` can point anywhere. `rowText` is the terminal row
+ * the pointer is on; when the target isn't visible in it, the hint spells the target out before the
+ * user ⌘-clicks. Fails toward SHOWING: an unreadable row, or a hard-wrapped chip whose path is only
+ * half on this row, shows the full target rather than trusting the label.
+ */
+export function linkHintDetail(
+  uri: string,
+  rowText: string | undefined,
+  allowFileUris: boolean,
+): string | undefined {
+  const target = /^https?:\/\//i.test(uri) ? uri : allowFileUris ? fileUriToPath(uri) : null
+  if (target === null) return undefined
+  if (rowText !== undefined && squash(rowText).includes(squash(target))) return undefined
+  return target
+}
+
 /**
  * Whether a click carries the "open" intent: the PRIMARY button plus the platform modifier —
  * ⌘ on macOS, Ctrl elsewhere. (Ctrl-click on macOS is the context-menu gesture, so it must not
@@ -117,6 +153,12 @@ export interface TerminalLinkDeps {
   openPath: (path: string) => void
   /** Whether `file://` OSC 8 links may open (host terminals only; false for isolated sessions). */
   allowFileUris: boolean
+  /**
+   * Read terminal row `row` (1-based, as xterm reports it in an OSC 8 link's range) as plain text,
+   * so the hint can tell whether the link's target is already visible. Optional: without it every
+   * OSC 8 link's target is spelled out.
+   */
+  readRow?: (row: number) => string | undefined
   /** Optional so callers without a container (and most tests) can skip the affordance. */
   hint?: TerminalLinkHint
 }
@@ -151,8 +193,9 @@ function createWebLinkHandler(deps: TerminalLinkDeps): (event: MouseEvent, uri: 
  * outright — container paths must not resolve to host paths).
  *
  * The hover hooks exist because xterm underlines a link and shows a pointer cursor whether or not the
- * modifier is held: without a hint, a plain click is a dead end with no feedback. A `file://` link's
- * hint shows the decoded path so a deceptive label can't hide the real target.
+ * modifier is held: without a hint, a plain click is a dead end with no feedback. The two paths hint
+ * differently only where they must: the addon's label is the URI itself, while an OSC 8 label is
+ * arbitrary agent output, so the latter spells out a target the row doesn't already show.
  */
 export function createTerminalLinkHandlers(deps: TerminalLinkDeps): {
   onClick: (event: MouseEvent, uri: string) => void
@@ -162,23 +205,32 @@ export function createTerminalLinkHandlers(deps: TerminalLinkDeps): {
   }
   linkHandler: {
     activate: (event: MouseEvent, uri: string) => void
-    hover: (event: MouseEvent, uri: string) => void
+    hover: (event: MouseEvent, uri: string, range?: TerminalLinkRange) => void
     leave: () => void
     allowNonHttpProtocols: boolean
   }
 } {
   const onClick = createWebLinkHandler(deps)
-  const hover = (event: MouseEvent, uri: string): void => {
-    if (isOpenableTerminalUri(uri, deps.allowFileUris)) {
-      // Show the decoded path for a file link; URLs keep the plain "⌘click to open" hint.
-      deps.hint?.show(event, fileUriToPath(uri) ?? undefined)
-    }
+
+  // Detected URL TEXT: the link's label IS the URI (that is what the addon matched), so the target
+  // is already on screen and spelling it out would only repeat the terminal.
+  const textHover = (event: MouseEvent, uri: string): void => {
+    if (isOpenableTerminalUri(uri, deps.allowFileUris)) deps.hint?.show(event)
   }
+
+  // OSC 8: the label is arbitrary and may not match the URI, so show the target unless the hovered
+  // row already contains it.
+  const oscHover = (event: MouseEvent, uri: string, range?: TerminalLinkRange): void => {
+    if (!isOpenableTerminalUri(uri, deps.allowFileUris)) return
+    const rowText = range ? deps.readRow?.(range.start.y) : undefined
+    deps.hint?.show(event, linkHintDetail(uri, rowText, deps.allowFileUris))
+  }
+
   const leave = (): void => deps.hint?.hide()
 
   return {
     onClick,
-    linkProviderOptions: { hover, leave },
-    linkHandler: { activate: onClick, hover, leave, allowNonHttpProtocols: deps.allowFileUris },
+    linkProviderOptions: { hover: textHover, leave },
+    linkHandler: { activate: onClick, hover: oscHover, leave, allowNonHttpProtocols: deps.allowFileUris },
   }
 }

--- a/src/renderer/panels/agent/hooks/terminalLinkHandler.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHandler.ts
@@ -1,10 +1,17 @@
 /**
- * Pure logic for the terminal's ⌘/⌃-click-to-open-URL behaviour (#149).
+ * Pure logic for the terminal's ⌘/⌃-click-to-open behaviour (#149, #164).
  *
  * Kept free of xterm and the DOM so it can be unit-tested directly. `useTerminalSetup`
- * wires it into `@xterm/addon-web-links`, whose click handler is invoked with the raw
- * `MouseEvent` and the detected URI. The hover hint that tells the user a modifier is
- * required is the one DOM-touching piece, and lives in `terminalLinkHint.ts`.
+ * wires it into `@xterm/addon-web-links` (URL-shaped text) and xterm's core `linkHandler`
+ * (OSC 8 hyperlinks). Two schemes open:
+ *  - `http(s)` URLs → `openExternal` (the OS browser), as before.
+ *  - `file://` OSC 8 hyperlinks → `openPath` (the same gated file opener the bare-path link
+ *    provider uses). Claude Code emits its `[file]`/`[image]` chips as `file://` OSC 8 links, so
+ *    honoring them makes even a hard-wrapped chip clickable — the link rides on the cells (#164).
+ * Every other scheme reaches `activate` but opens nothing.
+ *
+ * The hover hint (`terminalLinkHint.ts`) is the one DOM-touching piece; for a `file://` link it
+ * shows the DECODED path so a deceptive label can't hide the real target.
  */
 
 /** The parts of a `MouseEvent` the open-decision depends on. */
@@ -14,22 +21,64 @@ export interface TerminalLinkClick {
   ctrlKey: boolean
 }
 
-/** The hover affordance, injected so this module stays DOM-free. */
+/** The hover affordance, injected so this module stays DOM-free. `detail` (a `file://` link's
+ *  decoded path) is appended to the "⌘click to open" hint; omit it for URLs. */
 export interface TerminalLinkHint {
-  show(event: MouseEvent, uri: string): void
+  show(event: MouseEvent, detail?: string): void
   hide(): void
 }
 
 /**
- * Whether a URI is one the terminal will open at all.
- *
- * Re-checked here even though the addon only detects http(s): agent output is untrusted,
- * so this mirrors the renderer-side guard at `shared/utils/markdownComponents.tsx` (the
- * main process restricts it further still). It also gates the hover hint, so the terminal
+ * Convert a `file://` URL to a local filesystem path, or `null` if it isn't one we should open.
+ * macOS/POSIX-only (a Windows build would need drive-letter/UNC handling). Fails closed on anything
+ * that doesn't match the main-process `resolveTerminalPath` contract, so the hover hint never offers
+ * to open something the opener would reject:
+ *  - reject the RAW input up front for a backslash or any control char (`\p{Cc}`) — WHATWG `URL`
+ *    silently rewrites `\` to `/` and strips raw TAB/CR/LF, so these must never reach the parser — and
+ *    for overlong input;
+ *  - requires canonical `file:///…` or `file://localhost/…` with a SINGLE slash after the authority
+ *    (rejects `file:` shorthand and `file:////…` — `new URL('file:x').pathname` is `/x`, which would
+ *    look absolute);
+ *  - rejects a remote host, any query/fragment, and an encoded slash `%2f` (an encoded separator);
+ *  - decodes the pathname EXACTLY once, so `%20`→space and `%2520`→the literal `%20` are both valid;
+ *  - requires an absolute path ≤ 4096 with no control char (`\p{Cc}` — incl. DEL / C1, matching
+ *    `resolveTerminalPath`).
+ */
+export function fileUriToPath(uri: string): string | null {
+  if (uri.length > 16384) return null
+  if (/[\\\p{Cc}]/u.test(uri)) return null // raw backslash or control char — before URL normalizes them
+  if (!/^file:\/\/(localhost)?\/(?!\/)/i.test(uri)) return null // canonical, single slash after authority
+  let url: URL
+  try {
+    url = new URL(uri)
+  } catch {
+    return null
+  }
+  if (url.protocol !== 'file:') return null
+  if (url.hostname !== '' && url.hostname.toLowerCase() !== 'localhost') return null
+  if (url.search !== '' || url.hash !== '') return null
+  if (/%2f/i.test(url.pathname)) return null // encoded separator — never build a path from it
+  let path: string
+  try {
+    path = decodeURIComponent(url.pathname) // exactly once
+  } catch {
+    return null // malformed %-escape
+  }
+  if (!path.startsWith('/')) return null
+  if (/\p{Cc}/u.test(path)) return null // control chars, incl. NUL / DEL / C1
+  if (path.length > 4096) return null
+  return path
+}
+
+/**
+ * Whether a URI is one the terminal will open at all — `http(s)` always, `file://` only when
+ * `allowFileUris` (host terminals; an isolated/container session's paths don't map to the host).
+ * Re-checked here because agent output is untrusted and it also gates the hover hint, so the terminal
  * never offers to open something it would then refuse.
  */
-export function isOpenableTerminalUri(uri: string): boolean {
-  return /^https?:\/\//i.test(uri)
+export function isOpenableTerminalUri(uri: string, allowFileUris: boolean): boolean {
+  if (/^https?:\/\//i.test(uri)) return true
+  return allowFileUris && fileUriToPath(uri) !== null
 }
 
 /**
@@ -38,9 +87,9 @@ export function isOpenableTerminalUri(uri: string): boolean {
  * open; middle/right clicks are excluded via the button check.) A plain click returns false,
  * leaving xterm's normal selection/cursor behaviour untouched.
  *
- * Scheme-agnostic, because it is shared by both kinds of terminal link: URLs (below) and the
- * file paths in `terminalPathLinkProvider.ts`. The two must agree on the gesture — a modifier
- * that opened a URL but not a path would be indistinguishable from a broken link to the user.
+ * Scheme-agnostic, because it is shared by both kinds of terminal link: URLs/file OSC links (below)
+ * and the bare file paths in `terminalPathLinkProvider.ts`. The two must agree on the gesture — a
+ * modifier that opened one but not the other would be indistinguishable from a broken link.
  */
 export function hasOpenModifier(event: TerminalLinkClick, isMac: boolean): boolean {
   if (event.button !== 0) return false
@@ -48,20 +97,26 @@ export function hasOpenModifier(event: TerminalLinkClick, isMac: boolean): boole
 }
 
 /**
- * Whether a click on a detected terminal link should open it: the open gesture, plus a URI
- * this terminal will open at all.
+ * Whether a click on a detected terminal link should open it: the open gesture, plus a URI this
+ * terminal will open at all.
  */
 export function shouldOpenTerminalLink(
   event: TerminalLinkClick,
   uri: string,
-  isMac: boolean
+  isMac: boolean,
+  allowFileUris: boolean,
 ): boolean {
-  return hasOpenModifier(event, isMac) && isOpenableTerminalUri(uri)
+  return hasOpenModifier(event, isMac) && isOpenableTerminalUri(uri, allowFileUris)
 }
 
 export interface TerminalLinkDeps {
   isMac: boolean
+  /** Open an http(s) URL in the OS browser. */
   openExternal: (uri: string) => void
+  /** Open (or reveal) a local file — the target of a `file://` OSC 8 link. */
+  openPath: (path: string) => void
+  /** Whether `file://` OSC 8 links may open (host terminals only; false for isolated sessions). */
+  allowFileUris: boolean
   /** Optional so callers without a container (and most tests) can skip the affordance. */
   hint?: TerminalLinkHint
 }
@@ -69,12 +124,17 @@ export interface TerminalLinkDeps {
 /** The click handler shared by the web-links addon and xterm's OSC 8 `linkHandler`. */
 function createWebLinkHandler(deps: TerminalLinkDeps): (event: MouseEvent, uri: string) => void {
   return (event, uri) => {
-    if (shouldOpenTerminalLink(event, uri, deps.isMac)) {
-      // Hide first: focus leaves for the browser and xterm fires no `leave` for a link the
-      // pointer never left, so the hint would otherwise stay on screen.
-      deps.hint?.hide()
+    if (!shouldOpenTerminalLink(event, uri, deps.isMac, deps.allowFileUris)) return
+    // Hide first: focus leaves for the browser / opened app and xterm fires no `leave` for a link the
+    // pointer never left, so the hint would otherwise stay on screen.
+    deps.hint?.hide()
+    if (/^https?:\/\//i.test(uri)) {
       deps.openExternal(uri)
+      return
     }
+    // Non-http and it passed the gate → a `file://` link with `allowFileUris`, so this is non-null.
+    const path = fileUriToPath(uri)
+    if (path) deps.openPath(path)
   }
 }
 
@@ -83,14 +143,16 @@ function createWebLinkHandler(deps: TerminalLinkDeps): (event: MouseEvent, uri: 
  *  - `onClick` / `linkProviderOptions` for `@xterm/addon-web-links` (URL-shaped text), and
  *  - `linkHandler` for xterm's core OSC 8 hyperlinks.
  *
- * Both paths must be wired: without a `linkHandler`, OSC 8 links fall back to xterm's
- * default — a blocking `confirm()` then `window.open` on any plain click — which would open
- * some terminal links without the modifier, contradicting the feature. `allowNonHttpProtocols`
- * stays false so xterm also refuses non-http(s) OSC 8 links before they reach the handler.
+ * Both paths must be wired: without a `linkHandler`, OSC 8 links fall back to xterm's default — a
+ * blocking `confirm()` then `window.open` on any plain click. Because a handler is always present,
+ * that default never runs; `allowNonHttpProtocols` only controls WHICH schemes xterm delivers to
+ * `activate`. It is `true` for host terminals so `file://` OSC 8 links reach us (we open only
+ * `file://`; other schemes are ignored), and `false` for isolated sessions (`file://` refused
+ * outright — container paths must not resolve to host paths).
  *
- * The hover hooks exist because xterm underlines a link and shows a pointer cursor whether
- * or not the modifier is held: without a hint, a plain click is a dead end with no feedback.
- * Both paths share the hint for the same reason they share the gate.
+ * The hover hooks exist because xterm underlines a link and shows a pointer cursor whether or not the
+ * modifier is held: without a hint, a plain click is a dead end with no feedback. A `file://` link's
+ * hint shows the decoded path so a deceptive label can't hide the real target.
  */
 export function createTerminalLinkHandlers(deps: TerminalLinkDeps): {
   onClick: (event: MouseEvent, uri: string) => void
@@ -102,18 +164,21 @@ export function createTerminalLinkHandlers(deps: TerminalLinkDeps): {
     activate: (event: MouseEvent, uri: string) => void
     hover: (event: MouseEvent, uri: string) => void
     leave: () => void
-    allowNonHttpProtocols: false
+    allowNonHttpProtocols: boolean
   }
 } {
   const onClick = createWebLinkHandler(deps)
   const hover = (event: MouseEvent, uri: string): void => {
-    if (isOpenableTerminalUri(uri)) deps.hint?.show(event, uri)
+    if (isOpenableTerminalUri(uri, deps.allowFileUris)) {
+      // Show the decoded path for a file link; URLs keep the plain "⌘click to open" hint.
+      deps.hint?.show(event, fileUriToPath(uri) ?? undefined)
+    }
   }
   const leave = (): void => deps.hint?.hide()
 
   return {
     onClick,
     linkProviderOptions: { hover, leave },
-    linkHandler: { activate: onClick, hover, leave, allowNonHttpProtocols: false },
+    linkHandler: { activate: onClick, hover, leave, allowNonHttpProtocols: deps.allowFileUris },
   }
 }

--- a/src/renderer/panels/agent/hooks/terminalLinkHint.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHint.test.ts
@@ -12,6 +12,7 @@ describe('createTerminalLinkHint', () => {
   })
 
   const hintEl = () => container.firstElementChild as HTMLElement | null
+  const at = () => ({ clientX: 100, clientY: 200 }) as MouseEvent
 
   it('mounts hidden inside the terminal container', () => {
     createTerminalLinkHint(container)
@@ -21,9 +22,30 @@ describe('createTerminalLinkHint', () => {
   })
 
   it('names the platform modifier so the user knows what the plain click was missing', () => {
-    createTerminalLinkHint(container)
-
+    const hint = createTerminalLinkHint(container)
+    hint.show(at()) // no detail → the plain URL affordance
     expect(hintEl()!.textContent).toBe(`${modifierSymbol}click to open`)
+  })
+
+  it('appends the decoded path for a file link, so a deceptive label cannot hide the target', () => {
+    const hint = createTerminalLinkHint(container)
+    hint.show(at(), '/Users/a b.png')
+    expect(hintEl()!.textContent).toBe(`${modifierSymbol}click to open /Users/a b.png`)
+  })
+
+  it('updates the text when the pointer moves between targets', () => {
+    const hint = createTerminalLinkHint(container)
+    hint.show(at(), '/Users/first.png')
+    expect(hintEl()!.textContent).toContain('/Users/first.png')
+    hint.show(at()) // a URL next → no detail
+    expect(hintEl()!.textContent).toBe(`${modifierSymbol}click to open`)
+  })
+
+  it('renders the (untrusted) path as text, never as HTML', () => {
+    const hint = createTerminalLinkHint(container)
+    hint.show(at(), '/tmp/<img src=x onerror=alert(1)>.png')
+    expect(hintEl()!.querySelector('img')).toBeNull()
+    expect(hintEl()!.textContent).toContain('<img src=x onerror=alert(1)>')
   })
 
   it('carries xterm-hover so it does not swallow events into the terminal beneath', () => {
@@ -36,7 +58,7 @@ describe('createTerminalLinkHint', () => {
   it('shows at the pointer and hides again', () => {
     const hint = createTerminalLinkHint(container)
 
-    hint.show({ clientX: 100, clientY: 200 } as MouseEvent, 'https://example.com')
+    hint.show({ clientX: 100, clientY: 200 } as MouseEvent)
     expect(hintEl()!.style.display).toBe('')
     // Offset off the pointer so the hint never covers the link it describes.
     expect(hintEl()!.style.left).toBe('112px')

--- a/src/renderer/panels/agent/hooks/terminalLinkHint.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHint.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createTerminalLinkHint } from './terminalLinkHint'
+import { createTerminalLinkHint, middleEllipsis } from './terminalLinkHint'
 import { modifierSymbol } from '../../../shared/utils/platform'
 
 describe('createTerminalLinkHint', () => {
@@ -46,6 +46,36 @@ describe('createTerminalLinkHint', () => {
     hint.show(at(), '/tmp/<img src=x onerror=alert(1)>.png')
     expect(hintEl()!.querySelector('img')).toBeNull()
     expect(hintEl()!.textContent).toContain('<img src=x onerror=alert(1)>')
+  })
+
+  it('shortens a long target from the MIDDLE, keeping the tree and the filename', () => {
+    const long = `/Users/rob/repos/broomy/${'nested/'.repeat(20)}quiz-layout.png`
+    const hint = createTerminalLinkHint(container)
+    hint.show(at(), long)
+
+    const text = hintEl()!.textContent
+    expect(text).toContain('/Users/rob/repos') // the head survives
+    expect(text).toContain('quiz-layout.png') // and so does the filename
+    expect(text).toContain('…')
+    expect(text.length).toBeLessThan(long.length)
+  })
+
+  it('middleEllipsis leaves a short target alone and never exceeds the budget', () => {
+    expect(middleEllipsis('/tmp/a.png')).toBe('/tmp/a.png')
+    expect(middleEllipsis('/a/'.repeat(80)).length).toBe(72)
+    expect(middleEllipsis('abcdefghij', 5)).toBe('a…hij') // the budget favours the filename end
+  })
+
+  it('clamps back inside the window instead of running off the right edge', () => {
+    const hint = createTerminalLinkHint(container)
+    // jsdom reports 0 for offsetWidth/Height, so stub the measured size the clamp reads.
+    const el = hintEl()!
+    Object.defineProperty(el, 'offsetWidth', { value: 300, configurable: true })
+    Object.defineProperty(el, 'offsetHeight', { value: 20, configurable: true })
+
+    hint.show({ clientX: window.innerWidth - 10, clientY: window.innerHeight - 5 } as MouseEvent, '/tmp/a.png')
+    expect(parseInt(el.style.left, 10)).toBe(window.innerWidth - 300 - 4)
+    expect(parseInt(el.style.top, 10)).toBe(window.innerHeight - 20 - 4)
   })
 
   it('carries xterm-hover so it does not swallow events into the terminal beneath', () => {

--- a/src/renderer/panels/agent/hooks/terminalLinkHint.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHint.ts
@@ -21,7 +21,8 @@ const HINT_CLASSES =
   'bg-bg-tertiary text-text-secondary text-2xs whitespace-nowrap shadow-lg'
 
 export interface TerminalLinkHintElement {
-  show(event: MouseEvent, uri: string): void
+  /** `detail` (a file link's decoded path) is appended so a deceptive label can't hide the target. */
+  show(event: MouseEvent, detail?: string): void
   hide(): void
   dispose(): void
 }
@@ -35,12 +36,13 @@ export interface TerminalLinkHintElement {
 export function createTerminalLinkHint(container: HTMLElement): TerminalLinkHintElement {
   const el = document.createElement('div')
   el.className = HINT_CLASSES
-  el.textContent = `${modifierSymbol}click to open`
   el.style.display = 'none'
   container.appendChild(el)
 
   return {
-    show(event: MouseEvent): void {
+    show(event: MouseEvent, detail?: string): void {
+      // `textContent` (never innerHTML) — the decoded path is untrusted agent output.
+      el.textContent = detail ? `${modifierSymbol}click to open ${detail}` : `${modifierSymbol}click to open`
       el.style.display = ''
       // Anchored above-right of the pointer. `fixed` means viewport coordinates, which is
       // exactly what clientX/clientY are, so no ancestor needs to be positioned.

--- a/src/renderer/panels/agent/hooks/terminalLinkHint.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinkHint.ts
@@ -16,9 +16,32 @@ import { modifierSymbol } from '../../../shared/utils/platform'
 /** Kept off the pointer so the hint never covers the link it describes. */
 const CURSOR_OFFSET_PX = 12
 
+/** Kept clear of the window edges when the hint has to be pushed back inside. */
+const VIEWPORT_MARGIN_PX = 4
+
+/**
+ * Longest target spelled out in the hint. Paths that reach the hint are long by nature — that a
+ * chip's path wraps is the whole reason it needs a hyperlink — and the hint is one nowrap line.
+ */
+const MAX_DETAIL_CHARS = 72
+
+/**
+ * Shorten from the MIDDLE, so both ends survive: the leading `/Users/…` says which tree it is and
+ * the trailing segment is the filename — the part the user is actually checking before ⌘-clicking.
+ * A tail-truncating ellipsis (CSS `text-overflow`) would drop exactly that.
+ */
+export function middleEllipsis(text: string, max = MAX_DETAIL_CHARS): string {
+  if (text.length <= max) return text
+  const keepEnd = Math.ceil((max - 1) * 0.6) // favour the filename end
+  return `${text.slice(0, max - 1 - keepEnd)}…${text.slice(text.length - keepEnd)}`
+}
+
 const HINT_CLASSES =
   'xterm-hover fixed z-50 pointer-events-none px-1.5 py-0.5 rounded border border-border ' +
-  'bg-bg-tertiary text-text-secondary text-2xs whitespace-nowrap shadow-lg'
+  'bg-bg-tertiary text-text-secondary text-2xs whitespace-nowrap shadow-lg ' +
+  // Belt-and-braces for a window narrower than the hint itself: the clamp below can only push the
+  // hint back to the left edge, it cannot make it fit.
+  'max-w-[calc(100vw-8px)] overflow-hidden text-ellipsis'
 
 export interface TerminalLinkHintElement {
   /** `detail` (a file link's decoded path) is appended so a deceptive label can't hide the target. */
@@ -42,12 +65,20 @@ export function createTerminalLinkHint(container: HTMLElement): TerminalLinkHint
   return {
     show(event: MouseEvent, detail?: string): void {
       // `textContent` (never innerHTML) — the decoded path is untrusted agent output.
-      el.textContent = detail ? `${modifierSymbol}click to open ${detail}` : `${modifierSymbol}click to open`
+      el.textContent = detail
+        ? `${modifierSymbol}click to open ${middleEllipsis(detail)}`
+        : `${modifierSymbol}click to open`
       el.style.display = ''
-      // Anchored above-right of the pointer. `fixed` means viewport coordinates, which is
-      // exactly what clientX/clientY are, so no ancestor needs to be positioned.
-      el.style.left = `${event.clientX + CURSOR_OFFSET_PX}px`
-      el.style.top = `${event.clientY + CURSOR_OFFSET_PX}px`
+      // Anchored below-right of the pointer. `fixed` means viewport coordinates, which is exactly
+      // what clientX/clientY are, so no ancestor needs to be positioned.
+      //
+      // Then clamped back inside the window: the hint is one nowrap line, so a long target hovered
+      // near the right edge would otherwise run off-screen — and the end that falls off is the
+      // filename. Measured after the text is set and `display` cleared, so `offsetWidth` is real.
+      const maxLeft = window.innerWidth - el.offsetWidth - VIEWPORT_MARGIN_PX
+      const maxTop = window.innerHeight - el.offsetHeight - VIEWPORT_MARGIN_PX
+      el.style.left = `${Math.max(VIEWPORT_MARGIN_PX, Math.min(event.clientX + CURSOR_OFFSET_PX, maxLeft))}px`
+      el.style.top = `${Math.max(VIEWPORT_MARGIN_PX, Math.min(event.clientY + CURSOR_OFFSET_PX, maxTop))}px`
     },
     hide(): void {
       el.style.display = 'none'

--- a/src/renderer/panels/agent/hooks/terminalLinks.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinks.test.ts
@@ -50,6 +50,21 @@ describe('createLinkWiring', () => {
     expect(window.shell.openPath).not.toHaveBeenCalled()
   })
 
+  it('reads the hovered row from the attached terminal, so a truthful label needs no hint detail', () => {
+    const links = createLinkWiring(container, CWD, true)
+    const hintShow = vi.spyOn(links.hint, 'show')
+    const line = { translateToString: vi.fn(() => '[image]/Users/x.png (2KB)') }
+    links.attachTerminal({ buffer: { active: { getLine: vi.fn(() => line) } } } as never)
+
+    const event = { clientX: 1, clientY: 2 } as MouseEvent
+    links.linkHandler.hover!(event, 'file:///Users/x.png', { start: { x: 1, y: 5 }, end: { x: 20, y: 5 } })
+    expect(hintShow).toHaveBeenLastCalledWith(event, undefined) // row shows it → no repeat
+
+    line.translateToString.mockReturnValue('[image]/safe.png') // label lies about the target
+    links.linkHandler.hover!(event, 'file:///Users/x.png', { start: { x: 1, y: 5 }, end: { x: 20, y: 5 } })
+    expect(hintShow).toHaveBeenLastCalledWith(event, '/Users/x.png')
+  })
+
   it('mounts a hint the addon can drive, and removes it on dispose', () => {
     const links = createLinkWiring(container, CWD, true)
     const addon = links.addon as unknown as {

--- a/src/renderer/panels/agent/hooks/terminalLinks.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinks.test.ts
@@ -15,6 +15,7 @@ vi.mock('@xterm/addon-web-links', () => ({
 
 /** Both modifiers, so the assertion holds whichever platform the test runs on. */
 const MODIFIED_CLICK = { button: 0, metaKey: true, ctrlKey: true, clientX: 1, clientY: 2 } as MouseEvent
+const CWD = '/repo/worktree'
 
 describe('createLinkWiring', () => {
   let container: HTMLElement
@@ -22,20 +23,35 @@ describe('createLinkWiring', () => {
   beforeEach(() => {
     container = document.createElement('div')
     vi.mocked(window.shell.openExternal).mockReset().mockResolvedValue(undefined)
+    vi.mocked(window.shell.openPath).mockReset().mockResolvedValue({ action: 'opened' })
   })
 
-  it('wires both of xterm\'s link paths to the same gate', () => {
-    const links = createLinkWiring(container)
+  it('wires both of xterm\'s link paths, delivering non-http OSC 8 to the handler', () => {
+    const links = createLinkWiring(container, CWD, true)
 
     expect(links.addon).toBeInstanceOf(WebLinksAddon)
-    expect(links.linkHandler.allowNonHttpProtocols).toBe(false)
+    expect(links.linkHandler.allowNonHttpProtocols).toBe(true) // host terminal → file:// reaches us
 
     links.linkHandler.activate(MODIFIED_CLICK, 'https://osc8.example', undefined as never)
     expect(window.shell.openExternal).toHaveBeenCalledExactlyOnceWith('https://osc8.example')
   })
 
+  it('opens a file:// OSC 8 link via shell.openPath with the decoded path + cwd', () => {
+    const links = createLinkWiring(container, CWD, true)
+    links.linkHandler.activate(MODIFIED_CLICK, 'file:///Users/a%20b.png', undefined as never)
+    expect(window.shell.openPath).toHaveBeenCalledExactlyOnceWith('/Users/a b.png', CWD)
+    expect(window.shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('refuses file:// on an isolated terminal (allowFileUris false)', () => {
+    const links = createLinkWiring(container, CWD, false)
+    expect(links.linkHandler.allowNonHttpProtocols).toBe(false)
+    links.linkHandler.activate(MODIFIED_CLICK, 'file:///Users/x.png', undefined as never)
+    expect(window.shell.openPath).not.toHaveBeenCalled()
+  })
+
   it('mounts a hint the addon can drive, and removes it on dispose', () => {
-    const links = createLinkWiring(container)
+    const links = createLinkWiring(container, CWD, true)
     const addon = links.addon as unknown as {
       options?: { hover?: (e: MouseEvent, uri: string) => void; leave?: () => void }
     }
@@ -52,16 +68,35 @@ describe('createLinkWiring', () => {
     expect(container.querySelector('.xterm-hover')).toBeNull()
   })
 
-  it('logs a failed open instead of leaving an unhandled rejection', async () => {
+  it('logs a failed external open instead of leaving an unhandled rejection', async () => {
     allowConsoleError()
     vi.mocked(window.shell.openExternal).mockRejectedValue(new Error('no browser'))
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const links = createLinkWiring(container)
+    const links = createLinkWiring(container, CWD, true)
 
     links.linkHandler.activate(MODIFIED_CLICK, 'https://example.com', undefined as never)
     await vi.waitFor(() => expect(consoleError).toHaveBeenCalled())
 
     expect(consoleError.mock.calls[0][0]).toContain('failed to open link')
+    consoleError.mockRestore()
+  })
+
+  it('surfaces a RESOLVED openPath failure (it does not reject) and an IPC rejection', async () => {
+    allowConsoleError()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // openPath resolves { action: 'failed', error } rather than rejecting.
+    vi.mocked(window.shell.openPath).mockResolvedValueOnce({ action: 'failed', error: 'no app' })
+    const links = createLinkWiring(container, CWD, true)
+    links.linkHandler.activate(MODIFIED_CLICK, 'file:///Users/x.png', undefined as never)
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled())
+    expect(consoleError.mock.calls.at(-1)![1]).toBe('no app')
+
+    // And a rejected IPC call is caught, not left unhandled.
+    vi.mocked(window.shell.openPath).mockRejectedValueOnce(new Error('ipc down'))
+    links.linkHandler.activate(MODIFIED_CLICK, 'file:///Users/y.png', undefined as never)
+    await vi.waitFor(() => expect(consoleError.mock.calls.length).toBeGreaterThan(1))
+
     consoleError.mockRestore()
   })
 })

--- a/src/renderer/panels/agent/hooks/terminalLinks.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinks.ts
@@ -37,20 +37,31 @@ export interface TerminalLinkWiring {
 /**
  * Build the link wiring for a terminal mounted on `container`.
  *
- * The gate wants the platform modifier plus the primary button, and re-checks the scheme —
- * the main process restricts `shell.openExternal` to http(s) as well, since terminal output
- * is untrusted. Open failures are logged rather than left as an unhandled rejection: a plain
- * click still positions the cursor, so a failed open must not break the terminal.
+ * The gate wants the platform modifier plus the primary button, and re-checks the scheme. `http(s)`
+ * URLs open via `shell.openExternal` (which the main process also restricts to http(s)); `file://`
+ * OSC 8 links (Claude Code's chips, #164) open via `shell.openPath` — the same gated opener the
+ * bare-path provider uses (existence-checked, native-open allowlist, reveal-in-Finder), which resolves
+ * `{ action, error }` rather than rejecting, so a failed open is read off `r.error`. `allowFileUris` is
+ * false for isolated sessions, where a container path must not resolve to a host file. Open failures
+ * are logged rather than left as an unhandled rejection: a plain click still positions the cursor, so a
+ * failed open must not break the terminal.
  */
-export function createLinkWiring(container: HTMLElement): TerminalLinkWiring {
+export function createLinkWiring(container: HTMLElement, cwd: string, allowFileUris: boolean): TerminalLinkWiring {
   const hint = createTerminalLinkHint(container)
   const handlers = createTerminalLinkHandlers({
     isMac,
     hint,
+    allowFileUris,
     openExternal: (uri) => {
       window.shell.openExternal(uri).catch((err: unknown) => {
         console.error('[terminal] failed to open link', err)
       })
+    },
+    openPath: (path) => {
+      window.shell
+        .openPath(path, cwd)
+        .then((r) => { if (r.error) console.error('[terminal] failed to open path', r.error) })
+        .catch((err: unknown) => console.error('[terminal] failed to open path', err))
     },
   })
 

--- a/src/renderer/panels/agent/hooks/terminalLinks.ts
+++ b/src/renderer/panels/agent/hooks/terminalLinks.ts
@@ -10,11 +10,12 @@
  * Both paths must be wired. Detected URL text goes through the web-links addon; OSC 8
  * hyperlinks go through the core `linkHandler`, and without one they fall back to xterm's
  * default (a blocking `confirm()` then `window.open` on *any* plain click), which would open
- * some links with no modifier at all. They share one gate and one hint so the two kinds of
- * link are indistinguishable to the user.
+ * some links with no modifier at all. They share one gate and one hint, so the two kinds of link
+ * take the same gesture; only an OSC 8 link, whose label need not match its URI, adds the target
+ * to that hint (#164).
  */
 import { WebLinksAddon } from '@xterm/addon-web-links'
-import type { ILinkHandler } from '@xterm/xterm'
+import type { ILinkHandler, Terminal } from '@xterm/xterm'
 
 import { isMac } from '../../../shared/utils/platform'
 import { createTerminalLinkHandlers } from './terminalLinkHandler'
@@ -28,8 +29,16 @@ export interface TerminalLinkWiring {
   /**
    * The shared hover affordance. Handed to the file-path link provider (#153) so a path link
    * and a URL link are indistinguishable to the user: same gesture, same "⌘click to open".
+   * An OSC 8 link adds the target to that hint when its own row doesn't show it (#164), which is
+   * the one case where the text under the pointer isn't already the truth.
    */
   hint: TerminalLinkHintElement
+  /**
+   * Hand back the terminal once it exists. The wiring has to be built BEFORE the terminal (the
+   * `XTerm` constructor takes `linkHandler`), so the buffer an OSC 8 hover reads its row from can
+   * only be attached afterwards. Until it is, hovers just spell the target out.
+   */
+  attachTerminal: (terminal: Terminal) => void
   /** Belongs in the setup effect's cleanup, beside `terminal.dispose()`. */
   dispose: () => void
 }
@@ -48,10 +57,14 @@ export interface TerminalLinkWiring {
  */
 export function createLinkWiring(container: HTMLElement, cwd: string, allowFileUris: boolean): TerminalLinkWiring {
   const hint = createTerminalLinkHint(container)
+  let terminal: Terminal | null = null
   const handlers = createTerminalLinkHandlers({
     isMac,
     hint,
     allowFileUris,
+    // xterm reports an OSC 8 link's row as a 1-based ABSOLUTE buffer row, which is what
+    // `getLine` indexes from 0.
+    readRow: (row) => terminal?.buffer.active.getLine(row - 1)?.translateToString(true),
     openExternal: (uri) => {
       window.shell.openExternal(uri).catch((err: unknown) => {
         console.error('[terminal] failed to open link', err)
@@ -69,6 +82,7 @@ export function createLinkWiring(container: HTMLElement, cwd: string, allowFileU
     linkHandler: handlers.linkHandler,
     addon: new WebLinksAddon(handlers.onClick, handlers.linkProviderOptions),
     hint,
+    attachTerminal: (t) => { terminal = t },
     dispose: () => hint.dispose(),
   }
 }

--- a/src/renderer/panels/agent/hooks/terminalOscLink.integration.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalOscLink.integration.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { Terminal } from '@xterm/xterm'
+import { createTerminalLinkHandlers } from './terminalLinkHandler'
+
+/**
+ * Integration guard for the OSC 8 file-link path (#164). Claude Code emits `[file]`/`[image]` chips as
+ * OSC 8 `file://` hyperlinks; xterm attaches the link to the CELLS, so it survives a hard-wrap `\r\n`
+ * (the wrap the old text-detector couldn't link), and calls the terminal's `linkHandler.activate` when
+ * a covered cell on ANY row is clicked.
+ *
+ * xterm exposes no public API for per-cell hyperlinks, and jsdom can't hit-test rendered cells, so this
+ * drives a REAL `Terminal`, then reads xterm's INTERNAL buffer + OSC link service (private — treated as
+ * a test-only coupling) to prove the wrap-immunity directly, and exercises our handler for the click →
+ * openPath behaviour and the gates.
+ */
+type XtermInternals = {
+  _core: {
+    _bufferService: {
+      buffer: { lines: { get(y: number): { _extendedAttrs?: Record<number, { urlId?: number } | undefined> } | undefined } }
+    }
+    _oscLinkService: { getLinkData(id: number): { uri?: string } | undefined }
+  }
+}
+
+const OSC = '\x1b]8;;'
+const ST = '\x1b\\'
+const FILE = 'file:///Users/x/very/long/quiz-layout.png'
+const mod = { button: 0, metaKey: true, ctrlKey: true } as MouseEvent // both modifiers → platform-independent
+const write = (term: Terminal, data: string) => new Promise<void>((resolve) => term.write(data, resolve))
+
+function makeTerminal(allowFileUris = true) {
+  const openPath = vi.fn()
+  const openExternal = vi.fn()
+  const handlers = createTerminalLinkHandlers({ isMac: true, openExternal, openPath, allowFileUris })
+  const term = new Terminal({ cols: 40, rows: 10, linkHandler: handlers.linkHandler, allowProposedApi: true })
+  return { term, handlers, openPath, openExternal }
+}
+
+/** The distinct OSC 8 link ids attached to the cells of buffer row `y`. */
+function urlIdsOnRow(term: Terminal, y: number): number[] {
+  const line = (term as unknown as XtermInternals)._core._bufferService.buffer.lines.get(y)
+  const ext = line?._extendedAttrs
+  const ids = new Set<number>()
+  if (ext) for (let x = 0; x < term.cols; x++) { const id = ext[x]?.urlId; if (id) ids.add(id) }
+  return [...ids]
+}
+const linkUri = (term: Terminal, id: number): string | undefined =>
+  (term as unknown as XtermInternals)._core._oscLinkService.getLinkData(id)?.uri
+
+describe('OSC 8 file link (integration)', () => {
+  it('keeps ONE file:// hyperlink across a hard-wrap, and opens the decoded path on activate', async () => {
+    const { term, handlers, openPath } = makeTerminal(true)
+    // A chip whose visible text hard-wraps (a real \r\n + hanging indent) INSIDE one OSC 8 hyperlink.
+    await write(term, `${OSC}${FILE}${ST}[image]/Users/x/very/long/qu\r\n    iz-layout.png (495.3KB)${OSC}${ST}`)
+
+    // The chip's visible text landed across two buffer rows...
+    expect(term.buffer.active.getLine(0)?.translateToString(true)).toContain('[image]')
+    expect(term.buffer.active.getLine(1)?.translateToString(true)).toContain('iz-layout.png')
+    // ...and BOTH rows carry the SAME OSC 8 link id pointing at our file:// URI — the link rode the wrap.
+    const [anchorId] = urlIdsOnRow(term, 0)
+    const [continuationId] = urlIdsOnRow(term, 1)
+    expect(anchorId).toBeGreaterThan(0)
+    expect(continuationId).toBe(anchorId)
+    expect(linkUri(term, anchorId)).toBe(FILE)
+
+    // xterm invokes linkHandler.activate with that URI when a covered cell (either row) is clicked.
+    handlers.linkHandler.activate(mod, FILE)
+    expect(openPath).toHaveBeenCalledExactlyOnceWith('/Users/x/very/long/quiz-layout.png')
+
+    term.dispose()
+  })
+
+  it('does not open without the modifier, ignores an unsupported scheme, and refuses file:// when isolated', () => {
+    const host = makeTerminal(true)
+    host.handlers.linkHandler.activate({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, FILE)
+    host.handlers.linkHandler.activate(mod, 'javascript:alert(1)')
+    expect(host.openPath).not.toHaveBeenCalled()
+    host.term.dispose()
+
+    const isolated = makeTerminal(false)
+    expect(isolated.handlers.linkHandler.allowNonHttpProtocols).toBe(false)
+    isolated.handlers.linkHandler.activate(mod, FILE)
+    expect(isolated.openPath).not.toHaveBeenCalled()
+    isolated.term.dispose()
+  })
+})

--- a/src/renderer/panels/agent/hooks/terminalPathLinkProvider.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalPathLinkProvider.test.ts
@@ -217,7 +217,9 @@ describe('FilePathLinkProvider — plain lines', () => {
 
     const ev = { clientX: 5, clientY: 6 } as MouseEvent
     link.hover!(ev, link.text)
-    expect(hint.show).toHaveBeenCalledWith(ev, '/tmp/a.html')
+    // No target spelled out: the link's text IS the path, right under the pointer (#164 keeps that
+    // detail for OSC 8 links, whose label can disagree with their URI).
+    expect(hint.show).toHaveBeenCalledWith(ev)
     link.leave!(ev, link.text)
     expect(hint.hide).toHaveBeenCalledTimes(1)
 

--- a/src/renderer/panels/agent/hooks/terminalPathLinkProvider.test.ts
+++ b/src/renderer/panels/agent/hooks/terminalPathLinkProvider.test.ts
@@ -36,6 +36,7 @@ describe('detectPathCandidates', () => {
   })
 })
 
+
 // --- Faithful fake xterm buffer: fixed-width rows, right-trim, wide + width-0 cells ---
 
 interface CellSpec { chars: string; width: number }
@@ -224,6 +225,28 @@ describe('FilePathLinkProvider — plain lines', () => {
     // link the pointer never left, so the hint would otherwise stay on screen.
     link.activate({ button: 0, metaKey: true, ctrlKey: false } as MouseEvent, link.text)
     expect(hint.hide).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('FilePathLinkProvider — generic detection around chip-like text', () => {
+  // Claude's `[file]`/`[image]` chips are OSC 8 links now (#164, handled in terminalLinkHandler.ts),
+  // not detected here. The generic detector still links real bare paths that happen to sit near a
+  // `[file]` label or under a margin-filled non-anchor row.
+  it('links an indented generic path under a margin-filled non-anchor row', async () => {
+    const term = fakeTerminal([
+      { cells: asciiCells('abcdefghijklmnopqrst') }, // 20 chars fill the margin, but no ● tool anchor
+      { cells: asciiCells('  /gen/path.md') },
+    ], 20)
+    const links = await provide(new FilePathLinkProvider(term, deps({ pathExists: existsOnly('/gen/path.md') })), 2)
+    expect(links).toHaveLength(1)
+    expect(links![0].text).toBe('/gen/path.md')
+  })
+
+  it('links a real path printed after a [file] label (space-leading)', async () => {
+    const term = fakeTerminal([{ cells: asciiCells('[file] See /tmp/a.md (2KB)') }])
+    const links = await provide(new FilePathLinkProvider(term, deps({ pathExists: existsOnly('/tmp/a.md') })), 1)
+    expect(links).toHaveLength(1)
+    expect(links![0].text).toBe('/tmp/a.md')
   })
 })
 

--- a/src/renderer/panels/agent/hooks/terminalPathLinkProvider.ts
+++ b/src/renderer/panels/agent/hooks/terminalPathLinkProvider.ts
@@ -11,6 +11,11 @@
  *    tool-call envelope, gated by the wrap margin, a consistent content-start indent, and existence,
  *    so an ordinary indented line can't be mis-joined (#154 follow-up).
  *
+ * Claude Code file "chips" (`[file]/abs/path (2.7KB)` / `[image]…` in the input line, #164) are NOT
+ * detected here: Claude emits them as `file://` OSC 8 hyperlinks, honored directly by xterm's
+ * `linkHandler` (`terminalLinkHandler.ts`), which is wrap-immune. This provider only covers bare
+ * path TEXT (compiler errors, tool-call arguments) with no hyperlink of its own.
+ *
  * Everything is reconstructed into one canonical string `T` with a span table mapping each UTF-16
  * code unit back to its `{row, cell}` origin, so detection runs once and every link gets an exact,
  * honest cell range (per-row segments for hard wraps, where the stripped indent must not be
@@ -313,20 +318,21 @@ export class FilePathLinkProvider implements ILinkProvider {
     // All buffer reads + range mapping happen synchronously here, before the async existence probe.
     const qUnit = softUnitBounds(buf, q)
     if (qUnit.overflow) { callback(undefined); return } // truncated giant wrap → fail closed
-    const block = collectBlock(this._terminal, qUnit)
-    const rows = block ? block.rows : plainRows(qUnit)
-    const { text, spans, boundaries } = buildBlockText(buf, rows)
-    const candidates = detectPathCandidates(text)
-    if (candidates.length === 0) {
-      callback(undefined)
-      return
-    }
 
     // A tool-call block only links the wrapped PAYLOAD path: it must start after the anchor's `(`
     // (`● Label(`), begin in the anchor unit, and cross the FIRST hard-wrap boundary — which uniquely
     // selects it (only one detected token can start in the anchor payload and cross that seam), so an
     // incidental token sitting in a continuation row is never linked.
-    const blockInfo = block ? { parenOff: text.indexOf('('), boundaries } : null
+    const block = collectBlock(this._terminal, qUnit)
+    const built = buildBlockText(buf, block ? block.rows : plainRows(qUnit))
+    const text = built.text
+    const spans = built.spans
+    const candidates = detectPathCandidates(text)
+    const blockInfo = block ? { parenOff: text.indexOf('('), boundaries: built.boundaries } : null
+    if (candidates.length === 0) {
+      callback(undefined)
+      return
+    }
 
     const mapped = candidates
       .map((c) => this._toLink(c, spans, text, q, blockInfo))

--- a/src/renderer/panels/agent/hooks/terminalPathLinkProvider.ts
+++ b/src/renderer/panels/agent/hooks/terminalPathLinkProvider.ts
@@ -439,7 +439,9 @@ export class FilePathLinkProvider implements ILinkProvider {
       },
       // Same affordance as URL links: xterm underlines and shows a pointer cursor whether or not
       // the modifier is held, so without the hint a plain click is a dead end with no feedback.
-      hover: (event: MouseEvent) => this._deps.hint?.show(event, c.text),
+      // No target in the hint: a bare path link's text IS the path, right under the pointer, so
+      // spelling it out again would only repeat the terminal (an OSC 8 label can lie; this can't).
+      hover: (event: MouseEvent) => this._deps.hint?.show(event),
       leave: () => this._deps.hint?.hide(),
     }
   }

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.test.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.test.ts
@@ -269,11 +269,12 @@ describe('useTerminalSetup', () => {
     expect(window.shell.openExternal).toHaveBeenCalledExactlyOnceWith('https://text.example')
 
     // 2) OSC 8 hyperlinks (xterm linkHandler): the same gate must reach the Terminal constructor,
-    //    or OSC 8 links fall back to xterm's plain-click confirm()+window.open.
+    //    or OSC 8 links fall back to xterm's plain-click confirm()+window.open. On a host (non-isolated)
+    //    terminal `allowNonHttpProtocols` is true so Claude's file:// chip links reach the handler (#164).
     const ctorOptions = mockTerminalConstructor.mock.calls.at(-1)?.[0] as
       | { linkHandler?: { activate?: (e: MouseEvent, uri: string) => void; allowNonHttpProtocols?: boolean } }
       | undefined
-    expect(ctorOptions?.linkHandler?.allowNonHttpProtocols).toBe(false)
+    expect(ctorOptions?.linkHandler?.allowNonHttpProtocols).toBe(true)
     vi.mocked(window.shell.openExternal).mockClear()
     ctorOptions!.linkHandler!.activate!({ button: 0, metaKey: true, ctrlKey: true } as MouseEvent, 'https://osc8.example')
     ctorOptions!.linkHandler!.activate!({ button: 0, metaKey: false, ctrlKey: false } as MouseEvent, 'https://osc8.example')

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.ts
@@ -426,7 +426,9 @@ export function useTerminalSetup(
     // as a hook dependency. THIS EFFECT'S CLEANUP KILLS THE PTY — adding theme or
     // fontSize to its deps would destroy the running agent on every appearance
     // change. The separate effect below applies changes to the live terminal instead.
-    const links = createLinkWiring(containerRef.current)
+    // `file://` OSC 8 links (Claude Code chips) open host files, so they're allowed only for
+    // non-isolated terminals — the same reason the bare-path provider below is host-only.
+    const links = createLinkWiring(containerRef.current, effectCwd, !s.isolatedRef.current)
     const terminal = createConfiguredTerminal(links.linkHandler)
 
     const fitAddon = new FitAddon()

--- a/src/renderer/panels/agent/hooks/useTerminalSetup.ts
+++ b/src/renderer/panels/agent/hooks/useTerminalSetup.ts
@@ -430,6 +430,9 @@ export function useTerminalSetup(
     // non-isolated terminals — the same reason the bare-path provider below is host-only.
     const links = createLinkWiring(containerRef.current, effectCwd, !s.isolatedRef.current)
     const terminal = createConfiguredTerminal(links.linkHandler)
+    // The wiring is built first (the constructor takes `linkHandler`), so the buffer an OSC 8
+    // hover reads its row from is handed over here.
+    links.attachTerminal(terminal)
 
     const fitAddon = new FitAddon()
     terminal.loadAddon(fitAddon)

--- a/tests/features/terminal-chip-links/terminal-chip-links.spec.ts
+++ b/tests/features/terminal-chip-links/terminal-chip-links.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Feature Documentation: Claude Code's `[file]`/`[image]` chips are clickable (#164)
+ *
+ * Claude Code prints file "chips" — `[file]/abs/path (2.7KB)`, `[image]…` — as OSC 8 hyperlinks,
+ * the terminal escape sequence that attaches a link to the CELLS rather than to matched text. Broomy
+ * asks for them with `FORCE_HYPERLINK=1` on the agent PTY and honors the `file://` URIs they carry:
+ * ⌘-click (⌃-click on Windows/Linux) opens the file through the same gated `shell:openPath` used by
+ * bare-path links (#153) — existence-checked, never following a symlink, documents/media in the OS
+ * default app and everything else revealed in the file manager. Because the link rides on the cells,
+ * it survives the hard wrap that chip paths almost always hit, which text matching could not.
+ *
+ * The hover hint is where the trust boundary shows. An OSC 8 label is arbitrary agent output and
+ * need not match its URI, so the hint spells the real target out whenever the row under the pointer
+ * doesn't already show it — a truthful chip stays quiet, a deceptive one is exposed before the click.
+ *
+ * This walkthrough drives REAL OSC 8 sequences through a real xterm by printf-ing them into the
+ * terminal, which is byte-for-byte what Claude emits (`pathToFileURL` + `supports-hyperlinks`). The
+ * open itself is not observable in E2E (`shell:openPath` no-ops under E2E_TEST), so the URI
+ * validation, the isolated-session refusal, and the open/reveal decision are proven in the unit
+ * tests (`terminalLinkHandler.test.ts`, `terminalOscLink.integration.test.ts`, `shell.test.ts`).
+ * What is visible here — the link, the hint, and the anti-spoofing — is what this documents.
+ *
+ * Run with: pnpm test:feature-docs terminal-chip-links
+ */
+import { test, expect, resetApp } from '../_shared/electron-fixture'
+import type { Page, Locator } from '@playwright/test'
+import path from 'path'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+import { screenshotElement } from '../_shared/screenshot-helpers'
+import { generateFeaturePage, generateIndex, FeatureStep } from '../_shared/template'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const FEATURE_DIR = __dirname
+const SCREENSHOTS = path.join(FEATURE_DIR, 'screenshots')
+const FEATURES_ROOT = path.join(__dirname, '..')
+
+/** The file the chips point at — written by scripts/fake-claude.sh, so it really exists. */
+const TARGET = '/tmp/broomy-preview.html'
+/** An honest chip: the label names the file the URI points at. */
+const HONEST_LABEL = `[file]${TARGET} (1.2KB)`
+/** A deceptive chip: the label names an image, the URI points at the HTML file above. */
+const SPOOF_LABEL = '[image]/tmp/holiday-photo.png (495.3KB)'
+
+/** Read serialized terminal buffer content from the in-app registry. */
+async function getTerminalContent(p: Page): Promise<string> {
+  return p.evaluate(() => {
+    const registry = (window as unknown as {
+      __terminalBufferRegistry?: { getSessionIds: () => string[]; getBuffer: (id: string) => string | null }
+    }).__terminalBufferRegistry
+    if (!registry) return ''
+    for (const id of registry.getSessionIds()) {
+      if (id.endsWith('-user')) continue
+      const buf = registry.getBuffer(id)
+      if (buf && buf.length > 0) return buf
+    }
+    return ''
+  })
+}
+
+/**
+ * Hover the chip a few characters in from the start of its row.
+ *
+ * xterm rows span the full width, so hovering the row's centre would land past the text; a small
+ * fixed offset lands inside the `[file]`/`[image]` tag at any font size we ship. The hint is driven
+ * by xterm's own link layer, so this has to be a real pointer position over the linked cells — a
+ * synthetic hover on the element would not do.
+ */
+async function hoverChip(p: Page, panel: Locator, label: string): Promise<void> {
+  const row = panel.locator('.xterm-rows > div').filter({ hasText: label }).first()
+  await expect(row).toBeVisible()
+  const box = await row.boundingBox()
+  if (!box) throw new Error(`No bounding box for the chip row: ${label}`)
+  await p.mouse.move(box.x + 20, box.y + box.height / 2)
+}
+
+/** The hint element the terminal mounts for the hovered link. */
+const hintOf = (panel: Locator): Locator =>
+  panel.locator('.xterm-hover').filter({ hasText: 'click to open' })
+
+let page: Page
+const steps: FeatureStep[] = []
+
+test.beforeAll(async () => {
+  await fs.promises.mkdir(SCREENSHOTS, { recursive: true })
+  ;({ page } = await resetApp())
+})
+
+test.afterAll(async () => {
+  await generateFeaturePage(
+    {
+      title: "Claude's [file] and [image] Chips Are Clickable",
+      description:
+        'Claude Code prints file chips as OSC 8 hyperlinks, so the link lives on the terminal ' +
+        'cells and survives the hard wrap a long path always hits. ⌘-click (⌃-click on ' +
+        'Windows/Linux) opens the file; hovering names the real target whenever the chip’s own ' +
+        'label does not already show it.',
+      steps,
+    },
+    FEATURE_DIR,
+  )
+  await generateIndex(FEATURES_ROOT)
+})
+
+test.describe.serial('Feature: Clickable Claude Code file chips', () => {
+  test('A chip printed as an OSC 8 hyperlink renders in the terminal', async () => {
+    // The fake agent prints both chips as real OSC 8 sequences (scripts/fake-claude.sh).
+    await expect.poll(() => getTerminalContent(page), { timeout: 20000 }).toContain(HONEST_LABEL)
+
+    const agentPanel = page.locator('[data-panel-id="agent"]')
+    await expect(agentPanel).toBeVisible()
+
+    await screenshotElement(page, agentPanel, path.join(SCREENSHOTS, '01-chip-in-terminal.png'), {
+      maxHeight: 500,
+    })
+    steps.push({
+      screenshotPath: 'screenshots/01-chip-in-terminal.png',
+      caption: 'A file chip in the agent terminal',
+      description:
+        'When Claude reads or writes a file it prints a chip like `[file]/tmp/broomy-preview.html ' +
+        '(1.2KB)`. It looks like plain text, but Claude emits it as an OSC 8 hyperlink carrying a ' +
+        '`file://` URI, and Broomy asks for that explicitly by setting FORCE_HYPERLINK=1 on the ' +
+        'agent PTY — without it Claude cannot tell that this terminal supports hyperlinks and ' +
+        'falls back to plain text. The link is attached to the cells rather than to matched text, ' +
+        'which is why it still works when a long path hard-wraps across two rows: both rows carry ' +
+        'the same link. That wrap is the normal case for real chip paths, and it is what defeated ' +
+        'matching the rendered text.',
+    })
+  })
+
+  test('Hovering shows the ⌘click affordance without repeating what the row already says', async () => {
+    const agentPanel = page.locator('[data-panel-id="agent"]')
+    await hoverChip(page, agentPanel, HONEST_LABEL)
+
+    const hint = hintOf(agentPanel)
+    await expect(hint).toBeVisible()
+    // The row already spells out /tmp/broomy-preview.html, so the hint adds nothing to it.
+    await expect(hint).not.toContainText(TARGET)
+
+    await screenshotElement(page, agentPanel, path.join(SCREENSHOTS, '02-hover-hint.png'), {
+      maxHeight: 500,
+    })
+    steps.push({
+      screenshotPath: 'screenshots/02-hover-hint.png',
+      caption: 'Hovering underlines the chip and explains the gesture',
+      description:
+        'xterm underlines a link and shows a pointer cursor whether or not the modifier is held, ' +
+        'so without a hint a plain click would be a dead end with no explanation — a plain click ' +
+        'still just positions the cursor. The hint names the platform modifier: ⌘-click on macOS, ' +
+        '⌃-click on Windows and Linux, primary button only, because ⌃-click on macOS is the ' +
+        'context-menu gesture. Here the chip is honest — the path in the hint would be the path ' +
+        'already on the row — so the hint stays short rather than repeating the terminal.',
+    })
+  })
+
+  test('A chip whose label disagrees with its link has the real target spelled out', async () => {
+    const agentPanel = page.locator('[data-panel-id="agent"]')
+
+    // Same URI as the honest chip, under a label claiming to be an image somewhere else entirely.
+    await hoverChip(page, agentPanel, SPOOF_LABEL)
+
+    const hint = hintOf(agentPanel)
+    await expect(hint).toBeVisible()
+    await expect(hint).toContainText(TARGET) // the target the label was hiding
+
+    await screenshotElement(page, agentPanel, path.join(SCREENSHOTS, '03-spoofed-chip.png'), {
+      maxHeight: 500,
+    })
+    steps.push({
+      screenshotPath: 'screenshots/03-spoofed-chip.png',
+      caption: 'A deceptive label cannot hide where the click goes',
+      description:
+        'Terminal output is untrusted: an agent, or any command it runs, can print whatever it ' +
+        'likes, and an OSC 8 label need not match its URI. This chip reads ' +
+        '`[image]/tmp/holiday-photo.png` while its link points at /tmp/broomy-preview.html. ' +
+        'Because the row under the pointer does not contain the real target, the hint spells it ' +
+        'out before you ⌘-click — the same check covers https links, where a label could name one ' +
+        'site and the URI another. The path is rendered as text, never as markup, and shortened ' +
+        'from the middle so the filename survives. Opening then goes through the same gated opener ' +
+        'bare-path links use, and is refused outright for isolated/devcontainer sessions, whose ' +
+        'container paths must never resolve against the host filesystem.',
+    })
+  })
+})

--- a/tests/features/terminal-links/terminal-links.spec.ts
+++ b/tests/features/terminal-links/terminal-links.spec.ts
@@ -7,7 +7,9 @@
  * positions the cursor, and only http(s) URLs are opened.
  *
  * Hovering shows a "⌘click to open" hint, because xterm underlines a link whether or not
- * the modifier is held.
+ * the modifier is held. A `file://` OSC 8 hyperlink opens too — that is how Claude Code's file
+ * chips work (#164, see the terminal-chip-links walkthrough) — but through `shell:openPath`,
+ * never the browser. Every other scheme is ignored.
  *
  * The browser-open itself is not observable in E2E (`shell:openExternal` no-ops under
  * E2E_TEST), so the interaction logic — modifier gating, primary-button-only, http(s)
@@ -94,8 +96,9 @@ test.describe.serial('Feature: Click a URL in the Terminal', () => {
         'whether or not the modifier is held, so without the hint a plain click would be a dead ' +
         'end with no explanation. ⌘-click (⌃-click on Windows/Linux) opens it via ' +
         'window.shell.openExternal — the same external-browser path the rest of the app uses, so ' +
-        'the Electron window never navigates away. A plain click still positions the cursor, and ' +
-        'only http(s) URLs open (file:, javascript:, mailto: and scheme-less text are ignored). ' +
+        'the Electron window never navigates away. A plain click still positions the cursor. Only ' +
+        'http(s) opens externally; a `file://` OSC 8 link opens through the gated file opener ' +
+        'instead (#164), and javascript:, mailto: and scheme-less text are ignored. ' +
         'The open itself is not observable in E2E, so the modifier/button/scheme gating is ' +
         'proven in terminalLinkHandler.test.ts.',
     })


### PR DESCRIPTION
Closes #164.

## Background and Motivation

Claude Code prints file "chips" in the terminal — `[file]/abs/path (2.7KB)`, `[image]…` — that
should be ⌘/⌃-clickable to open the file. This PR's first approach matched the rendered TEXT, but
scoped it to **single-line** chips: a chip whose long path HARD-wraps across rows couldn't be
reassembled unambiguously, so it failed closed. In practice chip paths are long and almost always
wrap, so the feature missed its main case.

It turns out Claude Code already emits these chips as **OSC 8 hyperlinks** with `file://` URIs (it
builds them via `pathToFileURL` and gates emission on `supports-hyperlinks`). OSC 8 attaches the link
to the terminal *cells*, so it survives a hard wrap — which is exactly why these chips are already
clickable in iTerm2. Broomy was discarding that signal: xterm dropped `file://` OSC 8 links
(`allowNonHttpProtocols: false`, a #149 choice for URLs), and Broomy's PTY wasn't advertised as
hyperlink-capable, so Claude fell back to plain text.

This reworks the PR to **honor the OSC 8 links** instead of pattern-matching — wrap-immune by
construction, and it lets us delete the fragile geometry code.

## Design Decisions

- **Emit deterministically:** `FORCE_HYPERLINK=1` in the agent PTY env so Claude emits the OSC 8
  chips regardless of how Broomy was launched (overridable per session; not added to the isolated
  `dockerEnv`).
- **Honor safely:** `file://` OSC 8 links route through the SAME gated opener the bare-path links use
  (`shell:openPath` — existence check, native-open allowlist, reveal-in-Finder), never
  `openExternal`/navigation, so the app-wide `file://` navigation block is untouched. `fileUriToPath`
  decodes only a canonical `file://` URL (rejects encoded slash, query/fragment, remote host, control
  chars, overlong, and `file:` shorthand; decodes exactly once). `allowNonHttpProtocols` is `true`
  only for host terminals; a custom `linkHandler` is always present so xterm's default open never
  runs, and any non-file/non-http scheme reaches `activate` but opens nothing.
- **Isolated sessions excluded:** `file://` opening is disabled for devcontainer terminals — a
  container `/workspace/x` path must not resolve to a host file.
- **Anti-spoofing:** the hover hint shows the DECODED path (`textContent`), so a deceptive label
  (`[image]/safe.png` whose URI is `file:///…/other.html`) is visible before you ⌘-click.
- **Removed** the single-line chip text-detection; the generic bare-path detector (compiler errors,
  tool-call args) is unchanged. xterm 5.5.0 preserves the OSC hyperlink across a hard-wrap `\r\n`, so
  both the anchor row and the wrapped continuation become clickable.

### Accepted limitations
- Isolated/devcontainer chips stay plain-text / unsupported.
- Requires a Claude build that honors `FORCE_HYPERLINK` (all current versions do).

## Proposed Changes

- **Main process:** `pty.ts` — `FORCE_HYPERLINK=1` on host PTYs only.
- **Renderer (`panels/agent/hooks/`):** `terminalLinkHandler.ts` (`fileUriToPath`, `file://` routing,
  `allowFileUris` / `allowNonHttpProtocols`), `terminalLinks.ts` + `useTerminalSetup.ts` (wire
  `openPath` + cwd + `!isolated`, surface a resolved `openPath` failure), `terminalLinkHint.ts`
  (decoded-path hint), `terminalPathLinkProvider.ts` (remove chip detection, keep generic detection).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all`
- [x] `pnpm test:unit` (≥90% lines on the changed handler files; global ~90.8%)
- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 77 passed
- [x] Real-xterm OSC 8 hard-wrap integration test (`terminalOscLink.integration.test.ts`)
