### PR TITLE
fix(appearance): stop forcing web pages dark with the app theme

### DIFF
--- a/docs/superpowers/specs/2026-07-28-web-follows-system-appearance-design.md
+++ b/docs/superpowers/specs/2026-07-28-web-follows-system-appearance-design.md
@@ -1,0 +1,86 @@
+# Web content follows the OS, not the Broomy theme
+
+Broomy stops overriding `nativeTheme.themeSource`. Web pages shown in the webview
+render exactly as they would in any other browser on the user's machine, while
+Broomy's own UI keeps whatever theme the user picked.
+
+## The problem
+
+Choosing a dark Broomy theme also turns every website dark. Some users want a dark
+Broomy and light web pages, and today there is no way to have both.
+
+This is not a feature anyone built. `nativeTheme.themeSource` was introduced by
+e67d538 ("feat(settings): persist appearance globally and apply it before first
+paint") to make the native chrome follow the app theme — traffic lights, native
+menus, file dialogs, none of which can read a CSS variable. But `themeSource` is
+process-global and also drives `prefers-color-scheme` for every web content in the
+process, including `<webview>` guests. Dark websites are a side effect of that one
+assignment. Before e67d538, `themeSource` appears nowhere in the codebase and web
+content followed the OS.
+
+## The change
+
+Delete both assignments and leave `themeSource` at its Electron default of
+`'system'`:
+
+- `src/main/index.ts:486-488` — the startup assignment
+- `src/main/handlers/settings.ts:86` — the re-assignment on settings save
+
+Each site keeps a comment stating that this is deliberate, so the override is not
+reinstated as a "fix" later.
+
+No new setting and no settings UI. The theme picker keeps its current meaning; web
+content is simply no longer part of what it controls.
+
+## Why this does not lighten Broomy's UI
+
+Broomy's own interface is painted entirely from CSS variables driven by a
+`data-theme` attribute. It never consults `prefers-color-scheme` — `theme.css.test.ts:62`
+asserts that our stylesheets contain no such media query, because it would repaint
+every Storybook story. So `themeSource` contributes nothing to the app's appearance.
+
+The window frame also keeps following the theme: `applyChromeToAllWindows` pushes
+`backgroundColor` and the Windows `titleBarOverlay` explicitly from the palette,
+independent of `themeSource`.
+
+## What does change
+
+These native surfaces follow the OS appearance instead of the Broomy theme:
+
+- macOS traffic-light glyphs and the app menu bar
+- native file dialogs
+- the webview right-click menu built in `webviewMenu.ts`
+
+This is the trade, and it is the behaviour the app shipped with before e67d538. The
+alternative — keeping `themeSource` and overriding `prefers-color-scheme` per guest
+via `webContents.debugger` and CDP `Emulation.setEmulatedMedia` — buys correct
+native menus at the cost of a debugger attachment per guest, a live registry of
+guest contents, and re-apply plumbing. Not worth it for a context menu.
+
+## Secondary fix: the `System` theme option
+
+With `themeSource` forced, `nativeTheme.shouldUseDarkColors` reports the forced
+value rather than the OS appearance. The `nativeTheme.on('updated')` listener in
+`src/main/handlers/settings.ts:94` writes that value into `systemIsDark`, which
+`resolveTheme` then uses to resolve the `system` preference.
+
+Expected consequence today: on a light OS, switching from Dark to System leaves the
+app dark, because `systemIsDark` has been poisoned with the forced `true`. Removing
+the override means `shouldUseDarkColors` always reflects the real OS state.
+
+This is stated as an expectation, not a verified claim. The test below pins down the
+resulting behaviour either way.
+
+## Testing
+
+- A guard test asserting that `src/main` never assigns `nativeTheme.themeSource`,
+  mirroring the existing `prefers-color-scheme` guard in `theme.css.test.ts`. The
+  comments explain the intent; the test enforces it.
+- A test that `systemIsDark` tracks the OS value reported by the `updated` listener,
+  and that `resolveTheme('system', …)` follows it.
+
+## Verification
+
+1. `/validate` — lint, typecheck, check:all, unit tests, coverage, E2E
+2. `/feature-doc` — screenshot walkthrough
+3. `/code-review` on the changed files

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -2,11 +2,20 @@
  * IPC for the global appearance settings, and the owner of everything native that
  * has to follow the theme.
  *
- * The renderer can restyle itself from a CSS variable. The window frame, the
- * Windows caption buttons, the macOS traffic lights, the native file dialogs and
- * the context menus cannot — they live outside the DOM. `nativeTheme.themeSource`
- * is what makes those follow, and it is process-global, which is the main reason
- * appearance is a global setting rather than a per-profile one.
+ * The renderer restyles itself from a CSS variable. The window frame and the Windows
+ * caption buttons cannot — they live outside the DOM, so `applyChromeToAllWindows`
+ * pushes their colours from the palette explicitly.
+ *
+ * `nativeTheme.themeSource` is deliberately NEVER assigned, here or anywhere else in
+ * main. It looks like the obvious way to make the remaining native surfaces (macOS
+ * traffic lights, the menu bar, file dialogs, the webview context menu) follow the
+ * app theme, and it was used for exactly that until this was removed. But it is
+ * process-global AND it drives `prefers-color-scheme` for every web content in the
+ * process — so forcing it dark turned every website in the file viewer dark too,
+ * with nothing the user could do about it. Our own UI never reads
+ * `prefers-color-scheme` (see the guard in renderer/theme.css.test.ts), so leaving
+ * themeSource at 'system' costs the app's appearance nothing: those few native
+ * surfaces follow the OS, and web pages render as they would in any other browser.
  */
 import { BrowserWindow, IpcMain, nativeTheme, type MenuItemConstructorOptions } from 'electron'
 import { HandlerContext } from './types'
@@ -83,7 +92,6 @@ export function register(ipcMain: IpcMain, ctx: HandlerContext): void {
     const result = saveAppearance(appearance)
     // Apply even if the disk write failed: the user asked for this, and refusing to
     // show it because a file is unwritable would be worse than showing it.
-    nativeTheme.themeSource = getAppearance().theme === 'system' ? 'system' : (getResolvedTheme() === 'light' || getResolvedTheme() === 'hc-light' ? 'light' : 'dark')
     applyChromeToAllWindows(ctx)
     broadcast()
     return result

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,7 +13,6 @@
 import { app, BrowserWindow, ipcMain, Menu, shell, dialog, nativeTheme } from 'electron'
 import { chromeFor, getAppearance, getResolvedTheme, initSettings } from './settings'
 import { zoomMenuItems } from './handlers/settings'
-import { themeIsLight } from '../shared/appearance'
 import pkg from 'electron-updater'
 const { autoUpdater } = pkg
 import { join, dirname } from 'path'
@@ -480,12 +479,10 @@ function buildAppMenu() {
     // and the zoom factor — all constructor options. Load it late and a light-mode
     // user gets a dark frame flashed at them on every single launch.
     //
-    // themeSource is what makes the NATIVE surfaces follow: traffic lights, context
-    // menus, and the file dialogs. A renderer-side media query can never reach them.
+    // Deliberately does NOT set nativeTheme.themeSource — see the note in
+    // handlers/settings.ts. Our theme is CSS; forcing themeSource would drag every
+    // website in the file viewer dark along with it.
     initSettings(isDev, isE2ETest, nativeTheme.shouldUseDarkColors)
-    const pref = getAppearance().theme
-    nativeTheme.themeSource =
-      pref === 'system' ? 'system' : themeIsLight(getResolvedTheme()) ? 'light' : 'dark'
 
     // Reap PTY trees left behind by previous Broomy main-process crashes
     // before any new PTYs are spawned. Best-effort — never blocks startup.

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The `system` theme preference resolves against whatever the OS last reported.
+ *
+ * This only works because main no longer forces `nativeTheme.themeSource`: with the
+ * override in place, `shouldUseDarkColors` reported the FORCED value rather than the
+ * OS appearance, and the `nativeTheme.on('updated')` listener wrote that back into
+ * `systemIsDark` — so on a light OS, switching from Dark to System kept the app dark.
+ * See themeSource.test.ts for the guard that keeps the override out.
+ *
+ * Runs with isE2ETest=true throughout, which keeps ~/.broomy untouched while still
+ * holding the value in memory.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  getResolvedTheme,
+  getSystemIsDark,
+  initSettings,
+  saveAppearance,
+  setSystemIsDark,
+  snapshot,
+} from './settings'
+import { DEFAULT_APPEARANCE } from '../shared/appearance'
+
+describe('system theme resolution', () => {
+  // A light OS with the default dark app theme — the combination that was broken.
+  beforeEach(() => {
+    initSettings(false, true, false)
+  })
+
+  it('seeds systemIsDark from the OS value passed at startup', () => {
+    expect(getSystemIsDark()).toBe(false)
+  })
+
+  it('keeps the explicit theme regardless of the OS appearance', () => {
+    expect(DEFAULT_APPEARANCE.theme).toBe('dark')
+    expect(getResolvedTheme()).toBe('dark')
+  })
+
+  it('resolves `system` to light on a light OS, even after a dark app theme', () => {
+    saveAppearance({ ...DEFAULT_APPEARANCE, theme: 'system' })
+    expect(getResolvedTheme()).toBe('light')
+    expect(snapshot().resolvedTheme).toBe('light')
+  })
+
+  it('follows the OS when it changes under a `system` preference', () => {
+    saveAppearance({ ...DEFAULT_APPEARANCE, theme: 'system' })
+
+    // What the nativeTheme 'updated' listener does.
+    setSystemIsDark(true)
+    expect(getResolvedTheme()).toBe('dark')
+
+    setSystemIsDark(false)
+    expect(getResolvedTheme()).toBe('light')
+  })
+})

--- a/src/main/themeSource.test.ts
+++ b/src/main/themeSource.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Guard: main must never assign `nativeTheme.themeSource`.
+ *
+ * It is the obvious-looking way to make the last few native surfaces (macOS traffic
+ * lights, the menu bar, file dialogs, the webview context menu) follow the app
+ * theme, and it was used for exactly that until it was removed. The catch is that it
+ * is process-global AND drives `prefers-color-scheme` for every web content in the
+ * process, so a dark app theme silently turned every website in the file viewer dark
+ * too.
+ *
+ * Comments explain that; only a test stops someone reinstating it. Sibling of the
+ * `prefers-color-scheme` guard in renderer/theme.css.test.ts.
+ */
+import { readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) return sourceFiles(full)
+    if (!entry.name.endsWith('.ts') || entry.name.endsWith('.test.ts')) return []
+    return [full]
+  })
+}
+
+/** The rule is about code that runs, not about the words being written down. */
+const stripComments = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+describe('nativeTheme.themeSource', () => {
+  const files = sourceFiles(__dirname)
+
+  it('finds the main-process sources to scan', () => {
+    expect(files.length).toBeGreaterThan(10)
+  })
+
+  it('is never assigned — it would drag every website in the file viewer dark', () => {
+    const offenders = files.filter((file) =>
+      stripComments(readFileSync(file, 'utf-8')).includes('themeSource')
+    )
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/shared/appearance.ts
+++ b/src/shared/appearance.ts
@@ -4,14 +4,9 @@
  * the renderer.
  *
  * These live in a GLOBAL ~/.broomy/settings.json rather than the per-profile
- * config.json, for two reasons:
- *
- *   - `nativeTheme.themeSource` is process-global. If two profile windows disagreed
- *     about the theme, the native chrome (traffic lights, context menus, file
- *     dialogs) could only satisfy one of them.
- *   - How readable a UI is, is a property of the person's eyes — not of which
- *     project they happen to have open. Opening a new profile must not reset a
- *     low-vision user to 13px dark.
+ * config.json: how readable a UI is, is a property of the person's eyes — not of
+ * which project they happen to have open. Opening a new profile must not reset a
+ * low-vision user to 13px dark.
  */
 import { bestLabelOn, contrast, fitContrast, hexToRgb, parseTriplet, rgbToTriplet, type Rgb } from './color'
 import { IS_LIGHT, PALETTE, type ThemeName } from './theme'

--- a/tests/features/appearance/appearance.spec.ts
+++ b/tests/features/appearance/appearance.spec.ts
@@ -168,12 +168,13 @@ test.describe.serial('Feature: Appearance', () => {
       screenshotPath: 'screenshots/06-back-to-dark.png',
       caption: 'Back to dark — the accent and text size survive the theme change',
       description:
-        'Appearance is stored globally in ~/.broomy/settings.json rather than per-profile: ' +
-        'nativeTheme.themeSource is process-global, so two profile windows disagreeing would leave ' +
-        'the native chrome able to satisfy only one of them — and how readable a UI is, is a ' +
-        'property of a person\'s eyes, not of which project they happen to have open. The main ' +
-        'process reads it synchronously before the first window exists, so a light-mode user never ' +
-        'sees a dark frame flash on launch.',
+        'Appearance is stored globally in ~/.broomy/settings.json rather than per-profile: how ' +
+        'readable a UI is, is a property of a person\'s eyes, not of which project they happen to ' +
+        'have open. The main process reads it synchronously before the first window exists, so a ' +
+        'light-mode user never sees a dark frame flash on launch. Note what the theme does NOT ' +
+        'touch: web pages in the file viewer. Broomy leaves nativeTheme.themeSource alone, so a ' +
+        'site renders exactly as it would in any other browser on your machine — picking a dark ' +
+        'Broomy no longer forces every website dark along with it.',
     })
   })
 })


### PR DESCRIPTION
## Background and Motivation

Choosing a dark Broomy theme also turns every website in the file viewer dark, and there is no way to opt out. People who want a dark Broomy and light web pages cannot have both.

Nobody built that behaviour. e67d538 ("feat(settings): persist appearance globally") set `nativeTheme.themeSource` so the native chrome — traffic lights, menus, file dialogs — would follow the app theme, since none of those can read a CSS variable. But `themeSource` is process-global and also drives `prefers-color-scheme` for every web content in the process, including `<webview>` guests. Dark websites are a side effect of that one assignment. `git log -S themeSource` returns exactly one commit: before e67d538 the symbol appears nowhere in the codebase, and web content followed the OS.

## Design Decisions

**Leave `themeSource` at its `'system'` default rather than adding a setting.** The original ask was a toggle next to the theme picker. It turned out not to be needed: Broomy's UI is painted entirely from `data-theme` CSS variables and never reads `prefers-color-scheme` — `theme.css.test.ts:62` asserts our stylesheets contain no such media query. So `themeSource` contributes nothing to how the app looks, and dropping it costs the app's appearance nothing. Web pages then behave like they do in every other browser on the machine, which needs no explaining in a settings panel.

**The alternative, rejected:** keep `themeSource` and override `prefers-color-scheme` per guest via `webContents.debugger` and CDP `Emulation.setEmulatedMedia`. That is the only per-`webContents` lever Electron offers, and it would keep native menus following the app theme — at the cost of a debugger attachment per guest, a live registry of guest contents, and re-apply plumbing on every settings change. Not worth it for a context menu.

**What this gives up:** these native surfaces now follow the OS appearance instead of the Broomy theme — macOS traffic-light glyphs, the app menu bar, native file dialogs, and the webview right-click menu from `webviewMenu.ts`. That is the behaviour the app shipped with for its entire life before e67d538. The window frame is *not* affected: `applyChromeToAllWindows` pushes `backgroundColor` and the Windows `titleBarOverlay` from the palette explicitly.

## Proposed Changes

**Behaviour** — deleted both `nativeTheme.themeSource` assignments (`src/main/index.ts`, `src/main/handlers/settings.ts:86`). No new setting, no UI change; the theme picker keeps its current meaning and simply no longer reaches web content.

**Comments** — each removal site states that the omission is deliberate and why, so it is not reinstated as a "fix" later. Also corrected two now-false rationales that cited `themeSource` as the reason appearance is stored globally: the header of `src/shared/appearance.ts` and step 6 of the appearance walkthrough.

**Tests** — `src/main/themeSource.test.ts` is a guard that main never assigns `themeSource`, a sibling of the existing `prefers-color-scheme` guard in `theme.css.test.ts`; comments explain intent, only a test enforces it. `src/main/settings.test.ts` covers resolving the `system` preference against the OS value.

**Secondary fix.** With `themeSource` forced, `nativeTheme.shouldUseDarkColors` reports the *forced* value rather than the OS appearance, and the `nativeTheme.on('updated')` listener at `handlers/settings.ts:94` wrote that back into `systemIsDark`. Expected consequence: on a light OS, switching from Dark to System left the app dark until the OS theme next changed. This is reasoned from Electron's documented behaviour, not reproduced — flagging it as an expectation rather than a verified claim. The new test pins the correct behaviour either way.

Spec: `docs/superpowers/specs/2026-07-28-web-follows-system-appearance-design.md`.

## Testing

The guard test was verified to actually fail against the pre-change code rather than trusted to match — stashing the source changes and re-running gives `AssertionError: expected [ …(2) ] to deeply equal []`, flagging both old assignment sites.

The appearance feature walkthrough was regenerated after the narrative edit (`node scripts/feature-docs.cjs appearance` — 6 passed).

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:all` (2/2 passed)
- [x] `pnpm test:unit` (246 files, 4406 tests passed; coverage 90.92% lines, 9384/10321)
- [x] Ran all E2E tests locally (`pnpm test:e2e`) — 77 passed (1.1m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB3Hyc4woXbvqG6RAj19w2
